### PR TITLE
docs: svg-infographic maturity를 Stable로 전환한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Granular, per-change entries begin at the first public release. Earlier developm
 
 ### svg-infographic
 
+- **Maturity: Stable.** The skill catalog status graduates from Beta after fourteen bilingual examples, multiple iterative public releases, compute-first layout and pre-render checks, dimension-verified 2× export, and an opt-in sketch preset. This is a skill-contract maturity label, not a platform-verification claim: macOS rendering is verified; Windows/Linux render verification remains pending.
 - **New example (14th): `agent-system-sketch`.** A tidy hand-drawn component map showing an Orchestrator connected to Context, Memory, Tools, Guardrails, and Evaluation, with a feedback edge from evaluation back to the center. English + Korean use identical geometry, subset-embedded Nanum Pen Script, editable SVG, and 2× PNG.
 - **Gallery preview recuration.** The root preview now uses two large sketch heroes (`incident-response-sketch`, `agent-system-sketch`) above four structurally distinct supporting examples (`zero-trust-onion`, `agent-waiting-swimlane`, `cloud-infra-topology`, `agent-task-matrix`). The previous fixed 3×2 treatment is replaced by an editorial 2-hero + 4-supporting composition in EN/KO.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -70,7 +70,7 @@ svg-infographic으로 이 before/after 마이그레이션 계획을 슬라이드
 
 | Skill | 지원 runtime | Status | 설명 |
 | --- | --- | --- | --- |
-| [`svg-infographic`](./skills/svg-infographic) | Claude Code | Beta | layout을 먼저 계산하는 compute-first workflow로 flat하고 구조적인 SVG 인포그래픽을 만들고, 치수 검증된 2× PNG로 export합니다. |
+| [`svg-infographic`](./skills/svg-infographic) | Claude Code | Stable | layout을 먼저 계산하는 compute-first workflow로 flat하고 구조적인 SVG 인포그래픽을 만들고, 치수 검증된 2× PNG로 export합니다. |
 
 ## 품질 기준
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Starting with one practical skill. More skills can be added when they meet the s
 
 | Skill | Supported runtime | Status | What it does |
 | --- | --- | --- | --- |
-| [`svg-infographic`](./skills/svg-infographic) | Claude Code | Beta | Creates flat, structured SVG infographics with a compute-first layout workflow, then exports dimension-verified 2× PNGs. |
+| [`svg-infographic`](./skills/svg-infographic) | Claude Code | Stable | Creates flat, structured SVG infographics with a compute-first layout workflow, then exports dimension-verified 2× PNGs. |
 
 ## Quality Bar
 


### PR DESCRIPTION
## Summary

- Graduates the `svg-infographic` catalog status from Beta to Stable in both root READMEs.
- Records the maturity graduation in the existing `v0.3.1` changelog entry.
- Keeps platform verification explicit: macOS rendering is verified; Windows/Linux render verification remains pending.

## Verification

- `git diff --check origin/main...HEAD`
- Exact Stable status mapping in English/Korean root READMEs
- No stale Beta status mapping
- Windows/Linux pending-verification wording preserved

## Release correction

After merge, the published `v0.3.1` tag will be moved to the new main commit and the existing GitHub Release object will be updated with English-only notes, as explicitly approved by the owner.
