### PR TITLE
docs: 한·영 문서 쌍에 가시 언어 토글 추가

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
-<!-- English: [README.md](./README.md) -->
-
 # Skillstead
+
+[English](./README.md) · **한국어**
 
 Agentic coding workflow에 붙여 쓰는 실용적이고 portable한 skill catalog입니다.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<!-- 한국어: [README.ko.md](./README.ko.md) -->
-
 # Skillstead
+
+**English** · [한국어](./README.ko.md)
 
 Practical, portable skills for agentic coding workflows.
 

--- a/examples/svg-infographic/README.ko.md
+++ b/examples/svg-infographic/README.ko.md
@@ -1,6 +1,6 @@
-<!-- English: [README.md](./README.md) -->
-
 # 예제 — svg-infographic
+
+[English](./README.md) · **한국어**
 
 [`svg-infographic`](../../skills/svg-infographic) skill의 실제 산출물입니다. 각 예제는 flat하고 구조적인 시각 자료로, 원본 SVG + 2× PNG를 영문·한글 두 본과 생성 프롬프트와 함께 제공합니다.
 

--- a/examples/svg-infographic/README.md
+++ b/examples/svg-infographic/README.md
@@ -1,6 +1,6 @@
-<!-- 한국어: [README.ko.md](./README.ko.md) -->
-
 # Examples — svg-infographic
+
+**English** · [한국어](./README.ko.md)
 
 Real outputs from the [`svg-infographic`](../../skills/svg-infographic) skill. Each example is a flat, structural visual shipped as source SVG + 2× PNG, in English and Korean, with the prompt that generated it.
 

--- a/skills/svg-infographic/README.ko.md
+++ b/skills/svg-infographic/README.ko.md
@@ -1,6 +1,6 @@
-<!-- English: [README.md](./README.md) -->
-
 # svg-infographic
+
+[English](./README.md) · **한국어**
 
 Agentic coding workflow에서 쓰는 flat하고 구조적인 기술 시각 자료를 만듭니다. 아키텍처 다이어그램, 클라우드 토폴로지, 프로세스 플로우, Before / After 비교, 로드맵, 공유용 인포그래픽에 맞춰져 있습니다. 현재 package는 Claude Code용으로 작성되어 있습니다.
 

--- a/skills/svg-infographic/README.md
+++ b/skills/svg-infographic/README.md
@@ -1,6 +1,6 @@
-<!-- 한국어: [README.ko.md](./README.ko.md) -->
-
 # svg-infographic
+
+**English** · [한국어](./README.ko.md)
 
 Create flat, structured technical visuals for agentic coding workflows: architecture diagrams, cloud topologies, process flows, before/after comparisons, roadmaps, and share-ready infographics. The current package is authored for Claude Code.
 


### PR DESCRIPTION
## 배경

기존에는 한·영 문서 간 상호 링크를 **최상단 HTML 주석**으로만 두어 GitHub 등 렌더링 화면에서는 보이지 않았고, 독자가 다른 언어 버전으로 전환할 방법이 사실상 없었다.

## 변경

`sessioncue` repo와 동일하게 **H1 제목 바로 아래 가시 언어 토글 라인**으로 교체한다. 현재 언어는 굵게, 다른 언어는 링크로 노출한다.

- 영어 파일: `**English** · [한국어](./<name>.ko.md)`
- 한국어 파일: `[English](./<name>.md) · **한국어**`

## 대상 (3쌍 / 6개 파일)

- `README.md` ↔ `README.ko.md`
- `skills/svg-infographic/README.md` ↔ `README.ko.md`
- `examples/svg-infographic/README.md` ↔ `README.ko.md`

제목·본문은 무변경(각 파일 상단 3줄만 수정). `examples/svg-infographic/*/README.md` 10개는 파일↔파일 쌍이 아니라 단일 문서 세로 스택 구조여서 이번 범위에서 제외했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)