### PR TITLE
fix: docs-claim-check 픽스처의 미참조 vitest devDependency 제거

### DIFF
--- a/examples/docs-claim-check/fixtures/evidence/package.json
+++ b/examples/docs-claim-check/fixtures/evidence/package.json
@@ -8,8 +8,5 @@
   "dependencies": {
     "commander": "^12.0.0",
     "picocolors": "^1.0.0"
-  },
-  "devDependencies": {
-    "vitest": "^2.0.0"
   }
 }


### PR DESCRIPTION
## 배경

Dependabot이 `examples/docs-claim-check/fixtures/evidence/package.json`의 `vitest ^2.0.0`(devDependency)를 취약 의존성으로 표시했다("When Vitest UI server is listening, arbitrary file can be read and executed"). lockfile이 없어 자동 수정은 불가했다.

## 위험도 분석

**실제 노출도 = 사실상 0.** 이 파일은 `docs-claim-check` skill 예제의 합성 픽스처(`acmetask-fixture`)다. 설치·실행되지 않고(no `node_modules`/lockfile/CI install), vitest UI 서버가 뜰 일이 없다. 정적 "evidence" 입력 JSON일 뿐이다.

## 변경

`devDependencies` 블록(`vitest`)을 제거했다. 이 항목은 예제 안에서 **완전히 무참조**다:

- 어떤 claim·expected-outcome·README·example-output도 이 devDependency를 근거로 쓰지 않는다.
- 실제 참조 필드는 `dependencies`(C10)·`engines.node`(C2)·`license`(C12)·`name`(C5)뿐이다.
- 테스트 커버리지 서사(C11)는 `ci-test-output.txt` 로그 문자열이 담당하므로 그대로 유지된다.

→ 경보를 근원에서 해소하며 예제 동작은 하나도 바뀌지 않는다. 병합 후 Dependabot 재스캔 시 경보가 auto-close된다.

## 검증

- `python3 -m json.tool ...package.json` — JSON 유효
- `grep -rn devDependencies examples/docs-claim-check/` — 잔여 참조 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)