### PR TITLE
docs: v0.5.0 retagged install evidence 기록

### DIFF
--- a/examples/github-release-guide/fixtures/validation-evidence.md
+++ b/examples/github-release-guide/fixtures/validation-evidence.md
@@ -13,6 +13,7 @@ contract review so the public runtime-support claim does not imply that every ro
 | Claude Code clean A/B | Platform default `claude-fable-5`; effort omitted; isolated fresh contexts without the answer key | Same clean A/B inputs | Pass: Case A matched target, `public-baseline`, split language profiles, Blocked boundaries, full schema, and one Next Step; Case B refused visibility mutation and returned partial Assess + Blocked with one restore-and-reassess Next Step |
 | Live GitHub first-public | Codex driver; owner-approved manual Guided sequence; disposable github.com repository on 2026-07-16 | Synthetic FP1-style repository `kyungseo/github-release-guide-e2e-20260716`, commit `c1429e3`, tag `v1.0.0` | Pass: separate visibility, public-surface settings, security settings, and GitHub Release approvals; unauthenticated pinned clone; public document checks; Secret scanning and push protection enabled; zero open secret alerts; separately approved remote deletion verified through authenticated absence and public repository/release HTTP 404. |
 | Pinned v0.5.0 project install | Codex CLI 0.144.1 default model/effort; Claude Code 2.1.211 platform default/omitted effort | Fresh shallow clone of `v0.5.0` at `3637801`; complete package copied to each project path | Pass: source and both installed packages matched; Codex reported that it loaded `github-release-guide`; Claude Code discovered `.claude/skills/github-release-guide` and both profile references. |
+| Retagged v0.5.0 project install | Owner-approved post-release tag relocation on 2026-07-16 | Fresh shallow clone of re-pointed `v0.5.0` at `b5a36d4`; complete package copied to each project path | Pass: source and both installed packages matched. The retag changed only package README EN/KO support wording from `3637801`; `SKILL.md` and profile references were unchanged, so the prior Codex/Claude Code discovery observations remain applicable. |
 
 The Codex prompt allowed read-only access only to the installed skill package and `RELEASE-STATE.md`. It
 prohibited answer-key/example access, repository/network inspection, and mutation. The runtime outputs used no
@@ -63,3 +64,5 @@ answer key by the driver. It verifies contract consistency, not independent mode
   installation/discovery passed. The final strict claim audit passed with one non-blocking temporal-staleness
   correction to `docs/INSTALL.md`. The catalog and install matrix may show `github-release-guide` runtime
   support as `Supported` within this recorded evidence scope.
+- Owner subsequently re-pointed annotated `v0.5.0` to the current release-documentation commit `b5a36d4`.
+  A fresh clone and project copies passed again; the runtime entry and profile references were unchanged.


### PR DESCRIPTION
## 변경 사항

- owner 승인으로 재지정된 `v0.5.0` tag target(`b5a36d4`)의 fresh clone·project-copy evidence를 validation ledger에 추가합니다.
- 이전 pinned-install runtime discovery가 계속 적용되는 이유를 기록합니다. 새 target에서 runtime entry와 profile references는 변하지 않았습니다.

## 검증

- fresh shallow clone: `v0.5.0` → `b5a36d4`
- Claude Code·Codex project package copy: source와 동일
- `git diff --check`: pass
