### PR TITLE
feat: per-skill versioning validator와 release 도구 체계를 도입한다

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+# Manual release entry — the canonical wrapper (M5) is the only supported
+# path for GitHub Release operations. Isolated from the validation workflows
+# so that neither disables the other. The request file is authored and
+# committed beforehand; dry-run is the default so a plain dispatch never
+# mutates anything.
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      request_path:
+        description: "Path to the ReleaseOperationRequest JSON file"
+        required: true
+        default: ".skillstead/release-request.json"
+      dry_run:
+        description: "Stop after the allowed-matrix and pre-publish checks"
+        type: boolean
+        required: true
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Canonical release wrapper (M5)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          PYTHONPATH=tools python3 -m skillstead_validate release
+          --request "${{ inputs.request_path }}"
+          --repo-slug "$GITHUB_REPOSITORY"
+          --main-ref origin/main --repo-root .
+          ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,26 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      # The dispatch input is UNTRUSTED text: interpolating it into the run
+      # script would let quotes/metacharacters escape the argument and run
+      # arbitrary commands under the write token (R1-F2). It is passed via
+      # env, validated as a plain repo-relative path, and must be a file
+      # tracked in the trusted main checkout.
+      - name: Validate request path
+        env:
+          REQUEST_PATH: ${{ inputs.request_path }}
+        run: |
+          case "$REQUEST_PATH" in
+            (*[!A-Za-z0-9._/-]*|/*|*..*|"") echo "request_path rejected"; exit 1;;
+          esac
+          git ls-files --error-unmatch -- "$REQUEST_PATH"
+
       - name: Canonical release wrapper (M5)
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >
-          PYTHONPATH=tools python3 -m skillstead_validate release
-          --request "${{ inputs.request_path }}"
-          --repo-slug "$GITHUB_REPOSITORY"
-          --main-ref origin/main --repo-root .
-          ${{ inputs.dry_run && '--dry-run' || '' }}
+          REQUEST_PATH: ${{ inputs.request_path }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -- --request "$REQUEST_PATH" --repo-slug "$GITHUB_REPOSITORY" --main-ref origin/main --repo-root .
+          if [ "$DRY_RUN" = "true" ]; then set -- "$@" --dry-run; fi
+          PYTHONPATH=tools python3 -m skillstead_validate release "$@"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # Pinned to main (MR2R-F9): workflow_dispatch lets the caller pick any
+      # branch, and an unpinned checkout would run a feature branch's
+      # modified wrapper — and its request file — under the write token.
+      # Both the wrapper and the request must come from the trusted ref.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Canonical release wrapper (M5)

--- a/.github/workflows/validate-periodic.yml
+++ b/.github/workflows/validate-periodic.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Repo validation (M1)
         run: PYTHONPATH=tools python3 -m skillstead_validate repo --repo-root .
 
+      - name: Continuous tag checks (M3)
+        run: PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref origin/main --repo-root .
+
       - name: Spec reference validator (pinned skills-ref)
         run: python3 tools/run_skills_ref.py

--- a/.github/workflows/validate-periodic.yml
+++ b/.github/workflows/validate-periodic.yml
@@ -1,0 +1,31 @@
+# Periodic fallback validation. Catches state changes that fire no usable
+# event (e.g. a tag repointed or deleted outside a push). Kept in its own
+# workflow file so schedule disablement — including GitHub's automatic
+# 60-day-inactivity disable — cannot take the event-driven checks down with
+# it. Manual dispatch is the documented re-check and re-enable path.
+name: validate-periodic
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Validator self-tests (fixtures)
+        run: python3 -m unittest discover -s tests
+
+      - name: Repo validation (M1)
+        run: PYTHONPATH=tools python3 -m skillstead_validate repo --repo-root .
+
+      - name: Spec reference validator (pinned skills-ref)
+        run: python3 tools/run_skills_ref.py

--- a/.github/workflows/validate-periodic.yml
+++ b/.github/workflows/validate-periodic.yml
@@ -30,5 +30,10 @@ jobs:
       - name: Continuous tag checks (M3)
         run: PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref origin/main --repo-root .
 
+      - name: Cutover verdict (M4)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: PYTHONPATH=tools python3 -m skillstead_validate cutover --live --repo-slug "$GITHUB_REPOSITORY" --main-ref origin/main --repo-root .
+
       - name: Spec reference validator (pinned skills-ref)
         run: python3 tools/run_skills_ref.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,12 +9,15 @@ on:
   pull_request:
   push:
     branches: [main]
+  create:
+  delete:
 
 permissions:
   contents: read
 
 jobs:
   validate:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       # Full hydration is contractual: first-parent history, all tags, and
@@ -34,3 +37,19 @@ jobs:
 
       - name: Spec reference validator (pinned skills-ref)
         run: python3 tools/run_skills_ref.py
+
+  # Tag creation or deletion re-runs the continuous tag checks immediately
+  # (a deleted tag leaves no ref to check out, so main is checked out
+  # explicitly). Branch create/delete events also land here; the extra run
+  # is harmless.
+  tag-event:
+    if: github.event_name == 'create' || github.event_name == 'delete'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Continuous tag checks (M3)
+        run: PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref origin/main --repo-root .

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,7 @@
 # workflow (validate-periodic.yml) so that disabling either one — including
 # GitHub's automatic 60-day-inactivity disable of scheduled workflows — never
 # silences the other. Continuous tag checks (M3) and the cutover evaluator
-# (M4) are added by later checkpoints of FEAT-20260728-001.
+# (M4) are added by later stages of the validator work.
 name: validate
 
 on:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Continuous tag checks (M3)
         run: PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref origin/main --repo-root .
 
+      - name: Cutover verdict (M4)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: PYTHONPATH=tools python3 -m skillstead_validate cutover --live --repo-slug "$GITHUB_REPOSITORY" --main-ref origin/main --repo-root .
+
       - name: Spec reference validator (pinned skills-ref)
         run: python3 tools/run_skills_ref.py
 
@@ -53,3 +58,8 @@ jobs:
 
       - name: Continuous tag checks (M3)
         run: PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref origin/main --repo-root .
+
+      - name: Cutover verdict (M4)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: PYTHONPATH=tools python3 -m skillstead_validate cutover --live --repo-slug "$GITHUB_REPOSITORY" --main-ref origin/main --repo-root .

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,33 @@
+# Event-driven validation (M1). Deliberately separate from the periodic
+# workflow (validate-periodic.yml) so that disabling either one — including
+# GitHub's automatic 60-day-inactivity disable of scheduled workflows — never
+# silences the other. Continuous tag checks (M3) and the cutover evaluator
+# (M4) are added by later checkpoints of FEAT-20260728-001.
+name: validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      # Full hydration is contractual: first-parent history, all tags, and
+      # origin/main must be observable for the tag and cutover checks.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Validator self-tests (fixtures)
+        run: python3 -m unittest discover -s tests
+
+      - name: Repo validation (M1)
+        run: PYTHONPATH=tools python3 -m skillstead_validate repo --repo-root .
+
+      - name: Spec reference validator (pinned skills-ref)
+        run: python3 tools/run_skills_ref.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Repo validation (M1)
         run: PYTHONPATH=tools python3 -m skillstead_validate repo --repo-root .
 
+      - name: Continuous tag checks (M3)
+        run: PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref origin/main --repo-root .
+
       - name: Spec reference validator (pinned skills-ref)
         run: python3 tools/run_skills_ref.py

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ temp/
 # OS
 .DS_Store
 Thumbs.db
+# Python
+__pycache__/
+*.pyc

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -14,12 +14,21 @@
 | Mode | 내용 | 실행 시점 | 명령 |
 | --- | --- | --- | --- |
 | M1 | 저장소 검증 — package 구조, `metadata.version` ↔ CHANGELOG(I-1), 카탈로그 `Version` 열(I-7), package 완전성(I-9), 라이선스 사본 바이트 일치 | 모든 PR, `main` push, 매일 schedule | `PYTHONPATH=tools python3 -m skillstead_validate repo` |
-| M2 | 릴리스 preflight와 tag 생성 — payload diff 릴리스 게이트(I-3/I-4), bump 단계 검사(I-6), inventory 보호(I-10), major bump 보호, 신규 skill 최초 릴리스, tag 고유성 | 릴리스 제안 시. dry-run 가능 | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` |
+| M2 | 릴리스 preflight와 tag 생성 — payload diff 릴리스 게이트(I-3/I-4), bump 단계 검사(I-6), inventory 보호(I-10), major bump 보호, 신규 skill 최초 릴리스, tag 고유성 | 릴리스 제안 시. dry-run 가능 | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` (`git push --atomic`으로 remote에 발행. push 실패 시 local ref rollback) |
 | M3 | tag 지속 검사 — 모든 namespaced tag의 I-2·I-5·I-8과 durable expected-target 관계를 매 실행 검사 (tag는 변경 가능하므로 생성 시점 검사만으로는 아무것도 담보되지 않음) | 모든 PR, push, tag 생성/삭제, 매일 schedule | `… tags --main-ref origin/main` |
 | M4 | cutover verdict — cutover record·INSTALL pin·baseline ref·GitHub Releases에 대한 ordered evaluator | CI 상시 + 모든 릴리스 작업 전후 | `… cutover --live --repo-slug OWNER/REPO` |
 | M5 | canonical release wrapper — **GitHub Release 작업의 유일한 지원 경로** | 수동 또는 `release` workflow | `… release --request REQUEST.json --repo-slug OWNER/REPO [--dry-run]` |
 
-종료 코드는 green이면 `0`(M4는 red가 아닌 모든 verdict), 아니면 `1`입니다.
+종료 코드: green이면 `0`(M4는 red가 아닌 모든 verdict), finding·red verdict·request 거부/실패는
+`1`, usage 오류(알 수 없는 mode·필수 인자 누락)는 `2`입니다.
+
+action별 request boolean 제약(request는 의도한 최종 상태와 같아야 합니다):
+
+| action | draft | prerelease | latest_intent | owner_authorization |
+| --- | --- | --- | --- | --- |
+| create-draft | `true` 필수 | `false` 필수 | 자유 | 불필요 |
+| publish | `false` 필수 | `false` 필수 | `true` 필수 | 불필요 |
+| edit-metadata | `false` 필수 | `false` 필수 | Latest 정정 시 `true` | 필수 |
 
 **순서:** `M2 preflight green → M2 apply-tags → M3 → M5`. tag 변경은 preflight를 재실행하는
 `apply-tags`를 통해서만 일어납니다. wrapper는 tag를 만들지 않습니다(모든 create에

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -1,0 +1,183 @@
+# 검증·릴리스 도구 체계
+
+[English](./VALIDATION.md)
+
+이 문서는 `tools/skillstead_validate/`의 검증 도구 체계와 그것이 지키는 릴리스 경로를 설명합니다.
+버전 규칙 자체는 [`VERSIONING.md`](./VERSIONING.md)에 있고, 이 문서는 그 규칙을 어떻게 검사하고
+릴리스를 어떻게 실행하는지를 다룹니다.
+
+모든 판정 로직은 Python 3.11+ 표준 라이브러리만 사용하며 **fail-closed**입니다: 도구가 파싱하거나
+관측할 수 없는 것은 조용히 통과되지 않고 finding 또는 red verdict가 됩니다.
+
+## Mode
+
+| Mode | 내용 | 실행 시점 | 명령 |
+| --- | --- | --- | --- |
+| M1 | 저장소 검증 — package 구조, `metadata.version` ↔ CHANGELOG(I-1), 카탈로그 `Version` 열(I-7), package 완전성(I-9), 라이선스 사본 바이트 일치 | 모든 PR, `main` push, 매일 schedule | `PYTHONPATH=tools python3 -m skillstead_validate repo` |
+| M2 | 릴리스 preflight와 tag 생성 — payload diff 릴리스 게이트(I-3/I-4), bump 단계 검사(I-6), inventory 보호(I-10), major bump 보호, 신규 skill 최초 릴리스, tag 고유성 | 릴리스 제안 시. dry-run 가능 | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` |
+| M3 | tag 지속 검사 — 모든 namespaced tag의 I-2·I-5·I-8과 durable expected-target 관계를 매 실행 검사 (tag는 변경 가능하므로 생성 시점 검사만으로는 아무것도 담보되지 않음) | 모든 PR, push, tag 생성/삭제, 매일 schedule | `… tags --main-ref origin/main` |
+| M4 | cutover verdict — cutover record·INSTALL pin·baseline ref·GitHub Releases에 대한 ordered evaluator | CI 상시 + 모든 릴리스 작업 전후 | `… cutover --live --repo-slug OWNER/REPO` |
+| M5 | canonical release wrapper — **GitHub Release 작업의 유일한 지원 경로** | 수동 또는 `release` workflow | `… release --request REQUEST.json --repo-slug OWNER/REPO [--dry-run]` |
+
+종료 코드는 green이면 `0`(M4는 red가 아닌 모든 verdict), 아니면 `1`입니다.
+
+**순서:** `M2 preflight green → M2 apply-tags → M3 → M5`. tag 변경은 preflight를 재실행하는
+`apply-tags`를 통해서만 일어납니다. wrapper는 tag를 만들지 않습니다(모든 create에
+`--verify-tag`). `gh release …` 직접 호출은 **지원되지 않는 경로**입니다 — 저장소 ruleset에는
+admin bypass가 있으므로 이 경계는 hard guarantee가 아니라 discipline입니다.
+
+## CI workflow
+
+| 파일 | trigger | 목적 |
+| --- | --- | --- |
+| `validate.yml` | PR, `main` push, tag 생성/삭제 | event 기반 M1+M3+M4 (tag event는 명시적 `main` checkout으로 M3+M4 실행) |
+| `validate-periodic.yml` | 매일 schedule(`17 3 * * *` UTC), 수동 dispatch | event가 발생하지 않는 상태 변화(예: push 밖의 tag repoint)를 잡는 주기적 안전망 |
+| `release.yml` | 수동 dispatch 전용 | M5 wrapper 진입점. dry-run이 기본값이며 checkout이 `main`에 고정되어 있어 dispatch가 미검토 wrapper나 request를 write token으로 실행할 수 없음 |
+
+두 검증 workflow는 별도 파일입니다 — 어느 한쪽의 비활성화(저장소 60일 미활동 시 GitHub의
+schedule workflow 자동 비활성화 포함)가 다른 쪽을 침묵시키지 않도록 하기 위해서입니다.
+event 없는 변경의 명목상 최대 탐지 지연은 schedule 주기 1회(~24시간) + 스케줄러 지연입니다.
+schedule workflow가 자동 비활성화되면 다음 활동 후 Actions 탭에서 재활성화하거나 수동
+dispatch로 1회 실행하십시오.
+
+모든 job은 전체 이력과 tag를 checkout합니다(`fetch-depth: 0`) — 아래의 first-parent 파생이
+이를 요구합니다.
+
+## Release plan (M2 입력)
+
+```json
+{
+  "target_commit": "<main 위의 sha 또는 ref>",
+  "releases": [
+    {"skill": "<name>", "previous_ref": "<name>/vX.Y.Z 또는 null",
+     "proposed_version": "X.Y.Z", "proposed_ref": "refs/tags/<name>/vX.Y.Z"}
+  ]
+}
+```
+
+preflight는 직전 릴리스 이후 **payload**가 변한 skill 집합과 plan의 집합이 정확히 일치할 때만
+green입니다 — plan에서 빠진 변경 skill은 I-3, payload가 변하지 않았는데 plan에 있는 skill은
+I-4 finding입니다. payload는 정확히 두 개의 bookkeeping 산출물(`metadata.version` scalar,
+`CHANGELOG.md`)을 제외합니다(`VERSIONING.md` 참조).
+
+추가 검사: target commit은 전체 M1 검증을 통과하고 `main` first-parent history에 있어야 합니다.
+bump 단계는 경로 기본값과 일치해야 하고, major bump는 owner 승인 증거 형식이 확정되기 전까지
+무조건 거부되며, 승인된 retirement marker 없는 inventory 감소도 marker 형식 확정 전까지 무조건
+거부됩니다. 신규 skill의 최초 릴리스는 package와 양쪽 카탈로그 행을 target commit에서 함께
+도입해야 하고, 기존 tag와 SemVer precedence가 같은 버전(`+build` alias 포함)은 만들 수
+없습니다.
+
+**Bump-Adjustment marker.** 제안된 단계가 경로 기본값과 다르면 해당 릴리스의 CHANGELOG entry에
+독립된, 비어 있지 않은 사유 줄이 있어야 합니다:
+
+```text
+Bump-Adjustment: <기본 단계를 조정한 이유>
+```
+
+빈 marker, 다른 entry 안의 marker, 긴 줄 속에 섞인 marker는 인정되지 않습니다.
+
+## tag 지속 검사 (M3)
+
+모든 `<name>/vX.Y.Z` tag에 대해 매 실행:
+
+* **문법** — `<name>/vMAJOR.MINOR.PATCH`만. pre-release·build suffix 금지.
+* **I-2** — peeled target commit이 tag의 버전을 정확히 선언한다.
+* **I-8** — peeled target이 `main` 위의 commit이다.
+* **I-5** — 관측된 릴리스 commit에서 버전이 바뀐 모든 skill의 tag가 존재한다(존재만 검사 —
+  대상 정확성은 다음 검사의 몫). cutover record가 생긴 뒤에는 `main` first-parent 버전 변경에서
+  기대 tag 집합을 독립적으로 파생하므로 릴리스의 tag를 *전부* 삭제해도 검출된다.
+* **expected target** — tag를 보지 않고 파생한다: 일반 tag는 `main` first-parent에서 해당
+  skill의 선언 버전이 그 버전으로 바뀐 가장 오래된 commit, baseline tag 4개(record의 exact ref
+  membership으로만 판정 — 버전 문자열 비교 아님)는 record가 도입된 commit. 다른 곳을 가리키는
+  tag는 repoint finding이다.
+
+비교는 peeled commit SHA로 합니다 — 이 저장소 이력에는 annotated와 lightweight tag가 섞여
+있어 tag object SHA는 같은 tag를 다르게 판정할 수 있습니다.
+
+## Cutover verdict (M4)
+
+evaluator는 매 실행 관측에서 cutover 상태를 재산출하며 verdict를 저장하지 않습니다. 입력:
+INSTALL pin inventory, `.skillstead/cutover-record.json`의 record, baseline ref 4개, GitHub
+Releases 목록(전체 페이지 — pagination 미완주나 타입을 정할 수 없는 release 객체는
+`CV-DOMAIN`), 저장소 Latest, `main` first-parent history.
+
+verdict: `not-started` · `pending-tags` · `tags-ok` · `complete` · `aborted` · `red`(error
+code 포함). 실패에는 `candidate=`/`predicate=` detail이 붙습니다.
+
+| Code | 의미 | 해소 |
+| --- | --- | --- |
+| CV-ORPHAN | record 없이 pin·ref·release가 움직임 | 되돌리거나 정식 cutover commit 생성 |
+| CV-SCHEMA | record가 schema(S1~S10) 위반 | record 교체(baseline ref가 없는 동안만) |
+| CV-ATTEMPT | attempt sequence 위반. **모든 attempt 증가는 `T3-unprovable`** — 직전 attempt의 ref 부재는 기계 증명이 불가하므로 재시도는 cutover ⓪의 owner gate를 요구 | owner 절차 |
+| CV-ABORT-TAGS / CV-ABORT-PIN | aborted record인데 ref 존재 / pin이 legacy가 아님 | owner 판단 / pin 되돌리기 |
+| CV-PARTIAL-TAGS | baseline ref 4개 중 1~3개만 존재 | 집합 완성 — atomic 실패 잔재라면 owner 판단 선행 |
+| CV-PIN | pin inventory가 단계와 불일치 | `docs/INSTALL.md` pin 수정 |
+| CV-SAME / CV-BASE / CV-TREE | cutover commit이 같은 commit에서 pin을 전환하지 않음 / baseline SHA 도달 불가 / `skills/` tree drift | cutover commit 재생성(ref 0개일 때만) |
+| CV-CLOCK | public breakage 구간(pin 전환 후 tag 생성 전)이 1시간 초과 | tag 생성 완료 또는 revert |
+| CV-TARGET / CV-FROZEN | baseline tag repoint / ref 존재 후 record 변경(삭제·복원 포함) | owner 결정 — tag는 삭제하지 않음 |
+| CV-RELEASE | 발행된 release가 P1(prerelease 금지)·P2(제목에 `<skill> X.Y.Z` 포함)·P3(본문 첫 줄 exact Latest marker) 위반, 또는 후속 tag가 tag gate 실패 | wrapper를 통한 owner 승인 metadata 정정 |
+| CV-PREMATURE | cutover 완료 전에 통상 release가 발행됨 | wrapper를 통한 owner accept-forward |
+| CV-LATEST-INITIAL / CV-LATEST-STEADY | 저장소 Latest가 기대 release가 아님 | wrapper를 통한 owner 승인 Latest 정정 |
+| CV-DOMAIN | Releases 관측을 완주·정규화할 수 없음 | 재실행. transport 실패 해소 |
+| CV-OBSERVE | git 관측 실패(이 code는 도구가 정의한 것이고 나머지는 상위 decision record가 고정) | 재실행. 저장소 접근 해소 |
+
+P3의 exact marker(고정, English, trim 후 바이트 비교):
+
+```text
+> **Latest** refers to the most recently published individual skill release, not a catalog version.
+```
+
+## Release wrapper (M5)
+
+request 파일:
+
+```json
+{
+  "action": "create-draft | publish | edit-metadata",
+  "recovery_mode": "none | premature-accept-forward | metadata-correction",
+  "tag": "<name>/vX.Y.Z",
+  "title": "…",
+  "body": "…",
+  "draft": false,
+  "prerelease": false,
+  "latest_intent": true,
+  "owner_authorization": null
+}
+```
+
+`owner_authorization`은 `edit-metadata`와 `none`이 아닌 모든 `recovery_mode`에 필수입니다.
+wrapper는: evaluator를 실행하고, 아래 허용 행렬로 작업을 판정하고(판정 키는 verdict·error
+code·action·recovery mode의 조합 — recovery는 포괄 우회가 될 수 없음), tag 실재·P1~P3·전체
+tag 표면의 M3 green(어떤 finding이든 mutation 차단)을 확인하고, 허용된 `gh release
+create`/`edit`만 검증된 metadata를 정확히 적용해 실행하고, evaluator를 재실행해 publish
+후에는 **Latest가 방금 발행한 tag와 정확히 같을 것**을 요구합니다 — evaluator의 steady-state
+검사보다 강한 조건입니다.
+
+| Verdict | 허용 |
+| --- | --- |
+| not-started / aborted / pending-tags | 없음 |
+| tags-ok | record가 선언한 baseline ref 중 release가 없는 것의 create-draft/publish |
+| complete | 통상 gate를 통과하는 release의 create-draft/publish |
+| red / CV-RELEASE | offending release의 owner 승인 metadata 정정 |
+| red / CV-LATEST-* | 기대 release의 owner 승인 Latest 정정 |
+| red / CV-PREMATURE | owner accept-forward: 빠진 baseline release와 Latest 정정 |
+| red / 그 밖 | 없음 |
+
+## 규격 reference validator (skills-ref)
+
+`tools/run_skills_ref.py`는 agent skills 규격의 reference validator를 보조 검사로 실행하며
+정확한 upstream commit에 pin되어 있습니다:
+
+| 항목 | 값 |
+| --- | --- |
+| Source | `https://github.com/agentskills/agentskills` — `skills-ref/` subdirectory |
+| Pin | commit `38a2ff82958afee88dadf4831509e6f7e9d8ef4e` (exact. 업그레이드는 의도적·검토된 pin 변경으로만) |
+| Upstream license | Apache-2.0 |
+| 제약 | upstream 스스로 demonstration-only reference 구현이며 production 용도가 아니라고 명시 |
+| 이것이 검사하는 것 | frontmatter 필수 필드와 name↔folder 일치 |
+| 검사하지 않는 것 | 라이선스 pointer resolution, 라이선스 바이트 일치, SemVer 형식, CHANGELOG 일치, 카탈로그 열 — 전부 `skillstead_validate` 소관 |
+
+교체 조건 — 다음 중 하나가 성립하면 pin을 올리거나 의존을 제거합니다: upstream이 production
+준비를 선언하거나 규격이 실질 개정되어 pin이 더 이상 규격을 반영하지 못할 때, pin을 통한
+조달이 반복 실패할 때, `skillstead_validate`가 규격 수준 검사를 흡수해 reference 실행이
+불필요해질 때. pin된 validator의 조달·실행 실패는 빌드를 실패시킵니다(fail-closed).

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -26,8 +26,8 @@ action별 request boolean 제약(request는 의도한 최종 상태와 같아야
 
 | action | draft | prerelease | latest_intent | owner_authorization |
 | --- | --- | --- | --- | --- |
-| create-draft | `true` 필수 | `false` 필수 | 자유 | 불필요 |
-| publish | `false` 필수 | `false` 필수 | `true` 필수 | 불필요 |
+| create-draft | `true` 필수 | `false` 필수 | 자유 | `recovery_mode != none`이면 필수 |
+| publish | `false` 필수 | `false` 필수 | `true` 필수 | `recovery_mode != none`이면 필수 |
 | edit-metadata | `false` 필수 | `false` 필수 | Latest 정정 시 `true` | 필수 |
 
 **순서:** `M2 preflight green → M2 apply-tags → M3 → M5`. tag 변경은 preflight를 재실행하는

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -16,12 +16,23 @@ verdict, never a silent pass.
 | Mode | What | When it runs | Command |
 | --- | --- | --- | --- |
 | M1 | Repository validation — package structure, `metadata.version` ↔ CHANGELOG (I-1), catalog `Version` columns (I-7), package completeness (I-9), licence copy byte-equality | every PR, push to `main`, daily schedule | `PYTHONPATH=tools python3 -m skillstead_validate repo` |
-| M2 | Release preflight and tag creation — payload-diff release gate (I-3/I-4), bump-step check (I-6), inventory guard (I-10), major-bump guard, new-skill initial release, tag uniqueness | invoked for a proposed release; dry-runnable | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` |
+| M2 | Release preflight and tag creation — payload-diff release gate (I-3/I-4), bump-step check (I-6), inventory guard (I-10), major-bump guard, new-skill initial release, tag uniqueness | invoked for a proposed release; dry-runnable | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` (publishes to the remote with `git push --atomic`; a push failure rolls local refs back) |
 | M3 | Continuous tag checks — I-2, I-5, I-8 and the durable expected-target relation for every namespaced tag, on every run (tags are mutable; creation-time checks alone guarantee nothing) | every PR, push, tag create/delete, daily schedule | `… tags --main-ref origin/main` |
 | M4 | Cutover verdict — the ordered evaluator over the cutover record, INSTALL pins, baseline refs, and GitHub Releases | CI runs + before/after every release operation | `… cutover --live --repo-slug OWNER/REPO` |
 | M5 | Canonical release wrapper — **the only supported path for GitHub Release operations** | manual, or the `release` workflow | `… release --request REQUEST.json --repo-slug OWNER/REPO [--dry-run]` |
 
-Exit status is `0` when green (M4: any non-red verdict) and `1` otherwise.
+Exit status: `0` when green (M4: any non-red verdict), `1` on findings, a
+red verdict, or a rejected/failed request, and `2` on a usage error
+(unknown mode or missing required arguments).
+
+Request boolean constraints per action (the request must equal the intended
+final state):
+
+| action | draft | prerelease | latest_intent | owner_authorization |
+| --- | --- | --- | --- | --- |
+| create-draft | must be `true` | must be `false` | any | not required |
+| publish | must be `false` | must be `false` | must be `true` | not required |
+| edit-metadata | must be `false` | must be `false` | `true` when correcting Latest | required |
 
 **Ordering:** `M2 preflight green → M2 apply-tags → M3 → M5`. Tag mutation
 happens only through `apply-tags`, which re-runs the preflight first. The

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,0 +1,206 @@
+# Validation And Release Toolchain
+
+[한국어](./VALIDATION.ko.md)
+
+This document describes the repository's validation toolchain under
+`tools/skillstead_validate/` and the release path it guards. The versioning
+rules themselves live in [`VERSIONING.md`](./VERSIONING.md); this page covers
+how they are checked and how a release is executed.
+
+All judgment logic is Python 3.11+ standard library only and **fails
+closed**: anything the tools cannot parse or observe is a finding or a red
+verdict, never a silent pass.
+
+## Modes
+
+| Mode | What | When it runs | Command |
+| --- | --- | --- | --- |
+| M1 | Repository validation — package structure, `metadata.version` ↔ CHANGELOG (I-1), catalog `Version` columns (I-7), package completeness (I-9), licence copy byte-equality | every PR, push to `main`, daily schedule | `PYTHONPATH=tools python3 -m skillstead_validate repo` |
+| M2 | Release preflight and tag creation — payload-diff release gate (I-3/I-4), bump-step check (I-6), inventory guard (I-10), major-bump guard, new-skill initial release, tag uniqueness | invoked for a proposed release; dry-runnable | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` |
+| M3 | Continuous tag checks — I-2, I-5, I-8 and the durable expected-target relation for every namespaced tag, on every run (tags are mutable; creation-time checks alone guarantee nothing) | every PR, push, tag create/delete, daily schedule | `… tags --main-ref origin/main` |
+| M4 | Cutover verdict — the ordered evaluator over the cutover record, INSTALL pins, baseline refs, and GitHub Releases | CI runs + before/after every release operation | `… cutover --live --repo-slug OWNER/REPO` |
+| M5 | Canonical release wrapper — **the only supported path for GitHub Release operations** | manual, or the `release` workflow | `… release --request REQUEST.json --repo-slug OWNER/REPO [--dry-run]` |
+
+Exit status is `0` when green (M4: any non-red verdict) and `1` otherwise.
+
+**Ordering:** `M2 preflight green → M2 apply-tags → M3 → M5`. Tag mutation
+happens only through `apply-tags`, which re-runs the preflight first. The
+wrapper never creates tags (`--verify-tag` on every create). Calling `gh
+release …` directly is an **unsupported path** — repository rulesets carry
+admin bypasses, so this boundary is discipline, not a hard guarantee.
+
+## CI workflows
+
+| File | Triggers | Purpose |
+| --- | --- | --- |
+| `validate.yml` | PR, push to `main`, tag create/delete | event-driven M1+M3+M4 (tag events run M3+M4 against an explicit `main` checkout) |
+| `validate-periodic.yml` | daily schedule (`17 3 * * *` UTC), manual dispatch | periodic fallback for state changes that fire no event (e.g. a tag repointed outside a push) |
+| `release.yml` | manual dispatch only | M5 wrapper entry; dry-run by default; checkout pinned to `main` so a dispatch can never run an unreviewed wrapper or request under the write token |
+
+The two validation workflows are separate files so that disabling either —
+including GitHub's automatic disable of scheduled workflows after 60 days of
+repository inactivity — never silences the other. Nominal maximum detection
+latency for event-less mutations is one schedule period (~24h) plus
+scheduler delay. If the scheduled workflow is auto-disabled, re-enable it
+from the Actions tab (or run it once via manual dispatch) after the next
+activity.
+
+All jobs check out with full history and tags (`fetch-depth: 0`) — the
+first-parent derivations below require it.
+
+## Release plan (M2 input)
+
+```json
+{
+  "target_commit": "<sha or ref on main>",
+  "releases": [
+    {"skill": "<name>", "previous_ref": "<name>/vX.Y.Z or null",
+     "proposed_version": "X.Y.Z", "proposed_ref": "refs/tags/<name>/vX.Y.Z"}
+  ]
+}
+```
+
+The preflight is green only when the set of skills whose **payload** changed
+since their previous release equals the plan's set exactly — a changed skill
+missing from the plan is an I-3 finding, an unchanged skill in the plan is an
+I-4 finding. Payload excludes exactly two bookkeeping artifacts: the
+`metadata.version` scalar and `CHANGELOG.md` (see `VERSIONING.md`).
+
+Additional checks: the target commit must satisfy the full M1 validation and
+sit on `main` first-parent history; the bump step must match the path-default
+step; a major bump is rejected unconditionally until an owner-approval
+evidence format exists; an inventory reduction without an approved retirement
+marker is rejected unconditionally until the marker format exists; a new
+skill's initial release must introduce the package and both catalog rows in
+the target commit itself; no existing tag may share the proposed version's
+SemVer precedence (including `+build` aliases).
+
+**Bump-Adjustment marker.** When the proposed step differs from the
+path-default step, the release's CHANGELOG entry must contain a standalone,
+non-empty reason line:
+
+```text
+Bump-Adjustment: <why the default step was overridden>
+```
+
+An empty marker, a marker inside another entry, or a marker embedded in a
+longer line does not count.
+
+## Continuous tag checks (M3)
+
+For every `<name>/vX.Y.Z` tag, on every run:
+
+* **Grammar** — `<name>/vMAJOR.MINOR.PATCH` only; no pre-release or build
+  suffixes.
+* **I-2** — the peeled target commit declares exactly the tag's version.
+* **I-8** — the peeled target is a commit on `main`.
+* **I-5** — at every observed release commit, every skill whose version
+  changed there still has its tag (existence only; target correctness is the
+  next check's job). After the cutover record exists, the expected tag set
+  is also derived independently from `main` first-parent version changes, so
+  deleting *all* tags of a release is still detected.
+* **Expected target** — derived without looking at the tag: for an ordinary
+  tag, the oldest `main` first-parent commit where the skill's declared
+  version changed to the tag's version; for the four baseline tags (exact
+  ref membership in the cutover record, never version-string matching), the
+  commit that introduced the record. A tag pointing anywhere else is a
+  repoint finding.
+
+Comparisons use peeled commit SHAs — annotated and lightweight tags mix in
+this repository's history and tag-object SHAs would split them.
+
+## Cutover verdict (M4)
+
+The evaluator re-derives the cutover state from observation on every run;
+no verdict is ever stored. Inputs: the INSTALL pin inventory, the cutover
+record at `.skillstead/cutover-record.json`, the four baseline refs, the
+GitHub Releases list (every page; a pagination shortfall or an untypeable
+release object is `CV-DOMAIN`), the repository Latest, and `main`
+first-parent history.
+
+Verdicts: `not-started` · `pending-tags` · `tags-ok` · `complete` ·
+`aborted` · `red` (with an error code). Failures carry
+`candidate=`/`predicate=` detail.
+
+| Code | Meaning | Way out |
+| --- | --- | --- |
+| CV-ORPHAN | pins/refs/releases moved without a record | revert, or create a proper cutover commit |
+| CV-SCHEMA | record violates the schema (S1~S10) | replace the record (only while no baseline ref exists) |
+| CV-ATTEMPT | attempt sequence invalid; **any attempt increase is `T3-unprovable`** — a prior attempt's ref absence cannot be machine-verified, so retries require the owner gate in cutover step ⓪ | owner procedure |
+| CV-ABORT-TAGS / CV-ABORT-PIN | aborted record with refs present / non-legacy pins | owner judgment / revert pins |
+| CV-PARTIAL-TAGS | 1–3 of the four baseline refs exist | complete the set — owner judgment first if an atomic failure left residue |
+| CV-PIN | pin inventory does not match the phase | fix `docs/INSTALL.md` pins |
+| CV-SAME / CV-BASE / CV-TREE | cutover commit did not switch the pins in the same commit / baseline SHA unreachable / `skills/` tree drifted | recreate the cutover commit (only while refs are 0) |
+| CV-CLOCK | the public-breakage window (pins switched, tags not yet created) exceeded 1 hour | finish tag creation or revert |
+| CV-TARGET / CV-FROZEN | baseline tag repointed / record touched (including deleted-and-restored) after refs exist | owner decision — tags are never deleted |
+| CV-RELEASE | a published release violates P1 (no prereleases), P2 (title contains `<skill> X.Y.Z`), or P3 (exact Latest marker as the first body line), or a successor tag fails the tag gate | owner-approved metadata correction via the wrapper |
+| CV-PREMATURE | an ordinary release went out before the cutover completed | owner accept-forward via the wrapper |
+| CV-LATEST-INITIAL / CV-LATEST-STEADY | repository Latest is not the expected release | owner-approved Latest correction via the wrapper |
+| CV-DOMAIN | the Releases observation could not be completed or normalized | re-run; fix the transport failure |
+| CV-OBSERVE | a git observation failed (this code is tool-defined; the underlying decision record fixes the others) | re-run; fix the repository access |
+
+P3's exact marker (fixed, English, byte-compared after trimming):
+
+```text
+> **Latest** refers to the most recently published individual skill release, not a catalog version.
+```
+
+## Release wrapper (M5)
+
+Request file:
+
+```json
+{
+  "action": "create-draft | publish | edit-metadata",
+  "recovery_mode": "none | premature-accept-forward | metadata-correction",
+  "tag": "<name>/vX.Y.Z",
+  "title": "…",
+  "body": "…",
+  "draft": false,
+  "prerelease": false,
+  "latest_intent": true,
+  "owner_authorization": null
+}
+```
+
+`owner_authorization` is required for `edit-metadata` and for any
+`recovery_mode` other than `none`. The wrapper: runs the evaluator; checks
+the operation against the allowed matrix below (the judgment key is the
+combination of verdict, error code, action, and recovery mode — recovery is
+never a blanket bypass); verifies the tag exists, the metadata satisfies
+P1~P3, and the whole tag surface passes M3 (any finding blocks the
+mutation); executes only the permitted `gh release create`/`edit` with the
+verified metadata applied exactly; re-runs the evaluator and, after a
+publish, requires **Latest to equal the tag just published** — stronger than
+the evaluator's steady-state check.
+
+| Verdict | Allowed |
+| --- | --- |
+| not-started / aborted / pending-tags | nothing |
+| tags-ok | create-draft/publish for a record-declared baseline ref whose release is missing |
+| complete | create-draft/publish for a release that passes the normal gates |
+| red / CV-RELEASE | owner-approved metadata correction of the offending release |
+| red / CV-LATEST-* | owner-approved Latest correction of the expected release |
+| red / CV-PREMATURE | owner accept-forward: missing baseline releases and Latest correction |
+| red / anything else | nothing |
+
+## Spec reference validator (skills-ref)
+
+`tools/run_skills_ref.py` runs the agent-skills specification's reference
+validator as a supplementary check, pinned to an exact upstream commit:
+
+| Fact | Value |
+| --- | --- |
+| Source | `https://github.com/agentskills/agentskills` — `skills-ref/` subdirectory |
+| Pin | commit `38a2ff82958afee88dadf4831509e6f7e9d8ef4e` (exact; upgrades are deliberate, reviewed pin changes) |
+| Upstream license | Apache-2.0 |
+| Constraint | upstream describes itself as a demonstration-only reference implementation, not for production |
+| Checked by it | frontmatter required fields and name↔folder agreement |
+| Not checked by it | licence pointer resolution, licence byte-equality, SemVer form, CHANGELOG agreement, catalog columns — all owned by `skillstead_validate` |
+
+Replacement conditions — the pin is upgraded or the dependency dropped when
+any of these holds: upstream declares production readiness or materially
+changes the specification the pin no longer reflects; procurement through
+the pin fails repeatedly; or `skillstead_validate` absorbs the spec-level
+checks, making the reference run redundant. A failure to procure or run the
+pinned validator fails the build (fail-closed).

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -30,8 +30,8 @@ final state):
 
 | action | draft | prerelease | latest_intent | owner_authorization |
 | --- | --- | --- | --- | --- |
-| create-draft | must be `true` | must be `false` | any | not required |
-| publish | must be `false` | must be `false` | must be `true` | not required |
+| create-draft | must be `true` | must be `false` | any | required when `recovery_mode != none` |
+| publish | must be `false` | must be `false` | must be `true` | required when `recovery_mode != none` |
 | edit-metadata | must be `false` | must be `false` | `true` when correcting Latest | required |
 
 **Ordering:** `M2 preflight green → M2 apply-tags → M3 → M5`. Tag mutation

--- a/tests/fixture_builder.py
+++ b/tests/fixture_builder.py
@@ -1,0 +1,60 @@
+"""Builds synthetic repositories for validator tests.
+
+A fixture repo is a minimal tree that passes M1 (``run_repo_validation``)
+before mutation. Negative fixtures are produced by mutating a valid tree; this
+keeps each fixture's failure attributable to exactly one seeded defect.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+LICENSE_TEXT = "Apache License stand-in body for fixtures.\n"
+
+EN_HEADER = "| Skill | Best for | Version | Runtime support | Maturity |"
+KO_HEADER = "| 스킬 | 이런 작업에 적합 | 버전 | 지원 실행 환경 | 성숙도 |"
+
+
+def _skill_md(name: str, version: str, license_ptr: str = "LICENSE.txt") -> str:
+    return (
+        "---\n"
+        f"name: {name}\n"
+        "description: >\n"
+        "  Fixture skill package used by validator tests.\n"
+        f"license: {license_ptr}\n"
+        "metadata:\n"
+        f"  version: {version}\n"
+        "---\n"
+        f"\n# {name}\n"
+    )
+
+
+def _changelog(name: str, version: str) -> str:
+    return (
+        f"# Changelog — {name}\n\n"
+        f"## [{version}] — 2026-07-24\n\n"
+        "Fixture baseline entry.\n"
+    )
+
+
+def _catalog(header: str, rows: dict[str, str]) -> str:
+    lines = [header, "| --- | --- | --- | --- | --- |"]
+    for name, version in sorted(rows.items()):
+        lines.append(f"| [`{name}`](./skills/{name}) | Fixture | `{version}` | Claude Code | Beta |")
+    return "# Fixture catalog\n\n" + "\n".join(lines) + "\n"
+
+
+def build_valid_repo(root: Path, skills: dict[str, str] | None = None) -> Path:
+    """Create a valid fixture repo at ``root``; returns ``root``."""
+    skills = skills or {"alpha-skill": "1.2.3", "beta-skill": "0.4.0"}
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "LICENSE").write_text(LICENSE_TEXT, encoding="utf-8")
+    (root / "README.md").write_text(_catalog(EN_HEADER, skills), encoding="utf-8")
+    (root / "README.ko.md").write_text(_catalog(KO_HEADER, skills), encoding="utf-8")
+    for name, version in skills.items():
+        pkg = root / "skills" / name
+        pkg.mkdir(parents=True)
+        (pkg / "SKILL.md").write_text(_skill_md(name, version), encoding="utf-8")
+        (pkg / "CHANGELOG.md").write_text(_changelog(name, version), encoding="utf-8")
+        (pkg / "LICENSE.txt").write_text(LICENSE_TEXT, encoding="utf-8")
+    return root

--- a/tests/git_fixture.py
+++ b/tests/git_fixture.py
@@ -38,6 +38,14 @@ def build_released_repo(root: Path, skills: dict[str, str] | None = None) -> Pat
     return root
 
 
+def build_unreleased_repo(root: Path, skills: dict[str, str] | None = None) -> Path:
+    """Valid repo committed on main with NO namespaced tags (pre-cutover)."""
+    build_valid_repo(root, skills or dict(SKILLS))
+    _git_init(root)
+    commit_all(root, "initial state, no releases")
+    return root
+
+
 def _git_init(repo: Path) -> None:
     subprocess.run(["git", "init", "-q", "-b", "main", str(repo)],
                    capture_output=True, text=True, check=True)

--- a/tests/git_fixture.py
+++ b/tests/git_fixture.py
@@ -38,6 +38,16 @@ def build_released_repo(root: Path, skills: dict[str, str] | None = None) -> Pat
     return root
 
 
+def add_bare_remote(repo: Path) -> Path:
+    """Attach a bare 'origin' so atomic tag publication has a target."""
+    bare = repo.parent / (repo.name + "-origin.git")
+    subprocess.run(["git", "init", "-q", "--bare", str(bare)],
+                   capture_output=True, text=True, check=True)
+    _git(repo, "remote", "add", "origin", str(bare))
+    _git(repo, "push", "-q", "origin", "main")
+    return bare
+
+
 def build_unreleased_repo(root: Path, skills: dict[str, str] | None = None) -> Path:
     """Valid repo committed on main with NO namespaced tags (pre-cutover)."""
     build_valid_repo(root, skills or dict(SKILLS))

--- a/tests/git_fixture.py
+++ b/tests/git_fixture.py
@@ -1,0 +1,59 @@
+"""Synthetic git repositories for release-gate and tag-check fixtures.
+
+Each fixture starts from a valid tree (fixture_builder) committed on ``main``
+with a namespaced release tag per skill, so every negative fixture's failure
+is attributable to the single defect it seeds afterwards.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from fixture_builder import build_valid_repo
+
+SKILLS = {"alpha-skill": "1.2.3", "beta-skill": "0.4.0"}
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, check=True).stdout
+
+
+def commit_all(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").strip()
+
+
+def build_released_repo(root: Path, skills: dict[str, str] | None = None) -> Path:
+    """Valid repo whose HEAD carries a namespaced release tag per skill."""
+    skills = skills or dict(SKILLS)
+    build_valid_repo(root, skills)
+    _git_init(root)
+    sha = commit_all(root, "baseline release")
+    for name, version in skills.items():
+        _git(root, "tag", f"{name}/v{version}", sha)
+    return root
+
+
+def _git_init(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)],
+                   capture_output=True, text=True, check=True)
+    _git(repo, "config", "user.email", "fixture@example.invalid")
+    _git(repo, "config", "user.name", "Fixture")
+
+
+def plan_json(target: str, entries: list[dict]) -> str:
+    import json
+    return json.dumps({"target_commit": target, "releases": entries})
+
+
+def entry(skill: str, previous: str | None, version: str) -> dict:
+    return {
+        "skill": skill,
+        "previous_ref": previous,
+        "proposed_version": version,
+        "proposed_ref": f"refs/tags/{skill}/v{version}",
+    }

--- a/tests/test_cutover.py
+++ b/tests/test_cutover.py
@@ -296,6 +296,19 @@ class CutoverFixture(unittest.TestCase):
         v = self.verdict(releases=[r])
         self.assertEqual((v.verdict, v.code), ("red", "CV-DOMAIN"))
 
+    # MR2R-F5: top-level 비배열 입력과 published_at 없는 published Release
+    def test_f5r_non_array_input_is_cv_domain(self) -> None:
+        sha = self._to_tags_ok()
+        v = run_cutover(self.repo, "main", {}, None, now=self.now_at(sha))
+        self.assertEqual((v.verdict, v.code), ("red", "CV-DOMAIN"))
+
+    def test_f5r_published_without_timestamp_is_cv_domain(self) -> None:
+        self._to_tags_ok()
+        r = make_release(FIX_TAGS[0].removeprefix("refs/tags/"), "x")
+        r["published_at"] = None
+        v = self.verdict(releases=[r])
+        self.assertEqual((v.verdict, v.code), ("red", "CV-DOMAIN"))
+
     # -- multi-fault precedence (R0-F3) ---------------------------------
     def test_precedence_partial_tags_beats_identity(self) -> None:
         # Q-SAME broken (split commits) AND partial tags: Step 3 must win.

--- a/tests/test_cutover.py
+++ b/tests/test_cutover.py
@@ -1,4 +1,4 @@
-"""M4 cutover evaluator fixtures (DR-819 D8-1 · D8-2)."""
+"""M4 cutover evaluator fixtures (record schema and ordered-evaluator contract)."""
 
 from __future__ import annotations
 

--- a/tests/test_cutover.py
+++ b/tests/test_cutover.py
@@ -1,0 +1,354 @@
+"""M4 cutover evaluator fixtures (DR-819 D8-1 · D8-2)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from git_fixture import _git, build_unreleased_repo, commit_all  # noqa: E402
+from skillstead_validate import install_pins, record_schema  # noqa: E402
+from skillstead_validate.cutover import P3_MARKER, run_cutover  # noqa: E402
+from skillstead_validate.transport import (TransportError, fetch_latest,  # noqa: E402
+                                           fetch_releases)
+
+SKILLS = {"alpha-skill": "1.2.3", "beta-skill": "0.4.0"}
+FIX_TAGS = ("refs/tags/alpha-skill/v1.2.3", "refs/tags/beta-skill/v0.4.0")
+FIX_PIN = "alpha-skill/v1.2.3"
+
+
+def make_install(ref: str, skill: str = "alpha-skill", count: int = 7) -> str:
+    block = (f"```bash\n"
+             f"git clone --depth 1 --branch {ref} https://example.invalid/r.git /tmp/x\n"
+             f"cp -R /tmp/x/skills/{skill} dest/\n"
+             f"```\n")
+    return "# Install\n\n" + "\n".join(f"## Way {i}\n\n{block}" for i in range(count))
+
+
+def make_release(tag: str, published: str, *, prerelease: bool = False,
+                 title: str | None = None, body: str | None = None) -> dict:
+    skill, version = tag.split("/v")
+    return {"tag_name": tag, "draft": False, "prerelease": prerelease,
+            "name": title if title is not None else f"{skill} {version}",
+            "body": body if body is not None else P3_MARKER + "\n\nNotes.\n",
+            "published_at": published}
+
+
+class CutoverFixture(unittest.TestCase):
+    """Synthetic cutover lifecycle; canonical constants patched to fixture
+    values (guarded elsewhere by the D8-1 constants test)."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = build_unreleased_repo(Path(self._tmp.name) / "repo", dict(SKILLS))
+        (self.repo / "docs").mkdir(exist_ok=True)
+        (self.repo / "docs/INSTALL.md").write_text(make_install("v0.8.0"), encoding="utf-8")
+        self.base_sha = commit_all(self.repo, "legacy install")
+        stack = ExitStack()
+        stack.enter_context(patch.object(record_schema, "BASELINE_FINALIZATION_SHA", self.base_sha))
+        stack.enter_context(patch.object(record_schema, "BASELINE_TAGS", FIX_TAGS))
+        stack.enter_context(patch.object(record_schema, "LATEST_REF", FIX_TAGS[-1]))
+        stack.enter_context(patch.object(install_pins, "BASELINE_PIN", FIX_PIN))
+        self.addCleanup(stack.close)
+        self.addCleanup(self._tmp.cleanup)
+
+    # -- helpers --------------------------------------------------------
+    def record(self, **overrides) -> dict:
+        rec = {"schema": record_schema.SCHEMA, "attempt": 1, "phase": "prepared",
+               "baseline_finalization_sha": self.base_sha,
+               "latest_ref": FIX_TAGS[-1], "baseline_tags": list(FIX_TAGS)}
+        rec.update(overrides)
+        return rec
+
+    def cutover_commit(self, record: dict | str | None = None, pin: str = FIX_PIN) -> str:
+        (self.repo / "docs/INSTALL.md").write_text(make_install(pin), encoding="utf-8")
+        rec_dir = self.repo / ".skillstead"
+        rec_dir.mkdir(exist_ok=True)
+        record = self.record() if record is None else record
+        text = record if isinstance(record, str) else json.dumps(record)
+        (rec_dir / "cutover-record.json").write_text(text, encoding="utf-8")
+        return commit_all(self.repo, "cutover commit")
+
+    def create_tags(self, sha: str, refs=FIX_TAGS) -> None:
+        for ref in refs:
+            _git(self.repo, "tag", ref.removeprefix("refs/tags/"), sha)
+
+    def now_at(self, sha: str, delta: int = 10) -> int:
+        return int(_git(self.repo, "log", "-1", "--format=%ct", sha).strip()) + delta
+
+    def verdict(self, releases=(), latest=None, now=None):
+        head = _git(self.repo, "rev-parse", "HEAD").strip()
+        return run_cutover(self.repo, "main", list(releases), latest,
+                           now=now if now is not None else self.now_at(head))
+
+    # -- Step 1 ---------------------------------------------------------
+    def test_not_started(self) -> None:
+        self.assertEqual(self.verdict().verdict, "not-started")
+
+    def test_cv_orphan(self) -> None:
+        (self.repo / "docs/INSTALL.md").write_text(make_install(FIX_PIN), encoding="utf-8")
+        commit_all(self.repo, "pins switched without record")
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code), ("red", "CV-ORPHAN"))
+
+    # -- Step 2 (S1~S10) ------------------------------------------------
+    def test_schema_violations(self) -> None:
+        cases = {
+            "S2": json.dumps({**self.record(), "extra": 1}),
+            "S3": '{"schema": "x", "schema": "y"}',
+            "S4": json.dumps(self.record(schema="wrong")),
+            "S5": json.dumps(self.record(attempt=True)),
+            "S6": json.dumps(self.record(phase="active")),
+            "S7": json.dumps(self.record(baseline_finalization_sha="f" * 40)),
+            "S8": json.dumps(self.record(baseline_tags=[FIX_TAGS[0]])),
+            "S10": json.dumps(self.record(latest_ref=FIX_TAGS[0])),
+        }
+        for predicate, text in cases.items():
+            with self.subTest(predicate):
+                repo_state = _git(self.repo, "rev-parse", "HEAD").strip()
+                self.cutover_commit(record=text)
+                v = self.verdict()
+                self.assertEqual((v.verdict, v.code), ("red", "CV-SCHEMA"))
+                self.assertTrue(v.predicate.startswith(predicate), v)
+                _git(self.repo, "reset", "-q", "--hard", repo_state)
+
+    # -- Step 3 / Step 4 ------------------------------------------------
+    def test_pending_green(self) -> None:
+        self.cutover_commit()
+        self.assertEqual(self.verdict().verdict, "pending-tags")
+
+    def test_cv_clock(self) -> None:
+        sha = self.cutover_commit()
+        v = self.verdict(now=self.now_at(sha, 4000))
+        self.assertEqual((v.verdict, v.code), ("red", "CV-CLOCK"))
+
+    def test_cv_pin_pending(self) -> None:
+        self.cutover_commit(pin="v0.8.0")  # record present, pins still legacy
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code), ("red", "CV-PIN"))
+
+    def test_cv_same(self) -> None:
+        (self.repo / "docs/INSTALL.md").write_text(make_install(FIX_PIN), encoding="utf-8")
+        commit_all(self.repo, "pins only")
+        rec_dir = self.repo / ".skillstead"
+        rec_dir.mkdir(exist_ok=True)
+        (rec_dir / "cutover-record.json").write_text(json.dumps(self.record()), encoding="utf-8")
+        commit_all(self.repo, "record only")
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code), ("red", "CV-SAME"))
+
+    def test_cv_partial_tags(self) -> None:
+        sha = self.cutover_commit()
+        self.create_tags(sha, refs=FIX_TAGS[:1])
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code), ("red", "CV-PARTIAL-TAGS"))
+
+    def test_cv_attempt_t1(self) -> None:
+        self.cutover_commit(record=self.record(attempt=2))
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code, v.predicate), ("red", "CV-ATTEMPT", "T1"))
+
+    def test_cv_attempt_t3(self) -> None:
+        self.cutover_commit()  # attempt 1, prepared
+        self.cutover_commit(record=self.record(attempt=2))  # increase w/o aborted
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code, v.predicate), ("red", "CV-ATTEMPT", "T3"))
+
+    def test_aborted_green_and_retry(self) -> None:
+        self.cutover_commit()
+        # revert: pins back to legacy + phase aborted, one commit
+        (self.repo / "docs/INSTALL.md").write_text(make_install("v0.8.0"), encoding="utf-8")
+        (self.repo / ".skillstead/cutover-record.json").write_text(
+            json.dumps(self.record(phase="aborted")), encoding="utf-8")
+        commit_all(self.repo, "abort attempt 1")
+        self.assertEqual(self.verdict().verdict, "aborted")
+        # legitimate retry: attempt 2 after aborted predecessor
+        self.cutover_commit(record=self.record(attempt=2))
+        self.assertEqual(self.verdict().verdict, "pending-tags")
+
+    def test_cv_abort_tags(self) -> None:
+        sha = self.cutover_commit()
+        self.create_tags(sha)
+        (self.repo / ".skillstead/cutover-record.json").write_text(
+            json.dumps(self.record(phase="aborted")), encoding="utf-8")
+        (self.repo / "docs/INSTALL.md").write_text(make_install("v0.8.0"), encoding="utf-8")
+        commit_all(self.repo, "abort after tags")
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code), ("red", "CV-ABORT-TAGS"))
+
+    # -- tags-ok / Step 6 -----------------------------------------------
+    def _to_tags_ok(self) -> str:
+        sha = self.cutover_commit()
+        self.create_tags(sha)
+        return sha
+
+    def test_tags_ok_green(self) -> None:
+        self._to_tags_ok()
+        self.assertEqual(self.verdict().verdict, "tags-ok")
+
+    def test_cv_target(self) -> None:
+        self._to_tags_ok()
+        (self.repo / "NOTES.md").write_text("later\n", encoding="utf-8")
+        later = commit_all(self.repo, "later")
+        _git(self.repo, "tag", "-f", FIX_TAGS[0].removeprefix("refs/tags/"), later)
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code), ("red", "CV-TARGET"))
+
+    def test_cv_frozen(self) -> None:
+        self._to_tags_ok()
+        (self.repo / ".skillstead/cutover-record.json").write_text(
+            json.dumps(self.record(phase="prepared", attempt=1)) + "\n", encoding="utf-8")
+        commit_all(self.repo, "touch record after tags")
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code), ("red", "CV-FROZEN"))
+
+    def test_complete_initial_and_cv_latest_initial(self) -> None:
+        self._to_tags_ok()
+        releases = [make_release(t.removeprefix("refs/tags/"), f"2026-07-28T00:0{i}:00Z")
+                    for i, t in enumerate(FIX_TAGS)]
+        good = self.verdict(releases=releases, latest=FIX_TAGS[-1].removeprefix("refs/tags/"))
+        self.assertEqual((good.verdict, good.detail), ("complete", "initial promotion"))
+        bad = self.verdict(releases=releases, latest=FIX_TAGS[0].removeprefix("refs/tags/"))
+        self.assertEqual((bad.verdict, bad.code), ("red", "CV-LATEST-INITIAL"))
+
+    def test_cv_premature(self) -> None:
+        self._to_tags_ok()
+        releases = [make_release(FIX_TAGS[0].removeprefix("refs/tags/"), "2026-07-28T00:00:00Z"),
+                    make_release("alpha-skill/v1.3.0", "2026-07-28T01:00:00Z")]
+        v = self.verdict(releases=releases, latest="alpha-skill/v1.3.0")
+        self.assertEqual((v.verdict, v.code), ("red", "CV-PREMATURE"))
+
+    def test_cv_release_p1_p3(self) -> None:
+        self._to_tags_ok()
+        p1 = [make_release(FIX_TAGS[0].removeprefix("refs/tags/"), "2026-07-28T00:00:00Z",
+                           prerelease=True)]
+        v = self.verdict(releases=p1)
+        self.assertEqual((v.verdict, v.code, v.predicate), ("red", "CV-RELEASE", "P1"))
+        p3 = [make_release(FIX_TAGS[0].removeprefix("refs/tags/"), "2026-07-28T00:00:00Z",
+                           body="wrong first line\n")]
+        v = self.verdict(releases=p3)
+        self.assertEqual((v.verdict, v.code, v.predicate), ("red", "CV-RELEASE", "P3"))
+
+    def test_steady_state_and_cv_latest_steady(self) -> None:
+        self._to_tags_ok()
+        # real successor release: payload + bookkeeping + tag on main
+        skill_md = self.repo / "skills/alpha-skill/SKILL.md"
+        skill_md.write_text(skill_md.read_text(encoding="utf-8").replace(
+            "  version: 1.2.3", "  version: 1.3.0") + "\nBody.\n", encoding="utf-8")
+        changelog = self.repo / "skills/alpha-skill/CHANGELOG.md"
+        changelog.write_text(changelog.read_text(encoding="utf-8").replace(
+            "## [1.2.3]", "## [1.3.0] — 2026-07-28\n\nEntry.\n\n## [1.2.3]", 1), encoding="utf-8")
+        for fname in ("README.md", "README.ko.md"):
+            f = self.repo / fname
+            f.write_text(f.read_text(encoding="utf-8").replace("`1.2.3`", "`1.3.0`"), encoding="utf-8")
+        succ_sha = commit_all(self.repo, "release alpha 1.3.0")
+        _git(self.repo, "tag", "alpha-skill/v1.3.0", succ_sha)
+        releases = [make_release(t.removeprefix("refs/tags/"), f"2026-07-28T00:0{i}:00Z")
+                    for i, t in enumerate(FIX_TAGS)]
+        releases.append(make_release("alpha-skill/v1.3.0", "2026-07-28T02:00:00Z"))
+        good = self.verdict(releases=releases, latest="alpha-skill/v1.3.0")
+        self.assertEqual((good.verdict, good.detail), ("complete", "steady state"))
+        bad = self.verdict(releases=releases, latest=FIX_TAGS[0].removeprefix("refs/tags/"))
+        self.assertEqual((bad.verdict, bad.code), ("red", "CV-LATEST-STEADY"))
+
+    # -- multi-fault precedence (R0-F3) ---------------------------------
+    def test_precedence_partial_tags_beats_identity(self) -> None:
+        # Q-SAME broken (split commits) AND partial tags: Step 3 must win.
+        (self.repo / "docs/INSTALL.md").write_text(make_install(FIX_PIN), encoding="utf-8")
+        commit_all(self.repo, "pins only")
+        rec_dir = self.repo / ".skillstead"
+        rec_dir.mkdir(exist_ok=True)
+        (rec_dir / "cutover-record.json").write_text(json.dumps(self.record()), encoding="utf-8")
+        sha = commit_all(self.repo, "record only")
+        self.create_tags(sha, refs=FIX_TAGS[:1])
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code), ("red", "CV-PARTIAL-TAGS"))
+
+    def test_precedence_release_beats_pin(self) -> None:
+        # Invalid baseline release (Step 4 CV-RELEASE) AND legacy pins
+        # (Step 6A CV-PIN): Step 4 must win.
+        sha = self._to_tags_ok()
+        (self.repo / "docs/INSTALL.md").write_text(make_install("v0.8.0"), encoding="utf-8")
+        commit_all(self.repo, "pins back to legacy (defect)")
+        releases = [make_release(FIX_TAGS[0].removeprefix("refs/tags/"), "2026-07-28T00:00:00Z",
+                                 body="not the marker\n")]
+        v = self.verdict(releases=releases)
+        self.assertEqual((v.verdict, v.code), ("red", "CV-RELEASE"))
+
+
+class RealRepoNotStarted(unittest.TestCase):
+    def test_real_repo_is_not_started(self) -> None:
+        repo = Path(__file__).resolve().parent.parent
+        v = run_cutover(repo, "main", [], None)
+        self.assertEqual(v.verdict, "not-started", v)
+
+
+class InstallPinParsing(unittest.TestCase):
+    def test_real_install_is_pin_legacy(self) -> None:
+        repo = Path(__file__).resolve().parent.parent
+        inv = install_pins.parse_pins((repo / "docs/INSTALL.md").read_text(encoding="utf-8"))
+        self.assertEqual(len(inv.pins), 7)
+        self.assertFalse(inv.ambiguous)
+        self.assertEqual(install_pins.classify(inv, lambda _t: False), "PIN-LEGACY")
+
+    def test_ambiguous_block_is_other(self) -> None:
+        text = ("```bash\n"
+                "git clone --branch v1 https://x /tmp/a\n"
+                "git clone --branch v1 https://x /tmp/b\n"
+                "cp -R /tmp/a/skills/alpha-skill dest/\n"
+                "```\n")
+        inv = install_pins.parse_pins(text)
+        self.assertTrue(inv.ambiguous)
+        self.assertEqual(install_pins.classify(inv, lambda _t: True), "PIN-OTHER")
+
+    def test_namespace_copy_mismatch_is_other(self) -> None:
+        text = make_install("alpha-skill/v1.0.0", skill="beta-skill", count=2)
+        inv = install_pins.parse_pins(text)
+        self.assertEqual(install_pins.classify(inv, lambda _t: True), "PIN-OTHER")
+
+    def test_valid_namespaced(self) -> None:
+        text = make_install("alpha-skill/v1.0.0", skill="alpha-skill", count=2)
+        inv = install_pins.parse_pins(text)
+        self.assertEqual(install_pins.classify(inv, lambda _t: True), "PIN-NAMESPACED")
+        self.assertEqual(install_pins.classify(inv, lambda _t: False), "PIN-OTHER")
+
+
+class TransportSeam(unittest.TestCase):
+    def test_two_page_success(self) -> None:
+        pages = [json.dumps([{"id": i} for i in range(100)]), json.dumps([{"id": 100}])]
+        calls = []
+
+        def runner(args):
+            calls.append(args)
+            return pages[len(calls) - 1]
+        out = fetch_releases("o/r", runner)
+        self.assertEqual(len(out), 101)
+        self.assertEqual(len(calls), 2)
+
+    def test_mid_page_failure_fails_closed(self) -> None:
+        def runner(args):
+            if "page=2" in args[-1]:
+                raise TransportError("boom")
+            return json.dumps([{"id": i} for i in range(100)])
+        with self.assertRaises(TransportError):
+            fetch_releases("o/r", runner)
+
+    def test_malformed_page_fails_closed(self) -> None:
+        with self.assertRaises(TransportError):
+            fetch_releases("o/r", lambda a: "not json")
+
+    def test_latest_404_is_none(self) -> None:
+        def runner(args):
+            raise TransportError("HTTP 404: Not Found")
+        self.assertIsNone(fetch_latest("o/r", runner))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cutover.py
+++ b/tests/test_cutover.py
@@ -336,8 +336,14 @@ class CutoverFixture(unittest.TestCase):
 
 class RealRepoNotStarted(unittest.TestCase):
     def test_real_repo_is_not_started(self) -> None:
+        # CI checks out a PR merge ref without a local `main` branch, so the
+        # remote-tracking ref is the portable main reference.
+        import subprocess
         repo = Path(__file__).resolve().parent.parent
-        v = run_cutover(repo, "main", [], None)
+        has_origin = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "--verify", "origin/main"],
+            capture_output=True).returncode == 0
+        v = run_cutover(repo, "origin/main" if has_origin else "main", [], None)
         self.assertEqual(v.verdict, "not-started", v)
 
 

--- a/tests/test_cutover.py
+++ b/tests/test_cutover.py
@@ -161,7 +161,7 @@ class CutoverFixture(unittest.TestCase):
         v = self.verdict()
         self.assertEqual((v.verdict, v.code, v.predicate), ("red", "CV-ATTEMPT", "T3"))
 
-    def test_aborted_green_and_retry(self) -> None:
+    def test_aborted_green_and_retry_fails_closed(self) -> None:
         self.cutover_commit()
         # revert: pins back to legacy + phase aborted, one commit
         (self.repo / "docs/INSTALL.md").write_text(make_install("v0.8.0"), encoding="utf-8")
@@ -169,9 +169,12 @@ class CutoverFixture(unittest.TestCase):
             json.dumps(self.record(phase="aborted")), encoding="utf-8")
         commit_all(self.repo, "abort attempt 1")
         self.assertEqual(self.verdict().verdict, "aborted")
-        # legitimate retry: attempt 2 after aborted predecessor
+        # MR2-F3 owner 결정: 직전 attempt의 ref 부재는 기계 증명이 불가하므로
+        # 정상 형태의 retry도 fail-closed — 해소는 cutover ⓪ owner gate(C5)
         self.cutover_commit(record=self.record(attempt=2))
-        self.assertEqual(self.verdict().verdict, "pending-tags")
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code, v.predicate),
+                         ("red", "CV-ATTEMPT", "T3-unprovable"))
 
     def test_cv_abort_tags(self) -> None:
         sha = self.cutover_commit()
@@ -258,6 +261,41 @@ class CutoverFixture(unittest.TestCase):
         bad = self.verdict(releases=releases, latest=FIX_TAGS[0].removeprefix("refs/tags/"))
         self.assertEqual((bad.verdict, bad.code), ("red", "CV-LATEST-STEADY"))
 
+    # MR2-F1: 형식적 INSTALL 변경으로는 Q-SAME이 성립하지 않는다 —
+    # 실제 PIN-LEGACY → PIN-BASELINE 전환이어야 한다
+    def test_f1_cosmetic_install_edit_is_not_a_pin_switch(self) -> None:
+        (self.repo / "docs/INSTALL.md").write_text(
+            make_install("v0.8.0") + "\n<!-- cosmetic -->\n", encoding="utf-8")
+        rec_dir = self.repo / ".skillstead"
+        rec_dir.mkdir(exist_ok=True)
+        (rec_dir / "cutover-record.json").write_text(json.dumps(self.record()), encoding="utf-8")
+        commit_all(self.repo, "record + cosmetic INSTALL edit")
+        (self.repo / "docs/INSTALL.md").write_text(make_install(FIX_PIN), encoding="utf-8")
+        commit_all(self.repo, "actual pin switch, one commit too late")
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code), ("red", "CV-SAME"))
+
+    # MR2-F2: frozen 구간 내 record 삭제·복원은 freeze 위반이다
+    def test_f2_record_delete_and_restore_is_frozen_violation(self) -> None:
+        sha = self.cutover_commit()
+        self.create_tags(sha)
+        original = (self.repo / ".skillstead/cutover-record.json").read_text(encoding="utf-8")
+        (self.repo / ".skillstead/cutover-record.json").unlink()
+        commit_all(self.repo, "delete record")
+        (self.repo / ".skillstead").mkdir(exist_ok=True)
+        (self.repo / ".skillstead/cutover-record.json").write_text(original, encoding="utf-8")
+        commit_all(self.repo, "restore record verbatim")
+        v = self.verdict()
+        self.assertEqual((v.verdict, v.code), ("red", "CV-FROZEN"))
+
+    # MR2-F5: draft 필드가 없는 release 객체는 관측 불능 — CV-DOMAIN
+    def test_f5_missing_draft_field_is_cv_domain(self) -> None:
+        self._to_tags_ok()
+        r = make_release(FIX_TAGS[0].removeprefix("refs/tags/"), "2026-07-28T00:00:00Z")
+        del r["draft"]
+        v = self.verdict(releases=[r])
+        self.assertEqual((v.verdict, v.code), ("red", "CV-DOMAIN"))
+
     # -- multi-fault precedence (R0-F3) ---------------------------------
     def test_precedence_partial_tags_beats_identity(self) -> None:
         # Q-SAME broken (split commits) AND partial tags: Step 3 must win.
@@ -312,6 +350,32 @@ class InstallPinParsing(unittest.TestCase):
         text = make_install("alpha-skill/v1.0.0", skill="beta-skill", count=2)
         inv = install_pins.parse_pins(text)
         self.assertEqual(install_pins.classify(inv, lambda _t: True), "PIN-OTHER")
+
+    # MR2-F4: --branch 없는 clone block은 침묵이 아니라 모호성이다
+    def test_f4_clone_without_branch_is_ambiguous(self) -> None:
+        extra = ("```bash\n"
+                 "git clone https://example.invalid/r.git /tmp/x\n"
+                 "cp -R /tmp/x/skills/alpha-skill dest/\n"
+                 "```\n")
+        inv = install_pins.parse_pins(make_install("v0.8.0") + extra)
+        self.assertTrue(inv.ambiguous)
+        self.assertEqual(install_pins.classify(inv, lambda _t: True), "PIN-OTHER")
+
+    def test_f4_duplicate_copy_lines_are_ambiguous(self) -> None:
+        block = ("```bash\n"
+                 "git clone --branch v1 https://example.invalid/r.git /tmp/x\n"
+                 "cp -R /tmp/x/skills/alpha-skill a/\n"
+                 "cp -R /tmp/x/skills/alpha-skill b/\n"
+                 "```\n")
+        inv = install_pins.parse_pins(block)
+        self.assertTrue(inv.ambiguous)
+
+    def test_f4_unclosed_candidate_fence_is_ambiguous(self) -> None:
+        text = ("```bash\n"
+                "git clone --branch v1 https://example.invalid/r.git /tmp/x\n"
+                "cp -R /tmp/x/skills/alpha-skill dest/\n")
+        inv = install_pins.parse_pins(text)
+        self.assertTrue(inv.ambiguous)
 
     def test_valid_namespaced(self) -> None:
         text = make_install("alpha-skill/v1.0.0", skill="alpha-skill", count=2)

--- a/tests/test_package_check.py
+++ b/tests/test_package_check.py
@@ -1,8 +1,8 @@
 """M1 package-structure fixtures.
 
-Negative fixtures ①~④ are the four package-structure defects the pinned spec
-validator was measured to miss (FEAT-20260728-001 contract), plus fail-closed
-parse coverage. The positive fixture guards against false alarms.
+Negative fixtures ①~④ are the package-structure defects the C3 fixture
+contract requires this validator to catch, plus fail-closed parse coverage.
+The positive fixture guards against false alarms.
 """
 
 from __future__ import annotations
@@ -70,6 +70,22 @@ class PackageCheckFixtures(unittest.TestCase):
     # I-9 gate failure: SKILL.md 자체 부재
     def test_skill_md_missing(self) -> None:
         (self.repo / "skills/alpha-skill/SKILL.md").unlink()
+        self.assertIn("I-9", self.checks())
+
+    # R1-F3: package 밖을 가리키는 symlink는 자기완결 계약 우회다
+    def test_symlinked_license_rejected(self) -> None:
+        import os
+        target = self.repo / "skills/alpha-skill/LICENSE.txt"
+        target.unlink()
+        os.symlink("../../LICENSE", target)
+        self.assertIn("I-9", self.checks())
+
+    def test_symlinked_package_dir_rejected(self) -> None:
+        import os, shutil
+        pkg = self.repo / "skills/alpha-skill"
+        moved = self.repo / "alpha-elsewhere"
+        shutil.move(str(pkg), str(moved))
+        os.symlink("../alpha-elsewhere", pkg)
         self.assertIn("I-9", self.checks())
 
     # fail-closed: 파싱 불가는 통과가 아니라 finding이다

--- a/tests/test_package_check.py
+++ b/tests/test_package_check.py
@@ -1,0 +1,130 @@
+"""M1 package-structure fixtures.
+
+Negative fixtures ①~④ are the four package-structure defects the pinned spec
+validator was measured to miss (FEAT-20260728-001 contract), plus fail-closed
+parse coverage. The positive fixture guards against false alarms.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from fixture_builder import build_valid_repo  # noqa: E402
+from skillstead_validate.package_check import run_repo_validation  # noqa: E402
+
+
+class PackageCheckFixtures(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = build_valid_repo(Path(self._tmp.name) / "repo")
+        self.addCleanup(self._tmp.cleanup)
+
+    def checks(self) -> set[str]:
+        return {f.check for f in run_repo_validation(self.repo)}
+
+    def test_positive_fixture_is_green(self) -> None:
+        self.assertEqual(run_repo_validation(self.repo), [])
+
+    # ① license pointer 부재·외부 경로
+    def test_license_pointer_missing_file(self) -> None:
+        (self.repo / "skills/alpha-skill/LICENSE.txt").unlink()
+        self.assertIn("I-9", self.checks())
+
+    def test_license_pointer_escapes_package(self) -> None:
+        skill_md = self.repo / "skills/alpha-skill/SKILL.md"
+        skill_md.write_text(
+            skill_md.read_text(encoding="utf-8").replace(
+                "license: LICENSE.txt", "license: ../../LICENSE"),
+            encoding="utf-8")
+        self.assertIn("I-9", self.checks())
+
+    # ② metadata.version 비-SemVer
+    def test_non_semver_version(self) -> None:
+        skill_md = self.repo / "skills/alpha-skill/SKILL.md"
+        skill_md.write_text(
+            skill_md.read_text(encoding="utf-8").replace(
+                "  version: 1.2.3", "  version: not-a-semver"),
+            encoding="utf-8")
+        self.assertIn("VERSION", self.checks())
+
+    # ③ metadata.version ↔ CHANGELOG 최상단 불일치 (I-1)
+    def test_changelog_disagreement(self) -> None:
+        changelog = self.repo / "skills/alpha-skill/CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8").replace("[1.2.3]", "[9.9.9]"),
+            encoding="utf-8")
+        self.assertIn("I-1", self.checks())
+
+    # ④ 라이선스 사본 ↔ root LICENSE 바이트 불일치
+    def test_license_byte_mismatch(self) -> None:
+        (self.repo / "skills/alpha-skill/LICENSE.txt").write_text(
+            "Apache License stand-in body for fixtures. \n", encoding="utf-8")
+        self.assertIn("LICENSE-BYTES", self.checks())
+
+    # I-9 gate failure: SKILL.md 자체 부재
+    def test_skill_md_missing(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").unlink()
+        self.assertIn("I-9", self.checks())
+
+    # fail-closed: 파싱 불가는 통과가 아니라 finding이다
+    def test_unparseable_frontmatter_fails_closed(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            "no frontmatter at all\n", encoding="utf-8")
+        self.assertIn("PARSE", self.checks())
+
+    def test_changelog_first_heading_not_released_fails_closed(self) -> None:
+        changelog = self.repo / "skills/alpha-skill/CHANGELOG.md"
+        changelog.write_text(
+            "# Changelog\n\n## Something else\n\n## [1.2.3] — 2026-07-24\n",
+            encoding="utf-8")
+        self.assertIn("I-1", self.checks())
+
+
+class CatalogFixtures(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = build_valid_repo(Path(self._tmp.name) / "repo")
+        self.addCleanup(self._tmp.cleanup)
+
+    def checks(self) -> set[str]:
+        return {f.check for f in run_repo_validation(self.repo)}
+
+    def test_version_column_disagreement(self) -> None:
+        readme = self.repo / "README.md"
+        readme.write_text(
+            readme.read_text(encoding="utf-8").replace("`1.2.3`", "`1.2.4`"),
+            encoding="utf-8")
+        self.assertIn("I-7", self.checks())
+
+    def test_missing_catalog_row(self) -> None:
+        for fname in ("README.md", "README.ko.md"):
+            f = self.repo / fname
+            f.write_text(
+                "\n".join(l for l in f.read_text(encoding="utf-8").splitlines()
+                          if "beta-skill" not in l) + "\n",
+                encoding="utf-8")
+        self.assertIn("I-7", self.checks())
+
+    def test_inventory_is_not_fixed_to_four(self) -> None:
+        # A fifth package must be validated and demanded in the catalog.
+        pkg = self.repo / "skills" / "gamma-skill"
+        pkg.mkdir(parents=True)
+        (pkg / "SKILL.md").write_text(
+            "---\nname: gamma-skill\nlicense: LICENSE.txt\nmetadata:\n  version: 0.1.0\n---\n",
+            encoding="utf-8")
+        (pkg / "CHANGELOG.md").write_text(
+            "# Changelog — gamma-skill\n\n## [0.1.0] — 2026-07-28\n\nInitial.\n",
+            encoding="utf-8")
+        (pkg / "LICENSE.txt").write_text(
+            (self.repo / "LICENSE").read_text(encoding="utf-8"), encoding="utf-8")
+        self.assertIn("I-7", self.checks())  # catalog rows now lag the inventory
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -10,7 +10,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from git_fixture import build_released_repo, commit_all, entry, plan_json  # noqa: E402
+from git_fixture import (_git, build_released_repo, build_unreleased_repo,  # noqa: E402
+                         commit_all, entry, plan_json)
 from skillstead_validate.release_gate import apply_tags, preflight  # noqa: E402
 from skillstead_validate.release_plan import PlanError, parse_plan  # noqa: E402
 
@@ -138,6 +139,141 @@ class ReleaseGateFixtures(unittest.TestCase):
         commit_all(self.repo, "release alpha 1.3.0")
         plan = parse_plan(plan_json("HEAD", [entry("alpha-skill", "alpha-skill/v1.2.3", "1.3.0")]))
         self.assertEqual(apply_tags(self.repo, plan), ["alpha-skill/v1.3.0"])
+
+
+class MR1Fixtures(unittest.TestCase):
+    """중간 리뷰 ①의 probe 재현 fixture — 회귀 고정."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = build_released_repo(Path(self._tmp.name) / "repo")
+        self.addCleanup(self._tmp.cleanup)
+
+    def _release_body_change(self, version: str = "1.3.0") -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
+            + "\nNew body paragraph.\n", encoding="utf-8")
+        _bump_alpha(self.repo, version)
+
+    def _preflight(self, entries: list[dict]) -> set[str]:
+        plan = parse_plan(plan_json("HEAD", entries))
+        return {f.check for f in preflight(self.repo, plan)}
+
+    # MR1-F1: 기존 skill release에서 license 삭제 → I-9
+    def test_f1_license_deletion_caught_at_target(self) -> None:
+        self._release_body_change()
+        (self.repo / "skills/alpha-skill/LICENSE.txt").unlink()
+        commit_all(self.repo, "release without licence copy")
+        self.assertIn("I-9", self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "1.3.0")]))
+
+    # MR1-F1: KO catalog stale → I-7
+    def test_f1_stale_ko_catalog_caught_at_target(self) -> None:
+        self._release_body_change()
+        ko = self.repo / "README.ko.md"
+        ko.write_text(ko.read_text(encoding="utf-8").replace("`1.3.0`", "`1.2.3`"),
+                      encoding="utf-8")
+        commit_all(self.repo, "release with stale KO version cell")
+        self.assertIn("I-7", self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "1.3.0")]))
+
+    # MR1-F2: off-main target은 mutation 전에 거부된다
+    def test_f2_off_main_target_rejected(self) -> None:
+        _git(self.repo, "checkout", "-q", "-b", "side")
+        self._release_body_change()
+        commit_all(self.repo, "release on side branch")
+        plan = parse_plan(plan_json("HEAD", [entry("alpha-skill", "alpha-skill/v1.2.3", "1.3.0")]))
+        checks = {f.check for f in preflight(self.repo, plan, main_ref="main")}
+        _git(self.repo, "checkout", "-q", "main")
+        self.assertIn("I-8", checks)
+
+    # MR1-F2: 동일 SemVer precedence alias(+build) 검출
+    def test_f2_precedence_alias_rejected(self) -> None:
+        head = _git(self.repo, "rev-parse", "HEAD").strip()
+        _git(self.repo, "tag", "alpha-skill/v1.3.0+build", head)
+        self._release_body_change()
+        commit_all(self.repo, "release 1.3.0")
+        self.assertIn("D3-3", self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "1.3.0")]))
+
+    # MR1-F2: 다중 tag는 단일 transaction으로 생성된다 (positive)
+    def test_f2_multi_tag_transaction(self) -> None:
+        for skill, prev, version in (("alpha-skill", "1.2.3", "1.3.0"),
+                                     ("beta-skill", "0.4.0", "0.5.0")):
+            skill_md = self.repo / f"skills/{skill}/SKILL.md"
+            skill_md.write_text(
+                skill_md.read_text(encoding="utf-8").replace(
+                    f"  version: {prev}", f"  version: {version}") + "\nBody.\n",
+                encoding="utf-8")
+            changelog = self.repo / f"skills/{skill}/CHANGELOG.md"
+            changelog.write_text(
+                changelog.read_text(encoding="utf-8").replace(
+                    f"## [{prev}]", f"## [{version}] — 2026-07-28\n\nEntry.\n\n## [{prev}]", 1),
+                encoding="utf-8")
+            for fname in ("README.md", "README.ko.md"):
+                f = self.repo / fname
+                f.write_text(f.read_text(encoding="utf-8").replace(f"`{prev}`", f"`{version}`"),
+                             encoding="utf-8")
+        commit_all(self.repo, "dual release")
+        plan = parse_plan(plan_json("HEAD", [
+            entry("alpha-skill", "alpha-skill/v1.2.3", "1.3.0"),
+            entry("beta-skill", "beta-skill/v0.4.0", "0.5.0")]))
+        self.assertEqual(apply_tags(self.repo, plan),
+                         ["alpha-skill/v1.3.0", "beta-skill/v0.5.0"])
+
+    # MR1-F3: package가 이전 commit에 먼저 들어온 신규 skill → D3-3
+    def test_f3_new_skill_split_across_commits_rejected(self) -> None:
+        pkg = self.repo / "skills/gamma-skill"
+        pkg.mkdir(parents=True)
+        (pkg / "SKILL.md").write_text(
+            "---\nname: gamma-skill\nlicense: LICENSE.txt\nmetadata:\n  version: 0.1.0\n---\n",
+            encoding="utf-8")
+        (pkg / "CHANGELOG.md").write_text(
+            "# Changelog — gamma-skill\n\n## [0.1.0] — 2026-07-28\n\nInitial.\n", encoding="utf-8")
+        (pkg / "LICENSE.txt").write_text(
+            (self.repo / "LICENSE").read_text(encoding="utf-8"), encoding="utf-8")
+        commit_all(self.repo, "add gamma package only")
+        for fname in ("README.md", "README.ko.md"):
+            f = self.repo / fname
+            f.write_text(f.read_text(encoding="utf-8").replace(
+                "| --- | --- | --- | --- | --- |",
+                "| --- | --- | --- | --- | --- |\n| [`gamma-skill`](./skills/gamma-skill) | Fixture | `0.1.0` | Claude Code | Beta |",
+                1), encoding="utf-8")
+        commit_all(self.repo, "add gamma catalog rows later")
+        self.assertIn("D3-3", self._preflight([entry("gamma-skill", None, "0.1.0")]))
+
+    # MR1-F4: 빈 marker는 사유가 아니다
+    def test_f4_empty_adjustment_marker_rejected(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
+            + "\nTypo fix.\n", encoding="utf-8")
+        _bump_alpha(self.repo, "1.2.4")
+        changelog = self.repo / "skills/alpha-skill/CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8").replace(
+                "Fixture entry.", "Bump-Adjustment:\n\nFixture entry."),
+            encoding="utf-8")
+        commit_all(self.repo, "patch bump with empty marker")
+        self.assertIn("I-6", self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "1.2.4")]))
+
+    # MR1-F4: 다른 entry의 marker는 이 release의 사유가 아니다
+    def test_f4_marker_in_other_entry_rejected(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
+            + "\nTypo fix.\n", encoding="utf-8")
+        _bump_alpha(self.repo, "1.2.4")
+        changelog = self.repo / "skills/alpha-skill/CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8").replace(
+                "## [1.2.3] — 2026-07-24",
+                "## [1.2.3] — 2026-07-24\n\nBump-Adjustment: reason recorded on the wrong entry."),
+            encoding="utf-8")
+        commit_all(self.repo, "marker on previous entry")
+        self.assertIn("I-6", self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "1.2.4")]))
+
+    # MR1-F8: pre-cutover + 빈 plan = 진짜 no-op green
+    def test_f8_pre_cutover_empty_plan_is_green(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = build_unreleased_repo(Path(tmp) / "repo")
+            plan = parse_plan(plan_json("HEAD", []))
+            self.assertEqual(preflight(repo, plan), [])
 
 
 class GitFailClosed(unittest.TestCase):

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -10,8 +10,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from git_fixture import (_git, build_released_repo, build_unreleased_repo,  # noqa: E402
-                         commit_all, entry, plan_json)
+from git_fixture import (_git, add_bare_remote, build_released_repo,  # noqa: E402
+                         build_unreleased_repo, commit_all, entry, plan_json)
 from skillstead_validate.release_gate import apply_tags, preflight  # noqa: E402
 from skillstead_validate.release_plan import PlanError, parse_plan  # noqa: E402
 
@@ -131,13 +131,30 @@ class ReleaseGateFixtures(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             apply_tags(self.repo, plan)
 
-    def test_apply_tags_creates_planned_tags(self) -> None:
+    def test_apply_tags_publishes_to_remote(self) -> None:
+        bare = add_bare_remote(self.repo)
         (self.repo / "skills/alpha-skill/SKILL.md").write_text(
             (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
             + "\nNew body paragraph.\n", encoding="utf-8")
         _bump_alpha(self.repo, "1.3.0")
         commit_all(self.repo, "release alpha 1.3.0")
         plan = parse_plan(plan_json("HEAD", [entry("alpha-skill", "alpha-skill/v1.2.3", "1.3.0")]))
+        self.assertEqual(apply_tags(self.repo, plan), ["alpha-skill/v1.3.0"])
+        remote_tags = _git(self.repo, "ls-remote", "--tags", str(bare))
+        self.assertIn("refs/tags/alpha-skill/v1.3.0", remote_tags)
+
+    # R1-F1: 발행 실패 시 local ref rollback — 재시도가 막히지 않는다
+    def test_apply_tags_rolls_back_on_push_failure(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
+            + "\nNew body paragraph.\n", encoding="utf-8")
+        _bump_alpha(self.repo, "1.3.0")
+        commit_all(self.repo, "release alpha 1.3.0")
+        plan = parse_plan(plan_json("HEAD", [entry("alpha-skill", "alpha-skill/v1.2.3", "1.3.0")]))
+        with self.assertRaises(RuntimeError):  # no origin remote yet
+            apply_tags(self.repo, plan)
+        self.assertNotIn("alpha-skill/v1.3.0", _git(self.repo, "tag", "--list"))
+        add_bare_remote(self.repo)
         self.assertEqual(apply_tags(self.repo, plan), ["alpha-skill/v1.3.0"])
 
 
@@ -212,6 +229,7 @@ class MR1Fixtures(unittest.TestCase):
                 f.write_text(f.read_text(encoding="utf-8").replace(f"`{prev}`", f"`{version}`"),
                              encoding="utf-8")
         commit_all(self.repo, "dual release")
+        add_bare_remote(self.repo)
         plan = parse_plan(plan_json("HEAD", [
             entry("alpha-skill", "alpha-skill/v1.2.3", "1.3.0"),
             entry("beta-skill", "beta-skill/v0.4.0", "0.5.0")]))

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -275,6 +275,52 @@ class MR1Fixtures(unittest.TestCase):
             plan = parse_plan(plan_json("HEAD", []))
             self.assertEqual(preflight(repo, plan), [])
 
+    # MR1R-F3: parent catalog가 손상돼 같은 commit 도입을 증명할 수 없으면
+    # fail-closed다 — silent skip으로 green이 되면 안 된다
+    def test_f3_unreadable_parent_catalog_fails_closed(self) -> None:
+        for fname in ("README.md", "README.ko.md"):
+            f = self.repo / fname
+            f.write_text(f.read_text(encoding="utf-8").replace("| Skill |", "| Broken |")
+                         .replace("| 스킬 |", "| 깨짐 |"), encoding="utf-8")
+        commit_all(self.repo, "corrupt catalog headers")
+        pkg = self.repo / "skills/gamma-skill"
+        pkg.mkdir(parents=True)
+        (pkg / "SKILL.md").write_text(
+            "---\nname: gamma-skill\nlicense: LICENSE.txt\nmetadata:\n  version: 0.1.0\n---\n",
+            encoding="utf-8")
+        (pkg / "CHANGELOG.md").write_text(
+            "# Changelog — gamma-skill\n\n## [0.1.0] — 2026-07-28\n\nInitial.\n", encoding="utf-8")
+        (pkg / "LICENSE.txt").write_text(
+            (self.repo / "LICENSE").read_text(encoding="utf-8"), encoding="utf-8")
+        for fname in ("README.md", "README.ko.md"):
+            f = self.repo / fname
+            f.write_text(f.read_text(encoding="utf-8").replace("| Broken |", "| Skill |")
+                         .replace("| 깨짐 |", "| 스킬 |")
+                         .replace("| --- | --- | --- | --- | --- |",
+                                  "| --- | --- | --- | --- | --- |\n| [`gamma-skill`](./skills/gamma-skill) | Fixture | `0.1.0` | Claude Code | Beta |",
+                                  1), encoding="utf-8")
+        commit_all(self.repo, "repair headers + add gamma in one commit")
+        self.assertIn("D3-3", self._preflight([entry("gamma-skill", None, "0.1.0")]))
+
+    # MR1R-F8: record 흔적이 있으면 tag 전량 삭제 상태를 pre-cutover로
+    # 오인하지 않는다 — I-10 fail-closed
+    def test_f8_full_deletion_with_record_trace_not_mistaken_for_pre_cutover(self) -> None:
+        import shutil
+        record_dir = self.repo / ".skillstead"
+        record_dir.mkdir()
+        (record_dir / "cutover-record.json").write_text("{}", encoding="utf-8")
+        commit_all(self.repo, "record trace")
+        for tag in ("alpha-skill/v1.2.3", "beta-skill/v0.4.0"):
+            _git(self.repo, "tag", "-d", tag)
+        shutil.rmtree(self.repo / "skills/beta-skill")
+        for fname in ("README.md", "README.ko.md"):
+            f = self.repo / fname
+            f.write_text(
+                "\n".join(l for l in f.read_text(encoding="utf-8").splitlines()
+                          if "beta-skill" not in l) + "\n", encoding="utf-8")
+        commit_all(self.repo, "remove beta after deleting all tags")
+        self.assertIn("I-10", self._preflight([]))
+
 
 class GitFailClosed(unittest.TestCase):
     # 경계 (b): git/history 조회 실패는 통과가 아니라 finding이다

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -1,0 +1,170 @@
+"""M2 release-gate fixtures: E7 ⓐⓑⓓ, I-6, E14, §D3-3, plan fail-closed."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from git_fixture import build_released_repo, commit_all, entry, plan_json  # noqa: E402
+from skillstead_validate.release_gate import apply_tags, preflight  # noqa: E402
+from skillstead_validate.release_plan import PlanError, parse_plan  # noqa: E402
+
+
+def _bump_alpha(repo: Path, version: str, *, adjustment: bool = False) -> None:
+    """Write bookkeeping for an alpha-skill release: version + CHANGELOG + catalog."""
+    skill_md = repo / "skills/alpha-skill/SKILL.md"
+    skill_md.write_text(
+        skill_md.read_text(encoding="utf-8").replace("  version: 1.2.3", f"  version: {version}"),
+        encoding="utf-8")
+    changelog = repo / "skills/alpha-skill/CHANGELOG.md"
+    reason = "Bump-Adjustment: path default overridden — fixture reason.\n\n" if adjustment else ""
+    changelog.write_text(
+        changelog.read_text(encoding="utf-8").replace(
+            "## [1.2.3]", f"## [{version}] — 2026-07-28\n\n{reason}Fixture entry.\n\n## [1.2.3]", 1)
+        .replace(f"## [{version}] — 2026-07-28 — 2026-07-24", f"## [{version}] — 2026-07-28"),
+        encoding="utf-8")
+    for fname in ("README.md", "README.ko.md"):
+        f = repo / fname
+        f.write_text(f.read_text(encoding="utf-8").replace("`1.2.3`", f"`{version}`"), encoding="utf-8")
+
+
+class ReleaseGateFixtures(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = build_released_repo(Path(self._tmp.name) / "repo")
+        self.addCleanup(self._tmp.cleanup)
+
+    def _preflight(self, entries: list[dict]) -> set[str]:
+        plan = parse_plan(plan_json("HEAD", entries))
+        return {f.check for f in preflight(self.repo, plan)}
+
+    # 정상 release: payload 변경(minor 경로) + minor bump + CHANGELOG + catalog
+    def test_positive_release_is_green(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
+            + "\nNew body paragraph.\n", encoding="utf-8")
+        _bump_alpha(self.repo, "1.3.0")
+        commit_all(self.repo, "release alpha 1.3.0")
+        self.assertEqual(self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "1.3.0")]), set())
+
+    # E7-ⓐ: payload 변경 + 미bump (plan에 없음) → I-3
+    def test_e7a_payload_change_without_release(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
+            + "\nChanged.\n", encoding="utf-8")
+        commit_all(self.repo, "change payload without bump")
+        self.assertIn("I-3", self._preflight([]))
+
+    # E7-ⓑ: bookkeeping-only bump → I-4
+    def test_e7b_bookkeeping_only_bump(self) -> None:
+        _bump_alpha(self.repo, "1.2.4")
+        commit_all(self.repo, "bookkeeping-only bump")
+        self.assertIn("I-4", self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "1.2.4")]))
+
+    # E7-ⓓ: marker 없는 inventory 감소 → I-10 (fail-closed)
+    def test_e7d_inventory_reduction_without_marker(self) -> None:
+        import shutil
+        shutil.rmtree(self.repo / "skills/beta-skill")
+        for fname in ("README.md", "README.ko.md"):
+            f = self.repo / fname
+            f.write_text(
+                "\n".join(l for l in f.read_text(encoding="utf-8").splitlines()
+                          if "beta-skill" not in l) + "\n", encoding="utf-8")
+        commit_all(self.repo, "remove beta-skill without marker")
+        self.assertIn("I-10", self._preflight([]))
+
+    # I-6: 경로 기본값 minor를 patch로 내렸는데 사유 없음 → I-6; 사유 있으면 green
+    def test_i6_adjustment_requires_reason(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
+            + "\nTypo fix.\n", encoding="utf-8")
+        _bump_alpha(self.repo, "1.2.4")
+        commit_all(self.repo, "patch bump for minor-default path")
+        self.assertIn("I-6", self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "1.2.4")]))
+
+    def test_i6_adjustment_with_reason_is_green(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
+            + "\nTypo fix.\n", encoding="utf-8")
+        _bump_alpha(self.repo, "1.2.4", adjustment=True)
+        commit_all(self.repo, "patch bump with recorded reason")
+        self.assertEqual(self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "1.2.4")]), set())
+
+    # E14: major bump는 승인 증거 형식 확정 전 무조건 거부
+    def test_e14_major_bump_fail_closed(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
+            + "\nBreaking.\n", encoding="utf-8")
+        _bump_alpha(self.repo, "2.0.0")
+        commit_all(self.repo, "major bump")
+        self.assertIn("E14", self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "2.0.0")]))
+
+    # §D3-3 tag 고유성: 동일 precedence tag 재사용 거부
+    def test_tag_uniqueness(self) -> None:
+        self.assertIn("D3-3", self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "1.2.3")]))
+
+    # §D3-3 신규 skill 최초 release: catalog 행 누락 → I-7
+    def test_new_skill_requires_catalog_rows(self) -> None:
+        pkg = self.repo / "skills/gamma-skill"
+        pkg.mkdir(parents=True)
+        (pkg / "SKILL.md").write_text(
+            "---\nname: gamma-skill\nlicense: LICENSE.txt\nmetadata:\n  version: 0.1.0\n---\n",
+            encoding="utf-8")
+        (pkg / "CHANGELOG.md").write_text(
+            "# Changelog — gamma-skill\n\n## [0.1.0] — 2026-07-28\n\nInitial.\n", encoding="utf-8")
+        (pkg / "LICENSE.txt").write_text(
+            (self.repo / "LICENSE").read_text(encoding="utf-8"), encoding="utf-8")
+        commit_all(self.repo, "add gamma without catalog rows")
+        self.assertIn("I-7", self._preflight([entry("gamma-skill", None, "0.1.0")]))
+
+    # apply-tags: preflight 위반 시 거부, green이면 계획된 tag를 생성
+    def test_apply_tags_refuses_on_findings(self) -> None:
+        _bump_alpha(self.repo, "1.2.4")
+        commit_all(self.repo, "bookkeeping-only bump")
+        plan = parse_plan(plan_json("HEAD", [entry("alpha-skill", "alpha-skill/v1.2.3", "1.2.4")]))
+        with self.assertRaises(RuntimeError):
+            apply_tags(self.repo, plan)
+
+    def test_apply_tags_creates_planned_tags(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
+            + "\nNew body paragraph.\n", encoding="utf-8")
+        _bump_alpha(self.repo, "1.3.0")
+        commit_all(self.repo, "release alpha 1.3.0")
+        plan = parse_plan(plan_json("HEAD", [entry("alpha-skill", "alpha-skill/v1.2.3", "1.3.0")]))
+        self.assertEqual(apply_tags(self.repo, plan), ["alpha-skill/v1.3.0"])
+
+
+class GitFailClosed(unittest.TestCase):
+    # 경계 (b): git/history 조회 실패는 통과가 아니라 finding이다
+    def test_unresolvable_target_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = build_released_repo(Path(tmp) / "repo")
+            plan = parse_plan(plan_json("deadbeef" * 5, []))
+            checks = {f.check for f in preflight(repo, plan)}
+            self.assertIn("GIT", checks)
+
+
+class PlanParsingFailClosed(unittest.TestCase):
+    def test_duplicate_json_key_rejected(self) -> None:
+        text = '{"target_commit": "HEAD", "target_commit": "HEAD", "releases": []}'
+        with self.assertRaises(PlanError):
+            parse_plan(text)
+
+    def test_unknown_key_rejected(self) -> None:
+        with self.assertRaises(PlanError):
+            parse_plan('{"target_commit": "HEAD", "releases": [], "extra": 1}')
+
+    def test_duplicate_skill_rejected(self) -> None:
+        entries = [entry("alpha-skill", None, "0.1.0"), entry("alpha-skill", None, "0.1.0")]
+        with self.assertRaises(PlanError):
+            parse_plan(plan_json("HEAD", entries))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -143,6 +143,18 @@ class ReleaseGateFixtures(unittest.TestCase):
         remote_tags = _git(self.repo, "ls-remote", "--tags", str(bare))
         self.assertIn("refs/tags/alpha-skill/v1.3.0", remote_tags)
 
+    # R1R-F1: 빈 plan은 엄격한 no-op — branch도 tag도 원격으로 밀지 않는다
+    def test_empty_plan_apply_is_strict_noop(self) -> None:
+        bare = add_bare_remote(self.repo)
+        (self.repo / "AHEAD.md").write_text("local-only commit\n", encoding="utf-8")
+        commit_all(self.repo, "local main ahead of remote")
+        before_branches = _git(self.repo, "ls-remote", "--heads", str(bare))
+        before_tags = _git(self.repo, "ls-remote", "--tags", str(bare))
+        plan = parse_plan(plan_json("HEAD", []))
+        self.assertEqual(apply_tags(self.repo, plan), [])
+        self.assertEqual(_git(self.repo, "ls-remote", "--heads", str(bare)), before_branches)
+        self.assertEqual(_git(self.repo, "ls-remote", "--tags", str(bare)), before_tags)
+
     # R1-F1: 발행 실패 시 local ref rollback — 재시도가 막히지 않는다
     def test_apply_tags_rolls_back_on_push_failure(self) -> None:
         (self.repo / "skills/alpha-skill/SKILL.md").write_text(

--- a/tests/test_tag_check.py
+++ b/tests/test_tag_check.py
@@ -1,0 +1,148 @@
+"""M3 continuous tag-check fixtures: E7 ⓒⓔⓕ, I-2, baseline record branch."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from git_fixture import _git, build_released_repo, commit_all  # noqa: E402
+from skillstead_validate.tag_check import RECORD_PATH, run_tag_checks  # noqa: E402
+
+
+def _release_alpha(repo: Path, version: str, prev: str) -> str:
+    """Valid release commit for alpha-skill on main + tag; returns sha."""
+    skill_md = repo / "skills/alpha-skill/SKILL.md"
+    skill_md.write_text(
+        skill_md.read_text(encoding="utf-8").replace(f"  version: {prev}", f"  version: {version}")
+        + "\nBody change.\n", encoding="utf-8")
+    changelog = repo / "skills/alpha-skill/CHANGELOG.md"
+    changelog.write_text(
+        changelog.read_text(encoding="utf-8").replace(
+            f"## [{prev}]", f"## [{version}] — 2026-07-28\n\nEntry.\n\n## [{prev}]", 1),
+        encoding="utf-8")
+    for fname in ("README.md", "README.ko.md"):
+        f = repo / fname
+        f.write_text(f.read_text(encoding="utf-8").replace(f"`{prev}`", f"`{version}`"),
+                     encoding="utf-8")
+    sha = commit_all(repo, f"release alpha {version}")
+    _git(repo, "tag", f"alpha-skill/v{version}", sha)
+    return sha
+
+
+class TagCheckFixtures(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = build_released_repo(Path(self._tmp.name) / "repo")
+        self.addCleanup(self._tmp.cleanup)
+
+    def checks(self) -> set[str]:
+        return {f.check for f in run_tag_checks(self.repo)}
+
+    def test_positive_state_is_green(self) -> None:
+        _release_alpha(self.repo, "1.3.0", "1.2.3")
+        self.assertEqual(run_tag_checks(self.repo), [])
+
+    # E7-ⓒ: off-main tag — 유효한 release여도 main 밖이면 I-8
+    def test_e7c_off_main_tag(self) -> None:
+        _git(self.repo, "checkout", "-q", "-b", "side")
+        _release_alpha(self.repo, "1.3.0", "1.2.3")
+        _git(self.repo, "checkout", "-q", "main")
+        self.assertIn("I-8", self.checks())
+
+    # E7-ⓔ: 같은 version을 선언한 다른 main commit으로 repoint —
+    # I-2·I-5·I-8 전부 통과하면서 I-3-ⓒ만 잡는다
+    def test_e7e_repoint_same_version(self) -> None:
+        (self.repo / "NOTES.md").write_text("root doc only\n", encoding="utf-8")
+        sha2 = commit_all(self.repo, "root docs change, versions unchanged")
+        _git(self.repo, "tag", "-f", "alpha-skill/v1.2.3", sha2)
+        findings = run_tag_checks(self.repo)
+        checks = {f.check for f in findings}
+        self.assertIn("I-3-c", checks)
+        self.assertNotIn("I-2", checks)
+        self.assertNotIn("I-8", checks)
+        self.assertNotIn("I-5", checks)
+
+    # E7-ⓕ: multi-skill release tag의 부분 삭제 → I-5
+    def test_e7f_partial_deletion_of_multi_skill_release(self) -> None:
+        for skill, prev, version in (("alpha-skill", "1.2.3", "1.3.0"),
+                                     ("beta-skill", "0.4.0", "0.5.0")):
+            skill_md = self.repo / f"skills/{skill}/SKILL.md"
+            skill_md.write_text(
+                skill_md.read_text(encoding="utf-8").replace(
+                    f"  version: {prev}", f"  version: {version}") + "\nBody.\n",
+                encoding="utf-8")
+            changelog = self.repo / f"skills/{skill}/CHANGELOG.md"
+            changelog.write_text(
+                changelog.read_text(encoding="utf-8").replace(
+                    f"## [{prev}]", f"## [{version}] — 2026-07-28\n\nEntry.\n\n## [{prev}]", 1),
+                encoding="utf-8")
+            for fname in ("README.md", "README.ko.md"):
+                f = self.repo / fname
+                f.write_text(f.read_text(encoding="utf-8").replace(f"`{prev}`", f"`{version}`"),
+                             encoding="utf-8")
+        sha = commit_all(self.repo, "release alpha 1.3.0 + beta 0.5.0")
+        _git(self.repo, "tag", "alpha-skill/v1.3.0", sha)
+        _git(self.repo, "tag", "beta-skill/v0.5.0", sha)
+        self.assertEqual(run_tag_checks(self.repo), [])
+        _git(self.repo, "tag", "-d", "beta-skill/v0.5.0")
+        self.assertIn("I-5", self.checks())
+
+    # I-2: tag version과 선언 version 불일치
+    def test_i2_tag_version_disagreement(self) -> None:
+        head = _git(self.repo, "rev-parse", "HEAD").strip()
+        _git(self.repo, "tag", "alpha-skill/v1.9.9", head)
+        self.assertIn("I-2", self.checks())
+
+    # tag 문법 위반 (suffix)
+    def test_grammar_violation(self) -> None:
+        head = _git(self.repo, "rev-parse", "HEAD").strip()
+        _git(self.repo, "tag", "alpha-skill/v1.3.0-rc1", head)
+        self.assertIn("D3-3", self.checks())
+
+
+class BaselineRecordBranch(unittest.TestCase):
+    """I-3-ⓒ baseline 분기 — 예외는 version 문자열이 아니라 record의
+    exact ref membership으로만 성립한다."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = build_released_repo(Path(self._tmp.name) / "repo", {"alpha-skill": "1.2.3"})
+        # 기존 tag 없는 상태에서 record + baseline tag를 만들기 위해 초기 tag 제거
+        _git(self.repo, "tag", "-d", "alpha-skill/v1.2.3")
+        record_dir = self.repo / ".skillstead"
+        record_dir.mkdir()
+        (record_dir / "cutover-record.json").write_text(json.dumps({
+            "schema": "skillstead/cutover-record@1",
+            "attempt": 1,
+            "phase": "prepared",
+            "baseline_finalization_sha": "0" * 40,
+            "latest_ref": "refs/tags/alpha-skill/v1.2.3",
+            "baseline_tags": ["refs/tags/alpha-skill/v1.2.3"],
+        }), encoding="utf-8")
+        self.record_sha = commit_all(self.repo, "cutover commit with record")
+        _git(self.repo, "tag", "alpha-skill/v1.2.3", self.record_sha)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_baseline_tag_at_record_commit_is_green(self) -> None:
+        self.assertEqual(run_tag_checks(self.repo), [])
+
+    def test_baseline_tag_repoint_detected(self) -> None:
+        (self.repo / "NOTES.md").write_text("later\n", encoding="utf-8")
+        later = commit_all(self.repo, "later commit")
+        _git(self.repo, "tag", "-f", "alpha-skill/v1.2.3", later)
+        self.assertIn("I-3-c", {f.check for f in run_tag_checks(self.repo)})
+
+    def test_unreadable_record_fails_closed(self) -> None:
+        (self.repo / RECORD_PATH).write_text('{"attempt": 1, "attempt": 2}', encoding="utf-8")
+        commit_all(self.repo, "corrupt record")
+        self.assertIn("RECORD", {f.check for f in run_tag_checks(self.repo)})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tag_check.py
+++ b/tests/test_tag_check.py
@@ -124,6 +124,24 @@ class TagCheckFixtures(unittest.TestCase):
         self.assertIn("D3-3", self.checks())
 
 
+class DetachedHeadHydration(unittest.TestCase):
+    """R0-F5: 검사들은 checkout 상태(detached HEAD 포함)와 무관하게 명시된
+    main ref 기준으로 동작해야 한다 — CI가 PR merge ref나 tag event에서
+    실행되기 때문이다."""
+
+    def test_checks_are_checkout_independent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = build_released_repo(Path(tmp) / "repo")
+            _release_alpha(repo, "1.3.0", "1.2.3")
+            baseline = run_tag_checks(repo, "main")
+            head = _git(repo, "rev-parse", "HEAD~1").strip()
+            _git(repo, "checkout", "-q", "--detach", head)
+            try:
+                self.assertEqual(run_tag_checks(repo, "main"), baseline)
+            finally:
+                _git(repo, "checkout", "-q", "main")
+
+
 class BaselineRecordBranch(unittest.TestCase):
     """I-3-ⓒ baseline 분기 — 예외는 version 문자열이 아니라 record의
     exact ref membership으로만 성립하며, record 자체는 canonical 값과

--- a/tests/test_tag_check.py
+++ b/tests/test_tag_check.py
@@ -204,7 +204,7 @@ class BaselineRecordBranch(unittest.TestCase):
 
 
 class CanonicalConstantsGuard(unittest.TestCase):
-    """record_schema 상수가 DR-819 D8-1의 고정값과 일치하는지 고정한다."""
+    """record_schema 상수가 versioning decision record의 고정값과 일치하는지 고정한다."""
 
     def test_d8_1_values(self) -> None:
         self.assertEqual(record_schema.SCHEMA, "skillstead/cutover-record@1")

--- a/tests/test_tag_check.py
+++ b/tests/test_tag_check.py
@@ -11,8 +11,26 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from unittest.mock import patch  # noqa: E402
+
 from git_fixture import _git, build_released_repo, commit_all  # noqa: E402
+from skillstead_validate import record_schema  # noqa: E402
 from skillstead_validate.tag_check import RECORD_PATH, run_tag_checks  # noqa: E402
+
+FIXTURE_BASELINE = ("refs/tags/alpha-skill/v1.2.3",)
+
+
+def _fixture_record(**overrides) -> dict:
+    record = {
+        "schema": record_schema.SCHEMA,
+        "attempt": 1,
+        "phase": "prepared",
+        "baseline_finalization_sha": "0" * 40,
+        "latest_ref": FIXTURE_BASELINE[-1],
+        "baseline_tags": list(FIXTURE_BASELINE),
+    }
+    record.update(overrides)
+    return record
 
 
 def _release_alpha(repo: Path, version: str, prev: str) -> str:
@@ -108,7 +126,9 @@ class TagCheckFixtures(unittest.TestCase):
 
 class BaselineRecordBranch(unittest.TestCase):
     """I-3-ⓒ baseline 분기 — 예외는 version 문자열이 아니라 record의
-    exact ref membership으로만 성립한다."""
+    exact ref membership으로만 성립하며, record 자체는 canonical 값과
+    일치해야만 신뢰된다(MR1-F5). fixture는 canonical 상수를 fixture 값으로
+    patch하는 test seam을 쓴다."""
 
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
@@ -117,16 +137,13 @@ class BaselineRecordBranch(unittest.TestCase):
         _git(self.repo, "tag", "-d", "alpha-skill/v1.2.3")
         record_dir = self.repo / ".skillstead"
         record_dir.mkdir()
-        (record_dir / "cutover-record.json").write_text(json.dumps({
-            "schema": "skillstead/cutover-record@1",
-            "attempt": 1,
-            "phase": "prepared",
-            "baseline_finalization_sha": "0" * 40,
-            "latest_ref": "refs/tags/alpha-skill/v1.2.3",
-            "baseline_tags": ["refs/tags/alpha-skill/v1.2.3"],
-        }), encoding="utf-8")
+        (record_dir / "cutover-record.json").write_text(
+            json.dumps(_fixture_record()), encoding="utf-8")
         self.record_sha = commit_all(self.repo, "cutover commit with record")
         _git(self.repo, "tag", "alpha-skill/v1.2.3", self.record_sha)
+        patcher = patch.object(record_schema, "BASELINE_TAGS", FIXTURE_BASELINE)
+        patcher.start()
+        self.addCleanup(patcher.stop)
         self.addCleanup(self._tmp.cleanup)
 
     def test_baseline_tag_at_record_commit_is_green(self) -> None:
@@ -142,6 +159,47 @@ class BaselineRecordBranch(unittest.TestCase):
         (self.repo / RECORD_PATH).write_text('{"attempt": 1, "attempt": 2}', encoding="utf-8")
         commit_all(self.repo, "corrupt record")
         self.assertIn("RECORD", {f.check for f in run_tag_checks(self.repo)})
+
+    # MR1-F6: 후속 release tag의 "전체" 삭제 — 기존 tag 앵커로는 release
+    # commit 자체가 사라져 미검출되던 경로를 record 앵커 파생이 잡는다
+    def test_full_deletion_after_record_detected(self) -> None:
+        _release_alpha(self.repo, "1.3.0", "1.2.3")
+        self.assertEqual(run_tag_checks(self.repo), [])
+        _git(self.repo, "tag", "-d", "alpha-skill/v1.3.0")
+        self.assertIn("I-5", {f.check for f in run_tag_checks(self.repo)})
+
+    # MR1-F5: 위조 record가 일반 tag를 baseline으로 선언 → RECORD fail-closed
+    # + 예외 미적용으로 durable relation이 계속 동작한다
+    def test_forged_baseline_list_rejected(self) -> None:
+        (self.repo / RECORD_PATH).write_text(
+            json.dumps(_fixture_record(baseline_tags=["refs/tags/alpha-skill/v9.9.9"])),
+            encoding="utf-8")
+        commit_all(self.repo, "forged record")
+        checks = {f.check for f in run_tag_checks(self.repo)}
+        self.assertIn("RECORD", checks)
+
+    def test_bool_attempt_rejected(self) -> None:
+        (self.repo / RECORD_PATH).write_text(
+            json.dumps(_fixture_record(attempt=True)), encoding="utf-8")
+        commit_all(self.repo, "bool attempt")
+        self.assertIn("RECORD", {f.check for f in run_tag_checks(self.repo)})
+
+
+class CanonicalConstantsGuard(unittest.TestCase):
+    """record_schema 상수가 DR-819 D8-1의 고정값과 일치하는지 고정한다."""
+
+    def test_d8_1_values(self) -> None:
+        self.assertEqual(record_schema.SCHEMA, "skillstead/cutover-record@1")
+        self.assertEqual(record_schema.BASELINE_FINALIZATION_SHA,
+                         "3f92c4b3209c26d0b65129965d3cac63b8a1e9dd")
+        self.assertEqual(record_schema.BASELINE_TAGS, (
+            "refs/tags/docs-claim-check/v0.8.0",
+            "refs/tags/github-release-guide/v0.8.0",
+            "refs/tags/svg-infographic/v0.8.0",
+            "refs/tags/writing-quality-editor/v0.8.0",
+        ))
+        self.assertEqual(record_schema.LATEST_REF, record_schema.BASELINE_TAGS[-1])
+        self.assertEqual(record_schema.PHASES, frozenset({"prepared", "aborted"}))
 
 
 if __name__ == "__main__":

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -243,6 +243,31 @@ class WrapperFixture(unittest.TestCase):
         self.assertFalse(wrong_target.executed)
         self.assertIn("offending", wrong_target.error)
 
+    # MR2R-F5: missing 판정은 draft is False만 발행본으로 센다
+    def test_f5r_missing_counts_only_published(self) -> None:
+        from skillstead_validate.wrapper import _missing_baseline_tags
+        no_draft_field = {"tag_name": FIX_TAGS[0].removeprefix("refs/tags/")}
+        missing = _missing_baseline_tags([no_draft_field])
+        self.assertIn(FIX_TAGS[0].removeprefix("refs/tags/"), missing)
+
+    # MR2R-F6: edit-metadata는 draft=false만 — request가 최종 상태와 같아야 한다
+    def test_f6r_edit_metadata_rejects_draft_true(self) -> None:
+        self.store.append(make_release(FIX_TAGS[0].removeprefix("refs/tags/"),
+                                       "2026-07-28T00:00:00Z", body="wrong\n"))
+        result = self.invoke(request_json(action="edit-metadata", draft=True,
+                                          recovery_mode="metadata-correction",
+                                          owner_authorization="owner-2026-07-28"))
+        self.assertFalse(result.executed)
+        self.assertIn("draft=false", result.error)
+
+    # MR2R-F7: request tag와 무관한 finding도 fail-closed로 mutation을 막는다
+    def test_f7r_any_gate_finding_blocks_mutation(self) -> None:
+        _git(self.repo, "tag", "alpha-skill/v1.9.9-rc1", self.cut_sha)  # 문법 위반 tag
+        result = self.invoke(request_json())
+        self.assertFalse(result.executed)
+        self.assertIn("not green", result.error)
+        self.assertEqual(self.commands, [])
+
     def test_dry_run_makes_no_call(self) -> None:
         result = self.invoke(request_json(), dry_run=True)
         self.assertFalse(result.executed)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,0 +1,211 @@
+"""M5 wrapper fixtures — request contract, allowed matrix (W2), pre-publish
+checks (W3), execution shape (W4), post-verdict + exact postcondition (W5)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from git_fixture import _git, build_unreleased_repo, commit_all  # noqa: E402
+from skillstead_validate import install_pins, record_schema  # noqa: E402
+from skillstead_validate.cutover import P3_MARKER  # noqa: E402
+from skillstead_validate.wrapper import (RequestError, parse_request,  # noqa: E402
+                                         run_wrapper)
+from test_cutover import FIX_PIN, FIX_TAGS, SKILLS, make_install, make_release  # noqa: E402
+
+
+def request_json(**overrides) -> str:
+    req = {
+        "action": "publish",
+        "recovery_mode": "none",
+        "tag": FIX_TAGS[0].removeprefix("refs/tags/"),
+        "title": "alpha-skill 1.2.3",
+        "body": P3_MARKER + "\n\nNotes.\n",
+        "draft": False,
+        "prerelease": False,
+        "latest_intent": True,
+        "owner_authorization": None,
+    }
+    req.update(overrides)
+    return json.dumps(req)
+
+
+class RequestContract(unittest.TestCase):
+    def test_duplicate_key_rejected(self) -> None:
+        with self.assertRaises(RequestError):
+            parse_request('{"action": "publish", "action": "publish"}')
+
+    def test_unknown_key_rejected(self) -> None:
+        with self.assertRaises(RequestError):
+            parse_request(json.dumps({**json.loads(request_json()), "extra": 1}))
+
+    def test_recovery_requires_authorization(self) -> None:
+        with self.assertRaises(RequestError):
+            parse_request(request_json(recovery_mode="metadata-correction"))
+        parse_request(request_json(recovery_mode="metadata-correction",
+                                   action="edit-metadata",
+                                   owner_authorization="owner-2026-07-28"))
+
+    def test_edit_requires_authorization(self) -> None:
+        with self.assertRaises(RequestError):
+            parse_request(request_json(action="edit-metadata"))
+
+
+class WrapperFixture(unittest.TestCase):
+    """tags-ok state fixture (record + baseline tags), constants patched."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = build_unreleased_repo(Path(self._tmp.name) / "repo", dict(SKILLS))
+        (self.repo / "docs").mkdir(exist_ok=True)
+        (self.repo / "docs/INSTALL.md").write_text(make_install("v0.8.0"), encoding="utf-8")
+        self.base_sha = commit_all(self.repo, "legacy install")
+        stack = ExitStack()
+        stack.enter_context(patch.object(record_schema, "BASELINE_FINALIZATION_SHA", self.base_sha))
+        stack.enter_context(patch.object(record_schema, "BASELINE_TAGS", FIX_TAGS))
+        stack.enter_context(patch.object(record_schema, "LATEST_REF", FIX_TAGS[-1]))
+        stack.enter_context(patch.object(install_pins, "BASELINE_PIN", FIX_PIN))
+        self.addCleanup(stack.close)
+        self.addCleanup(self._tmp.cleanup)
+        # cutover commit + all baseline tags -> tags-ok
+        (self.repo / "docs/INSTALL.md").write_text(make_install(FIX_PIN), encoding="utf-8")
+        (self.repo / ".skillstead").mkdir()
+        (self.repo / ".skillstead/cutover-record.json").write_text(json.dumps({
+            "schema": record_schema.SCHEMA, "attempt": 1, "phase": "prepared",
+            "baseline_finalization_sha": self.base_sha,
+            "latest_ref": FIX_TAGS[-1], "baseline_tags": list(FIX_TAGS)}), encoding="utf-8")
+        self.cut_sha = commit_all(self.repo, "cutover commit")
+        for ref in FIX_TAGS:
+            _git(self.repo, "tag", ref.removeprefix("refs/tags/"), self.cut_sha)
+        self.store: list[dict] = []
+        self.latest: str | None = None
+        self.commands: list[list[str]] = []
+
+    def fetch(self):
+        return list(self.store), self.latest
+
+    def execute_and_apply(self, cmd: list[str]) -> None:
+        """Fake gh that mutates the fake Release store like GitHub would."""
+        self.commands.append(cmd)
+        tag = cmd[3]
+        if cmd[1:3] == ["release", "create"] and "--draft" in cmd:
+            self.store.append({"tag_name": tag, "draft": True, "prerelease": False,
+                               "name": cmd[cmd.index("--title") + 1],
+                               "body": cmd[cmd.index("--notes") + 1],
+                               "published_at": None})
+        elif cmd[1:3] == ["release", "create"]:
+            self.store.append(make_release(tag, "2026-07-28T03:00:00Z",
+                                           title=cmd[cmd.index("--title") + 1],
+                                           body=cmd[cmd.index("--notes") + 1]))
+            self.latest = tag
+        elif cmd[1:3] == ["release", "edit"] and "--draft=false" in cmd:
+            for r in self.store:
+                if r["tag_name"] == tag:
+                    r["draft"] = False
+                    r["published_at"] = "2026-07-28T03:00:00Z"
+                    r["body"] = P3_MARKER + "\n\nNotes.\n"
+            self.latest = tag
+
+    def invoke(self, req_text: str, **kwargs):
+        return run_wrapper(self.repo, parse_request(req_text), self.fetch,
+                           now=int(_git(self.repo, "log", "-1", "--format=%ct").strip()) + 10,
+                           execute=self.execute_and_apply, **kwargs)
+
+    # -- W2 allowed matrix ----------------------------------------------
+    def test_publish_missing_baseline_release_in_tags_ok(self) -> None:
+        result = self.invoke(request_json())
+        self.assertIsNone(result.error, result.error)
+        self.assertTrue(result.executed)
+        self.assertEqual(result.post_verdict.verdict, "tags-ok")
+
+    def test_non_baseline_tag_refused_in_tags_ok(self) -> None:
+        result = self.invoke(request_json(tag="alpha-skill/v9.9.9",
+                                       title="alpha-skill 9.9.9"))
+        self.assertFalse(result.executed)
+        self.assertIn("baseline", result.error)
+
+    def test_blocked_in_pending(self) -> None:
+        for ref in FIX_TAGS:
+            _git(self.repo, "tag", "-d", ref.removeprefix("refs/tags/"))
+        result = self.invoke(request_json())
+        self.assertFalse(result.executed)
+        self.assertIn("pending-tags", result.error)
+
+    def test_cv_premature_requires_recovery_mode(self) -> None:
+        # a successor release exists while baseline releases are incomplete
+        self.store.append(make_release("alpha-skill/v1.3.0", "2026-07-28T01:00:00Z"))
+        self.latest = "alpha-skill/v1.3.0"
+        refused = self.invoke(request_json())
+        self.assertFalse(refused.executed)
+        self.assertIn("premature-accept-forward", refused.error)
+        allowed = self.invoke(request_json(recovery_mode="premature-accept-forward",
+                                        owner_authorization="owner-2026-07-28"))
+        self.assertTrue(allowed.executed)
+
+    def test_metadata_correction_only_in_cv_release(self) -> None:
+        # invalid baseline release -> CV-RELEASE
+        self.store.append(make_release(FIX_TAGS[0].removeprefix("refs/tags/"),
+                                       "2026-07-28T00:00:00Z", body="wrong\n"))
+        publish = self.invoke(request_json(tag=FIX_TAGS[1].removeprefix("refs/tags/"),
+                                        title="beta-skill 0.4.0"))
+        self.assertFalse(publish.executed)
+        edit = self.invoke(request_json(action="edit-metadata",
+                                     recovery_mode="metadata-correction",
+                                     owner_authorization="owner-2026-07-28"))
+        self.assertTrue(edit.executed)
+
+    # -- W3 pre-publish checks ------------------------------------------
+    def test_nonexistent_tag_never_created(self) -> None:
+        _git(self.repo, "tag", "-d", FIX_TAGS[0].removeprefix("refs/tags/"))
+        # state becomes CV-PARTIAL-TAGS -> blocked by matrix even earlier;
+        # use recovery-free check via a tags-ok state with a bogus request tag
+        result = self.invoke(request_json(tag="ghost-skill/v1.0.0", title="ghost-skill 1.0.0"))
+        self.assertFalse(result.executed)
+
+    def test_p3_marker_enforced_before_publish(self) -> None:
+        result = self.invoke(request_json(body="not the marker\n"))
+        self.assertFalse(result.executed)
+        self.assertIn("P3", result.error)
+
+    def test_publish_requires_latest_intent(self) -> None:
+        result = self.invoke(request_json(latest_intent=False))
+        self.assertFalse(result.executed)
+        self.assertIn("latest_intent", result.error)
+
+    # -- W4/W5 ----------------------------------------------------------
+    def test_draft_then_publish_uses_edit(self) -> None:
+        draft = self.invoke(request_json(action="create-draft", draft=True))
+        self.assertTrue(draft.executed)
+        self.assertIn("--draft", draft.commands[0])
+        publish = self.invoke(request_json())
+        self.assertTrue(publish.executed)
+        self.assertIn("--draft=false", publish.commands[0])
+        self.assertIn("--latest", publish.commands[0])
+
+    def test_postcondition_latest_exact(self) -> None:
+        def bad_execute(cmd):
+            self.execute_and_apply(cmd)
+            self.latest = "somebody-else/v1.0.0"  # postcondition must fail
+        result = run_wrapper(self.repo, parse_request(request_json()), self.fetch,
+                             now=int(_git(self.repo, "log", "-1", "--format=%ct").strip()) + 10,
+                             execute=bad_execute)
+        self.assertTrue(result.executed)
+        self.assertIn("postcondition", result.error)
+
+    def test_dry_run_makes_no_call(self) -> None:
+        result = self.invoke(request_json(), dry_run=True)
+        self.assertFalse(result.executed)
+        self.assertIsNone(result.error)
+        self.assertEqual(self.commands, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -111,7 +111,8 @@ class WrapperFixture(unittest.TestCase):
                 if r["tag_name"] == tag:
                     r["draft"] = False
                     r["published_at"] = "2026-07-28T03:00:00Z"
-                    r["body"] = P3_MARKER + "\n\nNotes.\n"
+                    r["name"] = cmd[cmd.index("--title") + 1]
+                    r["body"] = cmd[cmd.index("--notes") + 1]
             self.latest = tag
 
     def invoke(self, req_text: str, **kwargs):
@@ -199,6 +200,48 @@ class WrapperFixture(unittest.TestCase):
                              execute=bad_execute)
         self.assertTrue(result.executed)
         self.assertIn("postcondition", result.error)
+
+    # MR2-F6: 검증한 request가 명령에 그대로 실린다
+    def test_f6_commands_carry_verified_metadata(self) -> None:
+        publish = self.invoke(request_json())
+        self.assertIn("--verify-tag", publish.commands[0])
+        draft = self.invoke(request_json(action="create-draft", draft=True,
+                                         tag=FIX_TAGS[1].removeprefix("refs/tags/"),
+                                         title="beta-skill 0.4.0"))
+        self.assertIn("--verify-tag", draft.commands[0])
+        from_draft = self.invoke(request_json(tag=FIX_TAGS[1].removeprefix("refs/tags/"),
+                                              title="beta-skill 0.4.0"))
+        cmd = from_draft.commands[0]
+        self.assertIn("--draft=false", cmd)
+        self.assertIn("--prerelease=false", cmd)
+        self.assertIn("--notes", cmd)
+
+    # MR2-F7: complete여도 대상 tag가 normal gate를 통과해야 mutation한다
+    def test_f7_complete_rechecks_target_tag(self) -> None:
+        for i, ref in enumerate(FIX_TAGS):
+            self.store.append(make_release(ref.removeprefix("refs/tags/"),
+                                           f"2026-07-28T00:0{i}:00Z"))
+        self.latest = FIX_TAGS[-1].removeprefix("refs/tags/")
+        _git(self.repo, "tag", "alpha-skill/v9.9.9", self.cut_sha)  # ghost: 선언 version과 불일치
+        result = self.invoke(request_json(tag="alpha-skill/v9.9.9",
+                                          title="alpha-skill 9.9.9"))
+        self.assertFalse(result.executed)
+        self.assertIn("normal tag gate", result.error)
+        self.assertEqual(self.commands, [])
+
+    # MR2-F8: CV-RELEASE 정정은 offending Release에만 결속된다
+    def test_f8_correction_bound_to_offending_release(self) -> None:
+        self.store.append(make_release(FIX_TAGS[0].removeprefix("refs/tags/"),
+                                       "2026-07-28T00:00:00Z", body="wrong\n"))
+        self.store.append(make_release(FIX_TAGS[1].removeprefix("refs/tags/"),
+                                       "2026-07-28T00:01:00Z"))
+        wrong_target = self.invoke(request_json(action="edit-metadata",
+                                                tag=FIX_TAGS[1].removeprefix("refs/tags/"),
+                                                title="beta-skill 0.4.0",
+                                                recovery_mode="metadata-correction",
+                                                owner_authorization="owner-2026-07-28"))
+        self.assertFalse(wrong_target.executed)
+        self.assertIn("offending", wrong_target.error)
 
     def test_dry_run_makes_no_call(self) -> None:
         result = self.invoke(request_json(), dry_run=True)

--- a/tools/run_skills_ref.py
+++ b/tools/run_skills_ref.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Pinned run of the agent-skills spec reference validator (`skills-ref`).
+
+Procurement facts (the full policy, including replacement conditions, lives in
+docs/VALIDATION.md):
+
+* source: https://github.com/agentskills/agentskills — ``skills-ref/`` subdirectory
+* pin: exact commit SHA below; upgrades are deliberate, reviewed pin changes
+* upstream license: MIT; upstream describes itself as a demonstration-only
+  reference implementation, so it is used strictly as a supplementary check
+* scope measured: frontmatter required fields and name↔folder agreement only —
+  everything beyond that is covered by ``skillstead_validate``
+
+Fail-closed: any procurement or execution failure exits non-zero.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+PIN_SHA = "38a2ff82958afee88dadf4831509e6f7e9d8ef4e"
+SPEC = f"git+https://github.com/agentskills/agentskills@{PIN_SHA}#subdirectory=skills-ref"
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    skills = sorted(p for p in (repo_root / "skills").iterdir() if p.is_dir())
+    if not skills:
+        print("run_skills_ref: no packages found under skills/", file=sys.stderr)
+        return 1
+    # `skills-ref validate` accepts exactly one SKILL_PATH per invocation.
+    failures = 0
+    for skill in skills:
+        cmd = ["pipx", "run", "--spec", SPEC, "skills-ref", "validate", str(skill)]
+        try:
+            proc = subprocess.run(cmd, check=False)
+        except FileNotFoundError:
+            print("run_skills_ref: pipx not found (procurement failure, fail-closed)", file=sys.stderr)
+            return 1
+        if proc.returncode != 0:
+            failures += 1
+    print(f"run_skills_ref: {len(skills)} package(s), {failures} failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run_skills_ref.py
+++ b/tools/run_skills_ref.py
@@ -9,7 +9,7 @@ docs/VALIDATION.md):
 * upstream license: Apache-2.0; upstream describes itself as a
   demonstration-only reference implementation, so it is used strictly as a
   supplementary check
-* scope measured: frontmatter required fields and name↔folder agreement only —
+* checked scope: frontmatter required fields and name↔folder agreement only —
   everything beyond that is covered by ``skillstead_validate``
 
 Fail-closed: any procurement or execution failure exits non-zero.

--- a/tools/run_skills_ref.py
+++ b/tools/run_skills_ref.py
@@ -6,8 +6,9 @@ docs/VALIDATION.md):
 
 * source: https://github.com/agentskills/agentskills — ``skills-ref/`` subdirectory
 * pin: exact commit SHA below; upgrades are deliberate, reviewed pin changes
-* upstream license: MIT; upstream describes itself as a demonstration-only
-  reference implementation, so it is used strictly as a supplementary check
+* upstream license: Apache-2.0; upstream describes itself as a
+  demonstration-only reference implementation, so it is used strictly as a
+  supplementary check
 * scope measured: frontmatter required fields and name↔folder agreement only —
   everything beyond that is covered by ``skillstead_validate``
 

--- a/tools/skillstead_validate/__init__.py
+++ b/tools/skillstead_validate/__init__.py
@@ -1,0 +1,7 @@
+"""Skillstead validation toolchain (C3).
+
+Python 3.11+ standard library only. All judgment logic fails closed: anything
+this package cannot parse or observe is reported as a finding, never skipped.
+"""
+
+SEMVER_RE = r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"

--- a/tools/skillstead_validate/__main__.py
+++ b/tools/skillstead_validate/__main__.py
@@ -37,6 +37,8 @@ def main(argv: list[str] | None = None) -> int:
         p = sub.add_parser(name, help=f"release gate {name} (M2)")
         p.add_argument("--plan", type=Path, required=True)
         p.add_argument("--repo-root", type=Path, default=Path.cwd())
+        p.add_argument("--main-ref", default="main")
+        p.add_argument("--remote", default="origin")
     tags = sub.add_parser("tags", help="continuous tag checks (M3)")
     tags.add_argument("--main-ref", default="main")
     tags.add_argument("--repo-root", type=Path, default=Path.cwd())
@@ -118,20 +120,26 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     root = args.repo_root.resolve()
     if args.mode == "preflight":
-        findings = preflight(root, plan)
+        findings = preflight(root, plan, args.main_ref)
         for f in findings:
             print(f, file=sys.stderr)
         print(f"skillstead_validate preflight: {len(findings)} finding(s)")
         return 1 if findings else 0
     if args.mode == "apply-tags":
         try:
-            created = apply_tags(root, plan)
+            created = apply_tags(root, plan, args.main_ref, args.remote)
         except RuntimeError as e:
             print(str(e), file=sys.stderr)
             return 1
         for name in created:
-            print(f"created {name}")
-        return 0
+            print(f"published {name}")
+        # Post-publication M3 pass: the refs now exist, so the continuous
+        # tag checks must be green before the release proceeds to M5.
+        post = run_tag_checks(root, args.main_ref)
+        for f in post:
+            print(f, file=sys.stderr)
+        print(f"post-publication tag checks: {len(post)} finding(s)")
+        return 1 if post else 0
     return 2
 
 

--- a/tools/skillstead_validate/__main__.py
+++ b/tools/skillstead_validate/__main__.py
@@ -25,6 +25,7 @@ from .release_gate import apply_tags, preflight
 from .release_plan import PlanError, parse_plan
 from .tag_check import run_tag_checks
 from .transport import TransportError, fetch_latest, fetch_releases
+from .wrapper import RequestError, parse_request, run_wrapper
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -46,7 +47,33 @@ def main(argv: list[str] | None = None) -> int:
     cut.add_argument("--latest-file", type=Path)
     cut.add_argument("--live", action="store_true")
     cut.add_argument("--repo-slug")
+    rel = sub.add_parser("release", help="canonical release wrapper (M5) — the only supported Release path")
+    rel.add_argument("--request", type=Path, required=True)
+    rel.add_argument("--repo-root", type=Path, default=Path.cwd())
+    rel.add_argument("--main-ref", default="main")
+    rel.add_argument("--repo-slug", required=True)
+    rel.add_argument("--dry-run", action="store_true")
     args = parser.parse_args(argv)
+
+    if args.mode == "release":
+        try:
+            request = parse_request(args.request.read_text(encoding="utf-8"))
+        except (OSError, RequestError) as e:
+            print(f"request rejected (fail-closed): {e}", file=sys.stderr)
+            return 1
+
+        def fetch():
+            return fetch_releases(args.repo_slug), fetch_latest(args.repo_slug)
+        try:
+            result = run_wrapper(args.repo_root.resolve(), request, fetch,
+                                 main_ref=args.main_ref, repo_slug=args.repo_slug,
+                                 dry_run=args.dry_run)
+        except TransportError as e:
+            print(f"red CV-DOMAIN candidate=- predicate=transport — {e}", file=sys.stderr)
+            return 1
+        if result.error:
+            return 1
+        return 0
 
     if args.mode == "cutover":
         try:

--- a/tools/skillstead_validate/__main__.py
+++ b/tools/skillstead_validate/__main__.py
@@ -5,9 +5,10 @@ Usage:
     python3 -m skillstead_validate preflight --plan PLAN.json [--repo-root PATH]
     python3 -m skillstead_validate apply-tags --plan PLAN.json [--repo-root PATH]
     python3 -m skillstead_validate tags [--main-ref REF] [--repo-root PATH]
+    python3 -m skillstead_validate cutover (--releases-file F --latest-file F | --live --repo-slug OWNER/REPO) [...]
 
-Exit status: 0 when no findings, 1 when findings exist, 2 on usage error.
-The cutover evaluator is added by a later checkpoint of FEAT-20260728-001.
+Exit status: 0 when no findings (cutover: non-red verdict), 1 otherwise,
+2 on usage error.
 """
 
 from __future__ import annotations
@@ -16,10 +17,14 @@ import argparse
 import sys
 from pathlib import Path
 
+import json
+
+from .cutover import run_cutover
 from .package_check import run_repo_validation
 from .release_gate import apply_tags, preflight
 from .release_plan import PlanError, parse_plan
 from .tag_check import run_tag_checks
+from .transport import TransportError, fetch_latest, fetch_releases
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -34,7 +39,36 @@ def main(argv: list[str] | None = None) -> int:
     tags = sub.add_parser("tags", help="continuous tag checks (M3)")
     tags.add_argument("--main-ref", default="main")
     tags.add_argument("--repo-root", type=Path, default=Path.cwd())
+    cut = sub.add_parser("cutover", help="cutover verdict evaluator (M4)")
+    cut.add_argument("--repo-root", type=Path, default=Path.cwd())
+    cut.add_argument("--main-ref", default="main")
+    cut.add_argument("--releases-file", type=Path)
+    cut.add_argument("--latest-file", type=Path)
+    cut.add_argument("--live", action="store_true")
+    cut.add_argument("--repo-slug")
     args = parser.parse_args(argv)
+
+    if args.mode == "cutover":
+        try:
+            if args.live:
+                if not args.repo_slug:
+                    print("cutover --live requires --repo-slug", file=sys.stderr)
+                    return 2
+                releases = fetch_releases(args.repo_slug)
+                latest = fetch_latest(args.repo_slug)
+            elif args.releases_file and args.latest_file:
+                releases = json.loads(args.releases_file.read_text(encoding="utf-8"))
+                latest_raw = json.loads(args.latest_file.read_text(encoding="utf-8"))
+                latest = latest_raw.get("tag_name") if isinstance(latest_raw, dict) else None
+            else:
+                print("cutover requires --live or both --releases-file/--latest-file", file=sys.stderr)
+                return 2
+        except (TransportError, OSError, json.JSONDecodeError) as e:
+            print(f"red CV-DOMAIN candidate=- predicate=transport — {e}", file=sys.stderr)
+            return 1
+        verdict = run_cutover(args.repo_root.resolve(), args.main_ref, releases, latest)
+        print(f"skillstead_validate cutover: {verdict}")
+        return 1 if verdict.verdict == "red" else 0
 
     if args.mode == "tags":
         findings = run_tag_checks(args.repo_root.resolve(), args.main_ref)

--- a/tools/skillstead_validate/__main__.py
+++ b/tools/skillstead_validate/__main__.py
@@ -4,10 +4,10 @@ Usage:
     python3 -m skillstead_validate repo [--repo-root PATH]
     python3 -m skillstead_validate preflight --plan PLAN.json [--repo-root PATH]
     python3 -m skillstead_validate apply-tags --plan PLAN.json [--repo-root PATH]
+    python3 -m skillstead_validate tags [--main-ref REF] [--repo-root PATH]
 
 Exit status: 0 when no findings, 1 when findings exist, 2 on usage error.
-Continuous tag checks and the cutover evaluator are added by later
-checkpoints of FEAT-20260728-001.
+The cutover evaluator is added by a later checkpoint of FEAT-20260728-001.
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ from pathlib import Path
 from .package_check import run_repo_validation
 from .release_gate import apply_tags, preflight
 from .release_plan import PlanError, parse_plan
+from .tag_check import run_tag_checks
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -30,7 +31,17 @@ def main(argv: list[str] | None = None) -> int:
         p = sub.add_parser(name, help=f"release gate {name} (M2)")
         p.add_argument("--plan", type=Path, required=True)
         p.add_argument("--repo-root", type=Path, default=Path.cwd())
+    tags = sub.add_parser("tags", help="continuous tag checks (M3)")
+    tags.add_argument("--main-ref", default="main")
+    tags.add_argument("--repo-root", type=Path, default=Path.cwd())
     args = parser.parse_args(argv)
+
+    if args.mode == "tags":
+        findings = run_tag_checks(args.repo_root.resolve(), args.main_ref)
+        for f in findings:
+            print(f, file=sys.stderr)
+        print(f"skillstead_validate tags: {len(findings)} finding(s)")
+        return 1 if findings else 0
 
     if args.mode == "repo":
         findings = run_repo_validation(args.repo_root.resolve())

--- a/tools/skillstead_validate/__main__.py
+++ b/tools/skillstead_validate/__main__.py
@@ -2,10 +2,12 @@
 
 Usage:
     python3 -m skillstead_validate repo [--repo-root PATH]
+    python3 -m skillstead_validate preflight --plan PLAN.json [--repo-root PATH]
+    python3 -m skillstead_validate apply-tags --plan PLAN.json [--repo-root PATH]
 
 Exit status: 0 when no findings, 1 when findings exist, 2 on usage error.
-Modes for release preflight, continuous tag checks, and the cutover evaluator
-are added by later checkpoints of FEAT-20260728-001.
+Continuous tag checks and the cutover evaluator are added by later
+checkpoints of FEAT-20260728-001.
 """
 
 from __future__ import annotations
@@ -15,6 +17,8 @@ import sys
 from pathlib import Path
 
 from .package_check import run_repo_validation
+from .release_gate import apply_tags, preflight
+from .release_plan import PlanError, parse_plan
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -22,6 +26,10 @@ def main(argv: list[str] | None = None) -> int:
     sub = parser.add_subparsers(dest="mode", required=True)
     repo = sub.add_parser("repo", help="package-structure + catalog validation (M1)")
     repo.add_argument("--repo-root", type=Path, default=Path.cwd())
+    for name in ("preflight", "apply-tags"):
+        p = sub.add_parser(name, help=f"release gate {name} (M2)")
+        p.add_argument("--plan", type=Path, required=True)
+        p.add_argument("--repo-root", type=Path, default=Path.cwd())
     args = parser.parse_args(argv)
 
     if args.mode == "repo":
@@ -30,6 +38,28 @@ def main(argv: list[str] | None = None) -> int:
             print(f, file=sys.stderr)
         print(f"skillstead_validate repo: {len(findings)} finding(s)")
         return 1 if findings else 0
+
+    try:
+        plan = parse_plan(args.plan.read_text(encoding="utf-8"))
+    except (OSError, PlanError) as e:
+        print(f"plan rejected (fail-closed): {e}", file=sys.stderr)
+        return 1
+    root = args.repo_root.resolve()
+    if args.mode == "preflight":
+        findings = preflight(root, plan)
+        for f in findings:
+            print(f, file=sys.stderr)
+        print(f"skillstead_validate preflight: {len(findings)} finding(s)")
+        return 1 if findings else 0
+    if args.mode == "apply-tags":
+        try:
+            created = apply_tags(root, plan)
+        except RuntimeError as e:
+            print(str(e), file=sys.stderr)
+            return 1
+        for name in created:
+            print(f"created {name}")
+        return 0
     return 2
 
 

--- a/tools/skillstead_validate/__main__.py
+++ b/tools/skillstead_validate/__main__.py
@@ -1,0 +1,37 @@
+"""CLI entrypoint.
+
+Usage:
+    python3 -m skillstead_validate repo [--repo-root PATH]
+
+Exit status: 0 when no findings, 1 when findings exist, 2 on usage error.
+Modes for release preflight, continuous tag checks, and the cutover evaluator
+are added by later checkpoints of FEAT-20260728-001.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .package_check import run_repo_validation
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="skillstead_validate")
+    sub = parser.add_subparsers(dest="mode", required=True)
+    repo = sub.add_parser("repo", help="package-structure + catalog validation (M1)")
+    repo.add_argument("--repo-root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+
+    if args.mode == "repo":
+        findings = run_repo_validation(args.repo_root.resolve())
+        for f in findings:
+            print(f, file=sys.stderr)
+        print(f"skillstead_validate repo: {len(findings)} finding(s)")
+        return 1 if findings else 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/skillstead_validate/bump.py
+++ b/tools/skillstead_validate/bump.py
@@ -1,4 +1,4 @@
-"""Bump-step mechanics (DR-818 §D2-1 rules 2–4, 6; §D2-2 boundary).
+"""Bump-step mechanics (path-default rules; see docs/VERSIONING.md).
 
 The machine computes the path-default step and validates the proposed
 version delta. Rule 1 (observable-behavior judgment) belongs to a human; an

--- a/tools/skillstead_validate/bump.py
+++ b/tools/skillstead_validate/bump.py
@@ -1,0 +1,42 @@
+"""Bump-step mechanics (DR-818 §D2-1 rules 2–4, 6; §D2-2 boundary).
+
+The machine computes the path-default step and validates the proposed
+version delta. Rule 1 (observable-behavior judgment) belongs to a human; an
+adjustment away from the path default must carry a reason line in the
+CHANGELOG entry (see ADJUSTMENT_MARKER in release_gate).
+"""
+
+from __future__ import annotations
+
+import re
+
+_FIXTURES = re.compile(r"^skills/[^/]+/scripts/(.+/)?fixtures/")
+_MINOR = re.compile(r"^skills/[^/]+/(SKILL\.md$|references/|agents/|scripts/)")
+
+
+def classify_path(path: str) -> str:
+    """Path-default step for one changed payload path: 'minor' or 'patch'."""
+    if _FIXTURES.match(path):
+        return "patch"
+    if _MINOR.match(path):
+        return "minor"
+    return "patch"
+
+
+def default_step(changed_paths: list[str]) -> str:
+    """Highest step wins; major is never automatic (rule 6)."""
+    return "minor" if any(classify_path(p) == "minor" for p in changed_paths) else "patch"
+
+
+def step_of(prev: str, proposed: str) -> str | None:
+    """Step implied by the version delta, or None when the delta is not a
+    single-step bump (skips and mixed increments are invalid)."""
+    pa, pi, pp = (int(x) for x in prev.split("."))
+    na, ni, np_ = (int(x) for x in proposed.split("."))
+    if (na, ni, np_) == (pa, pi, pp + 1):
+        return "patch"
+    if (na, ni, np_) == (pa, pi + 1, 0):
+        return "minor"
+    if (na, ni, np_) == (pa + 1, 0, 0):
+        return "major"
+    return None

--- a/tools/skillstead_validate/catalog.py
+++ b/tools/skillstead_validate/catalog.py
@@ -1,0 +1,53 @@
+"""Root README catalog table reader (I-7).
+
+Both ``README.md`` and ``README.ko.md`` carry a catalog table whose header and
+Version column position are fixed by the baseline. The reader locates the table
+by its exact header row and fails closed if the header or any row cannot be
+read.
+"""
+
+from __future__ import annotations
+
+import re
+
+EN_HEADER = "| Skill | Best for | Version | Runtime support | Maturity |"
+KO_HEADER = "| 스킬 | 이런 작업에 적합 | 버전 | 지원 실행 환경 | 성숙도 |"
+
+_ROW_SKILL = re.compile(r"^\|\s*\[`([^`]+)`\]\(\./skills/([^)]+)\)\s*\|")
+_VERSION_CELL = re.compile(r"^`([^`]*)`$")
+
+
+class CatalogError(ValueError):
+    """Raised when the catalog table cannot be read under the fixed shape."""
+
+
+def catalog_versions(text: str, header: str) -> dict[str, str]:
+    """Return {skill name: version} from the table under ``header``."""
+    lines = text.splitlines()
+    try:
+        start = lines.index(header)
+    except ValueError:
+        raise CatalogError(f"catalog header not found: {header!r}") from None
+
+    versions: dict[str, str] = {}
+    for line in lines[start + 2:]:  # skip header + separator row
+        if not line.startswith("|"):
+            break
+        m = _ROW_SKILL.match(line)
+        if not m:
+            raise CatalogError(f"unparseable catalog row: {line!r}")
+        name, folder = m.group(1), m.group(2)
+        if name != folder:
+            raise CatalogError(f"catalog row name {name!r} != folder {folder!r}")
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) != 5:
+            raise CatalogError(f"catalog row does not have 5 columns: {line!r}")
+        v = _VERSION_CELL.match(cells[2])
+        if not v:
+            raise CatalogError(f"version cell not backtick-wrapped: {cells[2]!r}")
+        if name in versions:
+            raise CatalogError(f"duplicate catalog row for {name!r}")
+        versions[name] = v.group(1)
+    if not versions:
+        raise CatalogError("catalog table has no rows")
+    return versions

--- a/tools/skillstead_validate/changelog.py
+++ b/tools/skillstead_validate/changelog.py
@@ -1,0 +1,32 @@
+"""Per-skill CHANGELOG parser (grammar fixed by docs/VERSIONING.md).
+
+Released entries use the heading form ``## [X.Y.Z] — YYYY-MM-DD`` (em dash),
+newest first. An optional ``## [Unreleased]`` section may sit above them. The
+topmost released heading is the parser contract consumed by I-1.
+"""
+
+from __future__ import annotations
+
+import re
+
+_RELEASED = re.compile(
+    r"^## \[(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\] — \d{4}-\d{2}-\d{2}\s*$"
+)
+_UNRELEASED = re.compile(r"^## \[Unreleased\]\s*$")
+_ANY_H2 = re.compile(r"^## ")
+
+
+class ChangelogError(ValueError):
+    """Raised when no released heading can be read under the fixed grammar."""
+
+
+def topmost_released_version(text: str) -> str:
+    for line in text.splitlines():
+        if _UNRELEASED.match(line):
+            continue
+        m = _RELEASED.match(line)
+        if m:
+            return f"{m.group(1)}.{m.group(2)}.{m.group(3)}"
+        if _ANY_H2.match(line):
+            raise ChangelogError(f"first '##' heading is not a released entry: {line!r}")
+    raise ChangelogError("no released heading found")

--- a/tools/skillstead_validate/cutover.py
+++ b/tools/skillstead_validate/cutover.py
@@ -32,6 +32,10 @@ _NAMESPACED_TAG = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+)\.(\d+)\.(\d+)$")
 _SHA40 = re.compile(r"^[0-9a-f]{40}$")
 
 
+class DomainError(ValueError):
+    """Release observation cannot be normalized — maps to CV-DOMAIN."""
+
+
 @dataclass(frozen=True)
 class Verdict:
     verdict: str                 # not-started|aborted|pending-tags|tags-ok|complete|red
@@ -149,12 +153,21 @@ def build_observation(repo: Path, main_ref: str, releases_raw: list[dict],
         except GitError:
             continue
 
+    # Domain normalization is exact and fail-closed (MR2-F5): a release
+    # object whose draft/prerelease/tag_name/published_at cannot be typed is
+    # not "probably published" — it is an incomplete observation.
     domain = []
     for r in releases_raw:
-        if not isinstance(r, dict) or r.get("draft") is True:
-            continue
+        if not isinstance(r, dict):
+            raise DomainError("release object is not a JSON object")
+        if not isinstance(r.get("draft"), bool) or not isinstance(r.get("prerelease"), bool):
+            raise DomainError(f"release {r.get('tag_name')!r}: draft/prerelease must be booleans")
         tag = r.get("tag_name")
-        if isinstance(tag, str) and _NAMESPACED_TAG.match(tag):
+        if not isinstance(tag, str):
+            raise DomainError("release object has no string tag_name")
+        if not (r.get("published_at") is None or isinstance(r.get("published_at"), str)):
+            raise DomainError(f"release {tag!r}: published_at must be a string or null")
+        if r["draft"] is False and _NAMESPACED_TAG.match(tag):
             domain.append(r)
 
     history_records: list[tuple[str, dict | str]] = []
@@ -213,6 +226,13 @@ def _check_attempts(obs: Observation, candidate: str) -> Verdict | None:
             inv = install_pins.parse_pins(parent_install)
             if install_pins.classify(inv, lambda _t: False) != "PIN-LEGACY":
                 return _red("CV-ATTEMPT", candidate, "T3", f"attempt increased at {commit[:12]} while parent pins were not PIN-LEGACY")
+        # T3's third condition — the previous attempt created NO refs — is
+        # not provable from any current git observation (deleted tags leave
+        # no trace). Owner decision 2026-07-28 (MR2-F3): retries fail closed
+        # and are released only through the cutover ⓪ owner procedure
+        # (U13-c, owned by C5), which verifies ref absence directly.
+        return _red("CV-ATTEMPT", candidate, "T3-unprovable",
+                    f"attempt increase at {commit[:12]} cannot be machine-verified (previous attempt's ref absence is unobservable); owner gate required — see cutover step ⓪")
     return None
 
 
@@ -241,6 +261,15 @@ def _prepared_identity(obs: Observation, record: dict, candidate: str) -> Verdic
         return _red("CV-OBSERVE", candidate, "Q-SAME", f"diff unobservable (fail-closed): {e}")
     if record_schema.RECORD_PATH not in changed or INSTALL_PATH not in changed:
         return _red("CV-SAME", candidate, "Q-SAME", "record transition and pin switch are not in the same commit")
+    # Q-SAME requires the ACTUAL pin switch, not any INSTALL edit (MR2-F1):
+    # the cutover commit must take the inventory from PIN-LEGACY to exactly
+    # PIN-BASELINE.
+    def _class_at(commit: str) -> str:
+        text = file_at(obs.repo, commit, INSTALL_PATH) or ""
+        return install_pins.classify(install_pins.parse_pins(text), lambda _t: False)
+    if _class_at(parent) != "PIN-LEGACY" or _class_at(expected) != "PIN-BASELINE":
+        return _red("CV-SAME", candidate, "Q-SAME",
+                    f"cutover commit does not switch pins PIN-LEGACY -> PIN-BASELINE (parent={_class_at(parent)}, target={_class_at(expected)})")
     try:
         git(obs.repo, "cat-file", "-e", f"{record_schema.BASELINE_FINALIZATION_SHA}^{{commit}}")
         git(obs.repo, "merge-base", "--is-ancestor", record_schema.BASELINE_FINALIZATION_SHA, obs.main_tip)
@@ -360,10 +389,17 @@ def evaluate(obs: Observation) -> Verdict:
     for ref, target in obs.baseline_targets.items():
         if target != expected:
             return _red("CV-TARGET", candidate, "baseline-target", f"{ref} -> {target[:12]} != expected {expected[:12]}")
-    tip_record = obs.record_text
-    intro_record = file_at(obs.repo, expected, record_schema.RECORD_PATH)
-    if tip_record != intro_record:
-        return _red("CV-FROZEN", candidate, "record-freeze", "record changed after baseline refs came into existence")
+    # Freeze spans the whole attempt (MR2-F2): with refs in existence, the
+    # record must exist unchanged at EVERY first-parent commit from its
+    # introduction to the tip — a delete-and-restore inside the span is a
+    # freeze violation, not a wash.
+    intro_idx = obs.commits.index(expected)
+    for commit in obs.commits[:intro_idx + 1]:
+        span_record = file_at(obs.repo, commit, record_schema.RECORD_PATH)
+        if span_record is None:
+            return _red("CV-FROZEN", candidate, "record-freeze", f"record absent at {commit[:12]} inside the frozen span")
+        if span_record != obs.record_text:
+            return _red("CV-FROZEN", candidate, "record-freeze", f"record differs at {commit[:12]} inside the frozen span")
     baseline_releases = [r for r in obs.domain if f"refs/tags/{r.get('tag_name')}" in baseline_refs]
     successors = [r for r in obs.domain if f"refs/tags/{r.get('tag_name')}" not in baseline_refs]
     for r in obs.domain:
@@ -409,6 +445,8 @@ def run_cutover(repo: Path, main_ref: str, releases_raw: list[dict],
                 latest_tag: str | None, now: int | None = None) -> Verdict:
     try:
         obs = build_observation(repo, main_ref, releases_raw, latest_tag, now)
+    except DomainError as e:
+        return _red("CV-DOMAIN", None, "normalization", f"release domain unnormalizable (fail-closed): {e}")
     except GitError as e:
         return _red("CV-OBSERVE", None, "step-0", f"observation failed (fail-closed): {e}")
     return evaluate(obs)

--- a/tools/skillstead_validate/cutover.py
+++ b/tools/skillstead_validate/cutover.py
@@ -1,4 +1,4 @@
-"""M4 cutover verdict — ordered evaluator (DR-819 D8-1 · D8-2, U13-b).
+"""M4 cutover verdict — ordered evaluator over the cutover record.
 
 Structure fixed by the DR: Step 0 builds an immutable observation snapshot;
 a single sequential evaluator consumes Steps 1→6B; every step assumes only
@@ -23,7 +23,7 @@ from . import install_pins, record_schema
 from .gitio import GitError, file_at, git, peeled
 from .tag_check import run_tag_checks
 
-# P3 exact marker — fixed by DR-819 D8-2 (English canonical, byte-exact).
+# P3 exact marker — fixed by the versioning decision record (English canonical, byte-exact).
 P3_MARKER = ("> **Latest** refers to the most recently published individual "
              "skill release, not a catalog version.")
 
@@ -236,7 +236,7 @@ def _check_attempts(obs: Observation, candidate: str) -> Verdict | None:
         # not provable from any current git observation (deleted tags leave
         # no trace). Owner decision 2026-07-28 (MR2-F3): retries fail closed
         # and are released only through the cutover ⓪ owner procedure
-        # (U13-c, owned by C5), which verifies ref absence directly.
+        # (owned by the cutover execution work), which verifies ref absence directly.
         return _red("CV-ATTEMPT", candidate, "T3-unprovable",
                     f"attempt increase at {commit[:12]} cannot be machine-verified (previous attempt's ref absence is unobservable); owner gate required — see cutover step ⓪")
     return None

--- a/tools/skillstead_validate/cutover.py
+++ b/tools/skillstead_validate/cutover.py
@@ -1,0 +1,414 @@
+"""M4 cutover verdict — ordered evaluator (DR-819 D8-1 · D8-2, U13-b).
+
+Structure fixed by the DR: Step 0 builds an immutable observation snapshot;
+a single sequential evaluator consumes Steps 1→6B; every step assumes only
+what prior steps established; states are positive predicates; failures stop
+in place with an error code plus ``candidate=``/``predicate=`` detail. The
+verdict is never stored — every run re-derives it.
+
+Deviation note (driver-defined, flagged for review): the DR fixes the CV-*
+code list but assigns no code to a failed *git/history observation*; those
+fail closed here as ``CV-OBSERVE``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import install_pins, record_schema
+from .gitio import GitError, file_at, git, peeled
+from .tag_check import run_tag_checks
+
+# P3 exact marker — fixed by DR-819 D8-2 (English canonical, byte-exact).
+P3_MARKER = ("> **Latest** refers to the most recently published individual "
+             "skill release, not a catalog version.")
+
+INSTALL_PATH = "docs/INSTALL.md"
+_NAMESPACED_TAG = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+)\.(\d+)\.(\d+)$")
+_SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+@dataclass(frozen=True)
+class Verdict:
+    verdict: str                 # not-started|aborted|pending-tags|tags-ok|complete|red
+    code: str | None = None
+    candidate: str | None = None
+    predicate: str | None = None
+    detail: str = ""
+
+    def __str__(self) -> str:
+        parts = [self.verdict]
+        if self.code:
+            parts.append(self.code)
+            parts.append(f"candidate={self.candidate or '-'}")
+            parts.append(f"predicate={self.predicate or '-'}")
+        if self.detail:
+            parts.append(f"— {self.detail}")
+        return " ".join(parts)
+
+
+def _red(code: str, candidate: str | None, predicate: str | None, detail: str) -> Verdict:
+    return Verdict("red", code, candidate, predicate, detail)
+
+
+@dataclass
+class Observation:
+    """Step 0 snapshot. Immutable by convention: built once, then read."""
+    repo: Path
+    main_ref: str
+    main_tip: str
+    commits: list[str]                    # first-parent, tip first
+    pin_class: str
+    record_text: str | None
+    baseline_targets: dict[str, str]      # existing baseline ref -> peeled sha
+    domain: list[dict]                    # public_namespaced_releases
+    latest_tag: str | None
+    now: int
+    history_records: list[tuple[str, dict | str]] = field(default_factory=list)
+    # (commit, parsed-record dict | error string) oldest→newest, record commits only
+
+
+def _parse_record(text: str) -> dict | str:
+    """Canonical S2~S10 field validation; returns dict or an error string
+    naming the first violated rule."""
+    class Dup(ValueError):
+        pass
+
+    def no_dup(pairs):
+        d = {}
+        for k, v in pairs:
+            if k in d:
+                raise Dup(k)
+            d[k] = v
+        return d
+
+    try:
+        raw = json.loads(text, object_pairs_hook=no_dup)
+    except Dup as e:
+        return f"S3: duplicate key {e}"
+    except json.JSONDecodeError as e:
+        return f"S2: invalid JSON ({e.msg})"
+    if not isinstance(raw, dict):
+        return "S2: not an object"
+    expected_keys = {"schema", "attempt", "phase", "baseline_finalization_sha",
+                     "latest_ref", "baseline_tags"}
+    if set(raw) != expected_keys:
+        return f"S2: keys must be exactly {sorted(expected_keys)}"
+    if raw["schema"] != record_schema.SCHEMA:
+        return "S4: schema mismatch"
+    if not isinstance(raw["attempt"], int) or isinstance(raw["attempt"], bool) or raw["attempt"] < 1:
+        return "S5: attempt must be an integer >= 1"
+    for key in ("schema", "phase", "baseline_finalization_sha", "latest_ref"):
+        if not isinstance(raw[key], str):
+            return f"S5: {key} must be a string"
+    if not isinstance(raw["baseline_tags"], list) or not all(isinstance(t, str) for t in raw["baseline_tags"]):
+        return "S5: baseline_tags must be a string array"
+    if raw["phase"] not in record_schema.PHASES:
+        return "S6: phase must be prepared|aborted"
+    sha = raw["baseline_finalization_sha"]
+    if sha != record_schema.BASELINE_FINALIZATION_SHA or not _SHA40.match(sha):
+        return "S7: baseline_finalization_sha mismatch"
+    if raw["baseline_tags"] != list(record_schema.BASELINE_TAGS):
+        return "S8: baseline_tags must equal the canonical refs in order"
+    if not all(t.startswith("refs/tags/") for t in raw["baseline_tags"]):
+        return "S9: baseline_tags must be full refs"
+    if raw["latest_ref"] != record_schema.LATEST_REF or raw["latest_ref"] != raw["baseline_tags"][-1]:
+        return "S10: latest_ref mismatch"
+    return raw
+
+
+def build_observation(repo: Path, main_ref: str, releases_raw: list[dict],
+                      latest_tag: str | None, now: int | None = None) -> Observation:
+    main_tip = peeled(repo, main_ref)
+    commits = git(repo, "log", "--first-parent", "--format=%H", main_tip).split()
+
+    def ref_on_main(tag: str) -> bool:
+        try:
+            target = peeled(repo, tag)
+            git(repo, "merge-base", "--is-ancestor", target, main_tip)
+            return True
+        except GitError:
+            return False
+
+    install_text = file_at(repo, main_tip, INSTALL_PATH)
+    if install_text is None:
+        pin_class = "PIN-OTHER"
+    else:
+        pin_class = install_pins.classify(install_pins.parse_pins(install_text), ref_on_main)
+
+    record_text = file_at(repo, main_tip, record_schema.RECORD_PATH)
+
+    baseline_targets: dict[str, str] = {}
+    for ref in record_schema.BASELINE_TAGS:
+        try:
+            baseline_targets[ref] = peeled(repo, ref)
+        except GitError:
+            continue
+
+    domain = []
+    for r in releases_raw:
+        if not isinstance(r, dict) or r.get("draft") is True:
+            continue
+        tag = r.get("tag_name")
+        if isinstance(tag, str) and _NAMESPACED_TAG.match(tag):
+            domain.append(r)
+
+    history_records: list[tuple[str, dict | str]] = []
+    for commit in reversed(commits):  # oldest first
+        text = file_at(repo, commit, record_schema.RECORD_PATH)
+        if text is not None:
+            history_records.append((commit, _parse_record(text)))
+
+    return Observation(
+        repo=repo, main_ref=main_ref, main_tip=main_tip, commits=commits,
+        pin_class=pin_class, record_text=record_text,
+        baseline_targets=baseline_targets, domain=domain,
+        latest_tag=latest_tag, now=int(now if now is not None else time.time()),
+        history_records=history_records)
+
+
+# --- predicate helpers (each returns None when satisfied, else a Verdict) ---
+
+def _attempt_transitions(obs: Observation) -> list[tuple[str, int, dict | str]]:
+    """(commit, attempt, parent-record) for each first introduction of an
+    attempt value, oldest first. Parse errors surface as error strings."""
+    out: list[tuple[str, int, dict | str]] = []
+    prev: dict | str | None = None
+    for commit, rec in obs.history_records:
+        if isinstance(rec, str):
+            out.append((commit, -1, rec))
+            prev = rec
+            continue
+        if not isinstance(prev, dict) or prev["attempt"] != rec["attempt"]:
+            out.append((commit, rec["attempt"], prev if prev is not None else {}))
+        prev = rec
+    return out
+
+
+def _check_attempts(obs: Observation, candidate: str) -> Verdict | None:
+    transitions = _attempt_transitions(obs)
+    if not transitions:
+        return _red("CV-ATTEMPT", candidate, "T1", "record present at tip but never introduced on first-parent history")
+    attempts = []
+    for commit, attempt, prev in transitions:
+        if attempt == -1:
+            return _red("CV-SCHEMA", candidate, "historical", f"unreadable record at {commit[:12]}: {prev}")
+        attempts.append((commit, attempt, prev))
+    if attempts[0][1] != 1:
+        return _red("CV-ATTEMPT", candidate, "T1", f"first attempt is {attempts[0][1]}, must be 1")
+    for i in range(1, len(attempts)):
+        commit, attempt, prev = attempts[i]
+        if attempt != attempts[i - 1][1] + 1:
+            return _red("CV-ATTEMPT", candidate, "T2", f"attempt {attempts[i - 1][1]} -> {attempt} at {commit[:12]}")
+        if not (isinstance(prev, dict) and prev.get("phase") == "aborted"):
+            return _red("CV-ATTEMPT", candidate, "T3", f"attempt increased at {commit[:12]} without an aborted predecessor")
+        idx = obs.commits.index(commit)
+        parent = obs.commits[idx + 1] if idx + 1 < len(obs.commits) else None
+        if parent is not None:
+            parent_install = file_at(obs.repo, parent, INSTALL_PATH) or ""
+            inv = install_pins.parse_pins(parent_install)
+            if install_pins.classify(inv, lambda _t: False) != "PIN-LEGACY":
+                return _red("CV-ATTEMPT", candidate, "T3", f"attempt increased at {commit[:12]} while parent pins were not PIN-LEGACY")
+    return None
+
+
+def _expected_target(obs: Observation, attempt: int) -> str | None:
+    """First-parent commit where the record first carried ``attempt``."""
+    for commit, a, _prev in _attempt_transitions(obs):
+        if a == attempt:
+            return commit
+    return None
+
+
+def _prepared_identity(obs: Observation, record: dict, candidate: str) -> Verdict | None:
+    fail = _check_attempts(obs, candidate)
+    if fail:
+        return fail
+    expected = _expected_target(obs, record["attempt"])
+    if expected is None:
+        return _red("CV-ATTEMPT", candidate, "T1", f"no commit introduces attempt {record['attempt']}")
+    idx = obs.commits.index(expected)
+    parent = obs.commits[idx + 1] if idx + 1 < len(obs.commits) else None
+    if parent is None:
+        return _red("CV-SAME", candidate, "Q-SAME", "cutover commit has no first parent")
+    try:
+        changed = git(obs.repo, "diff", "--name-only", parent, expected).splitlines()
+    except GitError as e:
+        return _red("CV-OBSERVE", candidate, "Q-SAME", f"diff unobservable (fail-closed): {e}")
+    if record_schema.RECORD_PATH not in changed or INSTALL_PATH not in changed:
+        return _red("CV-SAME", candidate, "Q-SAME", "record transition and pin switch are not in the same commit")
+    try:
+        git(obs.repo, "cat-file", "-e", f"{record_schema.BASELINE_FINALIZATION_SHA}^{{commit}}")
+        git(obs.repo, "merge-base", "--is-ancestor", record_schema.BASELINE_FINALIZATION_SHA, obs.main_tip)
+    except GitError:
+        return _red("CV-BASE", candidate, "Q-BASE", "baseline finalization SHA missing or not reachable from main")
+    try:
+        tree_a = git(obs.repo, "rev-parse", f"{expected}:skills").strip()
+        tree_b = git(obs.repo, "rev-parse", f"{record_schema.BASELINE_FINALIZATION_SHA}:skills").strip()
+    except GitError as e:
+        return _red("CV-OBSERVE", candidate, "Q-TREE", f"skills tree unobservable (fail-closed): {e}")
+    if tree_a != tree_b:
+        return _red("CV-TREE", candidate, "Q-TREE", "skills/ tree differs from the baseline finalization tree")
+    return None
+
+
+def _clock(obs: Observation, candidate: str) -> Verdict | None:
+    """Public-breakage clock: onset = committer time of the most recent
+    first-parent commit that left PIN-LEGACY. pending-tags only, cap 1h."""
+    onset_sha = None
+    for i, commit in enumerate(obs.commits):
+        text = file_at(obs.repo, commit, INSTALL_PATH) or ""
+        cls = install_pins.classify(install_pins.parse_pins(text), lambda _t: True)
+        if cls == "PIN-LEGACY":
+            continue
+        parent = obs.commits[i + 1] if i + 1 < len(obs.commits) else None
+        if parent is None:
+            onset_sha = commit
+            break
+        parent_text = file_at(obs.repo, parent, INSTALL_PATH) or ""
+        parent_cls = install_pins.classify(install_pins.parse_pins(parent_text), lambda _t: True)
+        if parent_cls == "PIN-LEGACY":
+            onset_sha = commit
+            break
+    if onset_sha is None:
+        return _red("CV-OBSERVE", candidate, "clock", "no PIN-LEGACY departure found on first-parent history (fail-closed)")
+    try:
+        onset = int(git(obs.repo, "log", "-1", "--format=%ct", onset_sha).strip())
+    except (GitError, ValueError) as e:
+        return _red("CV-OBSERVE", candidate, "clock", f"onset time unobservable (fail-closed): {e}")
+    if obs.now - onset > 3600:
+        return _red("CV-CLOCK", candidate, "clock", f"public breakage window exceeded 1h (onset {onset_sha[:12]})")
+    return None
+
+
+def _release_p123(release: dict) -> str | None:
+    """Return the violated predicate name, or None."""
+    if release.get("prerelease") is True:
+        return "P1"
+    tag = release.get("tag_name", "")
+    m = _NAMESPACED_TAG.match(tag)
+    if not m:
+        return "P2"
+    expected_title = f"{m.group(1)} {m.group(2)}.{m.group(3)}.{m.group(4)}"
+    if expected_title not in (release.get("name") or ""):
+        return "P2"
+    body = release.get("body") or ""
+    first = next((l.strip().strip("\r") for l in body.splitlines() if l.strip()), "")
+    if first != P3_MARKER:
+        return "P3"
+    return None
+
+
+# --- the ordered evaluator ---
+
+def evaluate(obs: Observation) -> Verdict:
+    baseline_refs = set(record_schema.BASELINE_TAGS)
+    ref_count = len(obs.baseline_targets)
+
+    # Step 1 — record-absence classifier.
+    if obs.record_text is None:
+        if obs.pin_class == "PIN-LEGACY" and ref_count == 0 and not obs.domain:
+            return Verdict("not-started")
+        return _red("CV-ORPHAN", None, "pre-start",
+                    f"no record but pins={obs.pin_class}, baseline refs={ref_count}, releases={len(obs.domain)}")
+
+    # Step 2 — schema validation (record exists).
+    record = _parse_record(obs.record_text)
+    if isinstance(record, str):
+        return _red("CV-SCHEMA", None, record.split(":", 1)[0], record)
+
+    # Step 3 — candidate classification (phase × ref count).
+    phase = record["phase"]
+    if phase == "aborted" and ref_count == 0:
+        candidate = "aborted"
+    elif phase == "aborted":
+        return _red("CV-ABORT-TAGS", "aborted", "ref-count", f"{ref_count} baseline refs exist under an aborted record")
+    elif ref_count == 0:
+        candidate = "pending-tags"
+    elif ref_count < len(baseline_refs):
+        return _red("CV-PARTIAL-TAGS", "pending-tags", "ref-count", f"{ref_count}/{len(baseline_refs)} baseline refs exist — atomic contract violated")
+    else:
+        candidate = "tags-ok"
+
+    # Step 4 — positive predicates per candidate (Step 5: fail in place).
+    if candidate == "aborted":
+        if obs.pin_class != "PIN-LEGACY":
+            return _red("CV-ABORT-PIN", candidate, "pin", f"pins={obs.pin_class}, aborted requires PIN-LEGACY")
+        fail = _check_attempts(obs, candidate)
+        if fail:
+            return fail
+        return Verdict("aborted")
+
+    if candidate == "pending-tags":
+        if obs.pin_class != "PIN-BASELINE":
+            return _red("CV-PIN", candidate, "pin", f"pins={obs.pin_class}, pending-tags requires PIN-BASELINE")
+        fail = _prepared_identity(obs, record, candidate) or _clock(obs, candidate)
+        if fail:
+            return fail
+        return Verdict("pending-tags")
+
+    # candidate == tags-ok
+    fail = _prepared_identity(obs, record, candidate)
+    if fail:
+        return fail
+    expected = _expected_target(obs, record["attempt"])
+    assert expected is not None  # _prepared_identity established it
+    for ref, target in obs.baseline_targets.items():
+        if target != expected:
+            return _red("CV-TARGET", candidate, "baseline-target", f"{ref} -> {target[:12]} != expected {expected[:12]}")
+    tip_record = obs.record_text
+    intro_record = file_at(obs.repo, expected, record_schema.RECORD_PATH)
+    if tip_record != intro_record:
+        return _red("CV-FROZEN", candidate, "record-freeze", "record changed after baseline refs came into existence")
+    baseline_releases = [r for r in obs.domain if f"refs/tags/{r.get('tag_name')}" in baseline_refs]
+    successors = [r for r in obs.domain if f"refs/tags/{r.get('tag_name')}" not in baseline_refs]
+    for r in obs.domain:
+        violated = _release_p123(r)
+        if violated:
+            return _red("CV-RELEASE", candidate, violated, f"release {r.get('tag_name')!r} violates {violated}")
+    if successors:
+        try:
+            tag_findings = run_tag_checks(obs.repo, obs.main_ref)
+        except GitError as e:
+            return _red("CV-OBSERVE", candidate, "tag-gate", f"tag checks unobservable (fail-closed): {e}")
+        successor_tags = {r.get("tag_name") for r in successors}
+        for f in tag_findings:
+            if f.subject in successor_tags or f.subject.removeprefix("refs/tags/") in successor_tags:
+                return _red("CV-RELEASE", candidate, "tag-gate", f"successor tag fails the normal tag gate: {f}")
+
+    # Step 6A — pin gate, chosen by baseline Release count.
+    if len(baseline_releases) < len(baseline_refs):
+        if obs.pin_class != "PIN-BASELINE":
+            return _red("CV-PIN", candidate, "pin-6A", f"pins={obs.pin_class}, cutover in progress requires PIN-BASELINE")
+    else:
+        if obs.pin_class not in ("PIN-NAMESPACED", "PIN-BASELINE"):
+            return _red("CV-PIN", candidate, "pin-6A", f"pins={obs.pin_class}, promoted state requires PIN-NAMESPACED")
+
+    # Step 6B — promotion and steady state.
+    latest_expected = record_schema.LATEST_REF.removeprefix("refs/tags/")
+    if len(baseline_releases) < len(baseline_refs):
+        if successors:
+            return _red("CV-PREMATURE", candidate, "promotion", "an ordinary release was published before the cutover completed")
+        return Verdict("tags-ok")
+    if not successors:
+        if obs.latest_tag == latest_expected:
+            return Verdict("complete", detail="initial promotion")
+        return _red("CV-LATEST-INITIAL", candidate, "promotion", f"Latest is {obs.latest_tag!r}, expected {latest_expected!r}")
+    stamps = [(r.get("published_at") or "") for r in obs.domain]
+    argmax = {r.get("tag_name") for r in obs.domain if (r.get("published_at") or "") == max(stamps)}
+    if obs.latest_tag in argmax:
+        return Verdict("complete", detail="steady state")
+    return _red("CV-LATEST-STEADY", candidate, "promotion", f"Latest {obs.latest_tag!r} not in argmax(published_at) {sorted(argmax)}")
+
+
+def run_cutover(repo: Path, main_ref: str, releases_raw: list[dict],
+                latest_tag: str | None, now: int | None = None) -> Verdict:
+    try:
+        obs = build_observation(repo, main_ref, releases_raw, latest_tag, now)
+    except GitError as e:
+        return _red("CV-OBSERVE", None, "step-0", f"observation failed (fail-closed): {e}")
+    return evaluate(obs)

--- a/tools/skillstead_validate/cutover.py
+++ b/tools/skillstead_validate/cutover.py
@@ -153,9 +153,12 @@ def build_observation(repo: Path, main_ref: str, releases_raw: list[dict],
         except GitError:
             continue
 
-    # Domain normalization is exact and fail-closed (MR2-F5): a release
-    # object whose draft/prerelease/tag_name/published_at cannot be typed is
-    # not "probably published" — it is an incomplete observation.
+    # Domain normalization is exact and fail-closed (MR2-F5 · MR2R-F5): the
+    # input must be an array, and a release object whose draft/prerelease/
+    # tag_name/published_at cannot be typed is not "probably published" —
+    # it is an incomplete observation.
+    if not isinstance(releases_raw, list):
+        raise DomainError("releases input is not an array")
     domain = []
     for r in releases_raw:
         if not isinstance(r, dict):
@@ -165,7 +168,10 @@ def build_observation(repo: Path, main_ref: str, releases_raw: list[dict],
         tag = r.get("tag_name")
         if not isinstance(tag, str):
             raise DomainError("release object has no string tag_name")
-        if not (r.get("published_at") is None or isinstance(r.get("published_at"), str)):
+        if r["draft"] is False:
+            if not isinstance(r.get("published_at"), str) or not r["published_at"]:
+                raise DomainError(f"release {tag!r}: a published release must carry a non-empty published_at")
+        elif not (r.get("published_at") is None or isinstance(r.get("published_at"), str)):
             raise DomainError(f"release {tag!r}: published_at must be a string or null")
         if r["draft"] is False and _NAMESPACED_TAG.match(tag):
             domain.append(r)

--- a/tools/skillstead_validate/findings.py
+++ b/tools/skillstead_validate/findings.py
@@ -1,0 +1,13 @@
+"""Finding model shared by all validator modes."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Finding:
+    check: str      # stable check id, e.g. "I-1", "LICENSE-BYTES", "PARSE"
+    subject: str    # skill name or repo-relative path
+    detail: str
+
+    def __str__(self) -> str:
+        return f"[{self.check}] {self.subject}: {self.detail}"

--- a/tools/skillstead_validate/frontmatter.py
+++ b/tools/skillstead_validate/frontmatter.py
@@ -1,0 +1,53 @@
+"""Constrained SKILL.md frontmatter reader.
+
+This is deliberately not a YAML parser. The baseline (docs/VERSIONING.md) fixes
+the frontmatter shape this repository uses; this reader accepts exactly that
+shape and fails closed on anything else. Fields read: top-level ``name``,
+top-level ``license``, and ``version`` nested directly under ``metadata:``.
+"""
+
+from __future__ import annotations
+
+import re
+
+_TOP_KEY = re.compile(r"^([A-Za-z][A-Za-z0-9_-]*):(.*)$")
+_META_VERSION = re.compile(r"^\s+version:\s*(\S+)\s*$")
+
+
+class FrontmatterError(ValueError):
+    """Raised when the frontmatter cannot be read under the fixed shape."""
+
+
+def parse_skill_frontmatter(text: str) -> dict:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise FrontmatterError("missing opening '---' delimiter")
+    try:
+        end = next(i for i in range(1, len(lines)) if lines[i].strip() == "---")
+    except StopIteration:
+        raise FrontmatterError("missing closing '---' delimiter") from None
+
+    fields: dict[str, str] = {}
+    current_top: str | None = None
+    for raw in lines[1:end]:
+        if not raw.strip():
+            continue
+        if not raw[0].isspace():
+            m = _TOP_KEY.match(raw)
+            if not m:
+                raise FrontmatterError(f"unparseable top-level line: {raw!r}")
+            current_top = m.group(1)
+            value = m.group(2).strip()
+            if value and value not in (">", "|", ">-", "|-"):
+                if current_top in fields:
+                    raise FrontmatterError(f"duplicate top-level key: {current_top}")
+                fields[current_top] = value
+        else:
+            # Continuation or nested line; only metadata.version is contractual.
+            if current_top == "metadata":
+                m = _META_VERSION.match(raw)
+                if m:
+                    if "metadata.version" in fields:
+                        raise FrontmatterError("duplicate metadata.version")
+                    fields["metadata.version"] = m.group(1)
+    return fields

--- a/tools/skillstead_validate/gitio.py
+++ b/tools/skillstead_validate/gitio.py
@@ -10,11 +10,11 @@ class GitError(RuntimeError):
     """A git query failed; callers must treat the observation as unavailable."""
 
 
-def git(repo: Path, *args: str) -> str:
+def git(repo: Path, *args: str, input_text: str | None = None) -> str:
     try:
         proc = subprocess.run(
             ["git", "-C", str(repo), *args],
-            capture_output=True, text=True, check=True)
+            capture_output=True, text=True, check=True, input=input_text)
     except FileNotFoundError as e:
         raise GitError("git executable not found") from e
     except subprocess.CalledProcessError as e:

--- a/tools/skillstead_validate/gitio.py
+++ b/tools/skillstead_validate/gitio.py
@@ -1,0 +1,73 @@
+"""Git observation layer. Every query failure raises GitError (fail-closed)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+class GitError(RuntimeError):
+    """A git query failed; callers must treat the observation as unavailable."""
+
+
+def git(repo: Path, *args: str) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True, text=True, check=True)
+    except FileNotFoundError as e:
+        raise GitError("git executable not found") from e
+    except subprocess.CalledProcessError as e:
+        raise GitError(f"git {' '.join(args)}: {e.stderr.strip()}") from e
+    return proc.stdout
+
+
+def peeled(repo: Path, ref: str) -> str:
+    """Peeled commit SHA — identical for annotated and lightweight tags."""
+    return git(repo, "rev-parse", f"{ref}^{{commit}}").strip()
+
+
+def file_at(repo: Path, commit: str, path: str) -> str | None:
+    """File content at a commit, or None when absent there."""
+    try:
+        return git(repo, "show", f"{commit}:{path}")
+    except GitError:
+        try:
+            git(repo, "cat-file", "-e", f"{commit}:{path}")
+        except GitError:
+            return None
+        raise
+
+
+def files_at(repo: Path, commit: str, prefix: str) -> dict[str, str]:
+    """{repo-relative path: blob sha} for files under ``prefix`` at ``commit``."""
+    out = git(repo, "ls-tree", "-r", commit, "--", prefix)
+    result: dict[str, str] = {}
+    for line in out.splitlines():
+        meta, path = line.split("\t", 1)
+        _mode, otype, sha = meta.split()
+        if otype == "blob":
+            result[path] = sha
+    return result
+
+
+def dirs_at(repo: Path, commit: str, prefix: str) -> set[str]:
+    """Top-level directory names under ``prefix`` at ``commit``."""
+    out = git(repo, "ls-tree", commit, "--", prefix if prefix.endswith("/") else prefix + "/")
+    dirs: set[str] = set()
+    for line in out.splitlines():
+        meta, path = line.split("\t", 1)
+        if meta.split()[1] == "tree":
+            dirs.add(path.rsplit("/", 1)[-1])
+    return dirs
+
+
+def tag_names(repo: Path, pattern: str = "*") -> list[str]:
+    out = git(repo, "tag", "--list", pattern)
+    return [l.strip() for l in out.splitlines() if l.strip()]
+
+
+def first_parent_positions(repo: Path, tip: str) -> dict[str, int]:
+    """{commit sha: index} along first-parent history from ``tip`` (0 = tip)."""
+    out = git(repo, "log", "--first-parent", "--format=%H", tip)
+    return {sha: i for i, sha in enumerate(out.split())}

--- a/tools/skillstead_validate/install_pins.py
+++ b/tools/skillstead_validate/install_pins.py
@@ -1,4 +1,4 @@
-"""INSTALL pin inventory (DR-819 D8-2).
+"""INSTALL pin inventory (see docs/VALIDATION.md).
 
 Parsing boundary fixed by the DR: only ``bash``/``powershell`` fenced blocks
 are examined; each candidate block must pair exactly one ``git clone`` with

--- a/tools/skillstead_validate/install_pins.py
+++ b/tools/skillstead_validate/install_pins.py
@@ -1,0 +1,80 @@
+"""INSTALL pin inventory (DR-819 D8-2).
+
+Parsing boundary fixed by the DR: only ``bash``/``powershell`` fenced blocks
+are examined; each candidate block must pair exactly one ``git clone`` with
+exactly one ``skills/<skill>`` copy source; any ambiguity classifies the
+whole inventory as ``PIN-OTHER``; prose ``--branch`` mentions are ignored.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+LEGACY_PIN = "v0.8.0"
+BASELINE_PIN = "github-release-guide/v0.8.0"
+BASELINE_PIN_COUNT = 7
+
+_FENCE = re.compile(r"^```(bash|powershell)\s*$")
+_CLONE_BRANCH = re.compile(r"\bgit\s+clone\b.*?--branch\s+(\S+)")
+_COPY_SKILL = re.compile(r"skills[/\\]([a-z0-9][a-z0-9-]*)")
+_NAMESPACED = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+)\.(\d+)\.(\d+)$")
+
+
+@dataclass(frozen=True)
+class Pin:
+    ref: str
+    copy_skill: str
+
+
+@dataclass(frozen=True)
+class PinInventory:
+    pins: tuple[Pin, ...]
+    ambiguous: bool  # any candidate block that could not be paired
+
+
+def parse_pins(install_text: str) -> PinInventory:
+    pins: list[Pin] = []
+    ambiguous = False
+    block: list[str] | None = None
+    for line in install_text.splitlines():
+        if block is None:
+            if _FENCE.match(line):
+                block = []
+            continue
+        if line.strip() == "```":
+            clones = [l for l in block if _CLONE_BRANCH.search(l)]
+            if clones:
+                copy_skills = {m.group(1) for l in block if not _CLONE_BRANCH.search(l)
+                               for m in [_COPY_SKILL.search(l)] if m}
+                if len(clones) != 1 or len(copy_skills) != 1:
+                    ambiguous = True
+                else:
+                    m = _CLONE_BRANCH.search(clones[0])
+                    assert m is not None
+                    pins.append(Pin(ref=m.group(1), copy_skill=next(iter(copy_skills))))
+            block = None
+            continue
+        block.append(line)
+    return PinInventory(pins=tuple(pins), ambiguous=ambiguous)
+
+
+def classify(inventory: PinInventory, ref_exists_on_main) -> str:
+    """Return one of PIN-LEGACY / PIN-BASELINE / PIN-NAMESPACED / PIN-OTHER.
+
+    ``ref_exists_on_main(tag_name) -> bool`` supplies the git observation so
+    this stays pure. PIN-BASELINE also satisfies PIN-NAMESPACED by the DR's
+    definitions; classification returns the most specific label first.
+    """
+    if inventory.ambiguous or not inventory.pins:
+        return "PIN-OTHER"
+    pins = inventory.pins
+    if len(pins) == BASELINE_PIN_COUNT and all(p.ref == LEGACY_PIN for p in pins):
+        return "PIN-LEGACY"
+    if len(pins) == BASELINE_PIN_COUNT and all(p.ref == BASELINE_PIN for p in pins):
+        return "PIN-BASELINE"
+    for p in pins:
+        m = _NAMESPACED.match(p.ref)
+        if not m or m.group(1) != p.copy_skill or not ref_exists_on_main(p.ref):
+            return "PIN-OTHER"
+    return "PIN-NAMESPACED"

--- a/tools/skillstead_validate/install_pins.py
+++ b/tools/skillstead_validate/install_pins.py
@@ -34,28 +34,44 @@ class PinInventory:
 
 
 def parse_pins(install_text: str) -> PinInventory:
+    """Candidate block = a fenced bash/powershell block containing a
+    ``git clone`` line (with or without ``--branch`` — an unsupported clone
+    is ambiguity, not silence). Copy-only blocks (e.g. uninstall paths that
+    mention ``skills/<name>``) carry no pin and are not candidates. Any
+    candidate that fails the exact one-supported-clone + one-copy-line
+    pairing, and any unclosed candidate fence, marks the inventory
+    ambiguous (→ PIN-OTHER)."""
     pins: list[Pin] = []
     ambiguous = False
     block: list[str] | None = None
+
+    def process(lines: list[str]) -> None:
+        nonlocal ambiguous
+        clone_lines = [l for l in lines if "git clone" in l]
+        if not clone_lines:
+            return
+        supported = [l for l in clone_lines if _CLONE_BRANCH.search(l)]
+        copy_lines = [m for l in lines if l not in clone_lines
+                      for m in [_COPY_SKILL.search(l)] if m]
+        if len(clone_lines) != 1 or len(supported) != 1 or len(copy_lines) != 1:
+            ambiguous = True
+            return
+        m = _CLONE_BRANCH.search(supported[0])
+        assert m is not None
+        pins.append(Pin(ref=m.group(1), copy_skill=copy_lines[0].group(1)))
+
     for line in install_text.splitlines():
         if block is None:
             if _FENCE.match(line):
                 block = []
             continue
         if line.strip() == "```":
-            clones = [l for l in block if _CLONE_BRANCH.search(l)]
-            if clones:
-                copy_skills = {m.group(1) for l in block if not _CLONE_BRANCH.search(l)
-                               for m in [_COPY_SKILL.search(l)] if m}
-                if len(clones) != 1 or len(copy_skills) != 1:
-                    ambiguous = True
-                else:
-                    m = _CLONE_BRANCH.search(clones[0])
-                    assert m is not None
-                    pins.append(Pin(ref=m.group(1), copy_skill=next(iter(copy_skills))))
+            process(block)
             block = None
             continue
         block.append(line)
+    if block is not None and any("git clone" in l for l in block):
+        ambiguous = True  # unclosed candidate fence
     return PinInventory(pins=tuple(pins), ambiguous=ambiguous)
 
 

--- a/tools/skillstead_validate/normalize.py
+++ b/tools/skillstead_validate/normalize.py
@@ -1,0 +1,87 @@
+"""Canonical payload normalization (DR-818 §D3-1).
+
+Payload of ``skills/<name>/**`` excludes exactly two bookkeeping artifacts:
+the ``metadata.version`` scalar inside ``SKILL.md`` (replaced by a fixed
+sentinel — the body still counts) and ``CHANGELOG.md`` in its entirety.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .gitio import file_at, files_at
+
+_SENTINEL = "@VERSION@"
+_META_VERSION_LINE = re.compile(r"^(\s+version:\s*)\S+(\s*)$")
+
+
+def normalize_skill_md(text: str) -> str:
+    """Replace the frontmatter ``metadata.version`` scalar with a sentinel."""
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    delimiters = 0
+    current_top: str | None = None
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "---" and delimiters < 2:
+            delimiters += 1
+            out.append(line)
+            continue
+        if delimiters == 1:
+            if line and not line[0].isspace():
+                current_top = line.split(":", 1)[0].strip()
+            elif current_top == "metadata":
+                m = _META_VERSION_LINE.match(line.rstrip("\n"))
+                if m:
+                    out.append(f"{m.group(1)}{_SENTINEL}{m.group(2)}\n")
+                    continue
+        out.append(line)
+    return "".join(out)
+
+
+def payload_changed(repo: Path, prev_commit: str, target_commit: str, skill: str) -> bool:
+    """True when the skill's payload differs between the two commits."""
+    prefix = f"skills/{skill}/"
+    prev = files_at(repo, prev_commit, prefix)
+    target = files_at(repo, target_commit, prefix)
+    changelog = prefix + "CHANGELOG.md"
+    skill_md = prefix + "SKILL.md"
+    prev.pop(changelog, None)
+    target.pop(changelog, None)
+
+    if set(prev) != set(target):
+        return True
+    for path in prev:
+        if path == skill_md:
+            continue
+        if prev[path] != target[path]:
+            return True
+    if skill_md in prev:
+        a = file_at(repo, prev_commit, skill_md) or ""
+        b = file_at(repo, target_commit, skill_md) or ""
+        if normalize_skill_md(a) != normalize_skill_md(b):
+            return True
+    return False
+
+
+def changed_payload_paths(repo: Path, prev_commit: str, target_commit: str, skill: str) -> list[str]:
+    """Payload paths that differ (for bump-step classification)."""
+    prefix = f"skills/{skill}/"
+    prev = files_at(repo, prev_commit, prefix)
+    target = files_at(repo, target_commit, prefix)
+    changelog = prefix + "CHANGELOG.md"
+    skill_md = prefix + "SKILL.md"
+    prev.pop(changelog, None)
+    target.pop(changelog, None)
+
+    changed = set(prev) ^ set(target)
+    for path in set(prev) & set(target):
+        if path == skill_md:
+            a = file_at(repo, prev_commit, skill_md) or ""
+            b = file_at(repo, target_commit, skill_md) or ""
+            if normalize_skill_md(a) != normalize_skill_md(b):
+                changed.add(path)
+        elif prev[path] != target[path]:
+            changed.add(path)
+    return sorted(changed)

--- a/tools/skillstead_validate/normalize.py
+++ b/tools/skillstead_validate/normalize.py
@@ -1,4 +1,4 @@
-"""Canonical payload normalization (DR-818 §D3-1).
+"""Canonical payload normalization (see docs/VERSIONING.md).
 
 Payload of ``skills/<name>/**`` excludes exactly two bookkeeping artifacts:
 the ``metadata.version`` scalar inside ``SKILL.md`` (replaced by a fixed

--- a/tools/skillstead_validate/package_check.py
+++ b/tools/skillstead_validate/package_check.py
@@ -1,9 +1,11 @@
-"""M1 repo validation: package-structure axis + I-1 + I-7 + I-9.
+"""Package-structure axis + I-1 + I-7 + I-9, over any Source.
 
-Covers what the pinned spec reference validator does not check (measured):
-license pointer resolution, license byte equality with the root LICENSE,
-SemVer form of ``metadata.version``, I-1 CHANGELOG agreement, and the I-7
-catalog Version columns. Every parse failure is itself a finding (fail-closed).
+Runs against the working tree (M1) or a specific commit (shared with the M2
+release preflight — the release-gate axis of I-7·I-9 requires checking the
+release target, not the checkout). Covers what the pinned spec reference
+validator does not: license pointer resolution, license byte equality with
+the root LICENSE, SemVer form, I-1 CHANGELOG agreement, and the catalog
+Version columns. Every parse failure is itself a finding (fail-closed).
 """
 
 from __future__ import annotations
@@ -16,31 +18,24 @@ from .catalog import EN_HEADER, KO_HEADER, CatalogError, catalog_versions
 from .changelog import ChangelogError, topmost_released_version
 from .findings import Finding
 from .frontmatter import FrontmatterError, parse_skill_frontmatter
+from .source import CommitSource, Source, WorktreeSource
 
 _SEMVER = re.compile(SEMVER_RE)
 
 
-def active_inventory(repo_root: Path) -> list[str]:
-    """Active package inventory: every directory under ``skills/``."""
-    skills_dir = repo_root / "skills"
-    if not skills_dir.is_dir():
-        return []
-    return sorted(p.name for p in skills_dir.iterdir() if p.is_dir())
-
-
-def check_package(repo_root: Path, name: str) -> tuple[list[Finding], str | None]:
+def check_package(source: Source, name: str) -> tuple[list[Finding], str | None]:
     """Validate one package. Returns (findings, declared version or None)."""
     findings: list[Finding] = []
-    pkg = repo_root / "skills" / name
+    pkg = f"skills/{name}"
 
-    skill_md = pkg / "SKILL.md"
-    if not skill_md.is_file():
+    skill_md = source.read_text(f"{pkg}/SKILL.md")
+    if skill_md is None:
         findings.append(Finding("I-9", name, "SKILL.md missing"))
         return findings, None
 
     try:
-        fm = parse_skill_frontmatter(skill_md.read_text(encoding="utf-8"))
-    except (FrontmatterError, UnicodeDecodeError) as e:
+        fm = parse_skill_frontmatter(skill_md)
+    except FrontmatterError as e:
         findings.append(Finding("PARSE", name, f"SKILL.md frontmatter: {e}"))
         return findings, None
 
@@ -54,26 +49,26 @@ def check_package(repo_root: Path, name: str) -> tuple[list[Finding], str | None
     license_ptr = fm.get("license")
     if license_ptr is None:
         findings.append(Finding("I-9", name, "license field missing"))
+    elif not Source.inside_package(name, license_ptr):
+        findings.append(Finding("I-9", name, f"license pointer {license_ptr!r} escapes the package"))
     else:
-        license_path = (pkg / license_ptr).resolve()
-        if not str(license_path).startswith(str(pkg.resolve()) + "/"):
-            findings.append(Finding("I-9", name, f"license pointer {license_ptr!r} escapes the package"))
-        elif not license_path.is_file():
+        copy_id = source.blob_id(f"{pkg}/{license_ptr}")
+        if copy_id is None:
             findings.append(Finding("I-9", name, f"license pointer {license_ptr!r} does not resolve"))
         else:
-            root_license = repo_root / "LICENSE"
-            if not root_license.is_file():
+            root_id = source.blob_id("LICENSE")
+            if root_id is None:
                 findings.append(Finding("LICENSE-BYTES", name, "root LICENSE missing"))
-            elif license_path.read_bytes() != root_license.read_bytes():
+            elif copy_id != root_id:
                 findings.append(Finding("LICENSE-BYTES", name, f"{license_ptr} differs from root LICENSE"))
 
-    changelog = pkg / "CHANGELOG.md"
-    if not changelog.is_file():
+    changelog = source.read_text(f"{pkg}/CHANGELOG.md")
+    if changelog is None:
         findings.append(Finding("I-1", name, "CHANGELOG.md missing"))
     else:
         try:
-            top = topmost_released_version(changelog.read_text(encoding="utf-8"))
-        except (ChangelogError, UnicodeDecodeError) as e:
+            top = topmost_released_version(changelog)
+        except ChangelogError as e:
             findings.append(Finding("I-1", name, f"CHANGELOG unreadable: {e}"))
         else:
             if version is not None and top != version:
@@ -82,18 +77,18 @@ def check_package(repo_root: Path, name: str) -> tuple[list[Finding], str | None
     return findings, version
 
 
-def check_catalog(repo_root: Path, versions: dict[str, str | None]) -> list[Finding]:
+def check_catalog(source: Source, versions: dict[str, str | None]) -> list[Finding]:
     """I-7: both catalog tables cover the inventory with matching versions."""
     findings: list[Finding] = []
     tables: dict[str, dict[str, str]] = {}
     for fname, header in (("README.md", EN_HEADER), ("README.ko.md", KO_HEADER)):
-        path = repo_root / fname
-        if not path.is_file():
+        text = source.read_text(fname)
+        if text is None:
             findings.append(Finding("I-7", fname, "file missing"))
             continue
         try:
-            tables[fname] = catalog_versions(path.read_text(encoding="utf-8"), header)
-        except (CatalogError, UnicodeDecodeError) as e:
+            tables[fname] = catalog_versions(text, header)
+        except CatalogError as e:
             findings.append(Finding("I-7", fname, str(e)))
     for fname, table in tables.items():
         if set(table) != set(versions):
@@ -113,16 +108,31 @@ def check_catalog(repo_root: Path, versions: dict[str, str | None]) -> list[Find
     return findings
 
 
-def run_repo_validation(repo_root: Path) -> list[Finding]:
-    """Full M1 pass over the repository."""
+def run_validation(source: Source) -> list[Finding]:
+    """Full package + catalog pass over one repository state."""
     findings: list[Finding] = []
-    inventory = active_inventory(repo_root)
+    inventory = source.skill_dirs()
     if not inventory:
         return [Finding("INVENTORY", "skills/", "no packages found")]
     versions: dict[str, str | None] = {}
     for name in inventory:
-        pkg_findings, version = check_package(repo_root, name)
+        pkg_findings, version = check_package(source, name)
         findings.extend(pkg_findings)
         versions[name] = version
-    findings.extend(check_catalog(repo_root, versions))
+    findings.extend(check_catalog(source, versions))
     return findings
+
+
+def run_repo_validation(repo_root: Path) -> list[Finding]:
+    """M1: validate the working tree."""
+    return run_validation(WorktreeSource(repo_root))
+
+
+def run_repo_validation_at(repo: Path, commit: str) -> list[Finding]:
+    """Release-gate axis of I-1·I-7·I-9: validate a specific commit."""
+    return run_validation(CommitSource(repo, commit))
+
+
+def active_inventory(repo_root: Path) -> list[str]:
+    """Active package inventory of the working tree."""
+    return WorktreeSource(repo_root).skill_dirs()

--- a/tools/skillstead_validate/package_check.py
+++ b/tools/skillstead_validate/package_check.py
@@ -1,0 +1,128 @@
+"""M1 repo validation: package-structure axis + I-1 + I-7 + I-9.
+
+Covers what the pinned spec reference validator does not check (measured):
+license pointer resolution, license byte equality with the root LICENSE,
+SemVer form of ``metadata.version``, I-1 CHANGELOG agreement, and the I-7
+catalog Version columns. Every parse failure is itself a finding (fail-closed).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from . import SEMVER_RE
+from .catalog import EN_HEADER, KO_HEADER, CatalogError, catalog_versions
+from .changelog import ChangelogError, topmost_released_version
+from .findings import Finding
+from .frontmatter import FrontmatterError, parse_skill_frontmatter
+
+_SEMVER = re.compile(SEMVER_RE)
+
+
+def active_inventory(repo_root: Path) -> list[str]:
+    """Active package inventory: every directory under ``skills/``."""
+    skills_dir = repo_root / "skills"
+    if not skills_dir.is_dir():
+        return []
+    return sorted(p.name for p in skills_dir.iterdir() if p.is_dir())
+
+
+def check_package(repo_root: Path, name: str) -> tuple[list[Finding], str | None]:
+    """Validate one package. Returns (findings, declared version or None)."""
+    findings: list[Finding] = []
+    pkg = repo_root / "skills" / name
+
+    skill_md = pkg / "SKILL.md"
+    if not skill_md.is_file():
+        findings.append(Finding("I-9", name, "SKILL.md missing"))
+        return findings, None
+
+    try:
+        fm = parse_skill_frontmatter(skill_md.read_text(encoding="utf-8"))
+    except (FrontmatterError, UnicodeDecodeError) as e:
+        findings.append(Finding("PARSE", name, f"SKILL.md frontmatter: {e}"))
+        return findings, None
+
+    version = fm.get("metadata.version")
+    if version is None:
+        findings.append(Finding("VERSION", name, "metadata.version missing"))
+    elif not _SEMVER.match(version):
+        findings.append(Finding("VERSION", name, f"metadata.version {version!r} is not MAJOR.MINOR.PATCH"))
+        version = None
+
+    license_ptr = fm.get("license")
+    if license_ptr is None:
+        findings.append(Finding("I-9", name, "license field missing"))
+    else:
+        license_path = (pkg / license_ptr).resolve()
+        if not str(license_path).startswith(str(pkg.resolve()) + "/"):
+            findings.append(Finding("I-9", name, f"license pointer {license_ptr!r} escapes the package"))
+        elif not license_path.is_file():
+            findings.append(Finding("I-9", name, f"license pointer {license_ptr!r} does not resolve"))
+        else:
+            root_license = repo_root / "LICENSE"
+            if not root_license.is_file():
+                findings.append(Finding("LICENSE-BYTES", name, "root LICENSE missing"))
+            elif license_path.read_bytes() != root_license.read_bytes():
+                findings.append(Finding("LICENSE-BYTES", name, f"{license_ptr} differs from root LICENSE"))
+
+    changelog = pkg / "CHANGELOG.md"
+    if not changelog.is_file():
+        findings.append(Finding("I-1", name, "CHANGELOG.md missing"))
+    else:
+        try:
+            top = topmost_released_version(changelog.read_text(encoding="utf-8"))
+        except (ChangelogError, UnicodeDecodeError) as e:
+            findings.append(Finding("I-1", name, f"CHANGELOG unreadable: {e}"))
+        else:
+            if version is not None and top != version:
+                findings.append(Finding("I-1", name, f"metadata.version {version} != CHANGELOG topmost {top}"))
+
+    return findings, version
+
+
+def check_catalog(repo_root: Path, versions: dict[str, str | None]) -> list[Finding]:
+    """I-7: both catalog tables cover the inventory with matching versions."""
+    findings: list[Finding] = []
+    tables: dict[str, dict[str, str]] = {}
+    for fname, header in (("README.md", EN_HEADER), ("README.ko.md", KO_HEADER)):
+        path = repo_root / fname
+        if not path.is_file():
+            findings.append(Finding("I-7", fname, "file missing"))
+            continue
+        try:
+            tables[fname] = catalog_versions(path.read_text(encoding="utf-8"), header)
+        except (CatalogError, UnicodeDecodeError) as e:
+            findings.append(Finding("I-7", fname, str(e)))
+    for fname, table in tables.items():
+        if set(table) != set(versions):
+            findings.append(Finding(
+                "I-7", fname,
+                f"catalog rows {sorted(table)} != inventory {sorted(versions)}"))
+            continue
+        for name, declared in versions.items():
+            if declared is not None and table[name] != declared:
+                findings.append(Finding(
+                    "I-7", fname,
+                    f"{name}: table version {table[name]} != metadata.version {declared}"))
+    if len(tables) == 2:
+        en, ko = tables["README.md"], tables["README.ko.md"]
+        if en != ko:
+            findings.append(Finding("I-7", "README.md/README.ko.md", f"EN table {en} != KO table {ko}"))
+    return findings
+
+
+def run_repo_validation(repo_root: Path) -> list[Finding]:
+    """Full M1 pass over the repository."""
+    findings: list[Finding] = []
+    inventory = active_inventory(repo_root)
+    if not inventory:
+        return [Finding("INVENTORY", "skills/", "no packages found")]
+    versions: dict[str, str | None] = {}
+    for name in inventory:
+        pkg_findings, version = check_package(repo_root, name)
+        findings.extend(pkg_findings)
+        versions[name] = version
+    findings.extend(check_catalog(repo_root, versions))
+    return findings

--- a/tools/skillstead_validate/record_schema.py
+++ b/tools/skillstead_validate/record_schema.py
@@ -1,0 +1,24 @@
+"""Cutover-record canonical constants (DR-819 D8-1).
+
+These values are fixed by the decision record, not configuration. The full
+S1~S10 schema validation belongs to the cutover evaluator; the subset checked
+by the continuous tag checks (M3) must still refuse anything that could
+widen the baseline exception (arbitrary refs, non-canonical schema).
+"""
+
+RECORD_PATH = ".skillstead/cutover-record.json"
+
+SCHEMA = "skillstead/cutover-record@1"
+
+PHASES = frozenset({"prepared", "aborted"})
+
+BASELINE_FINALIZATION_SHA = "3f92c4b3209c26d0b65129965d3cac63b8a1e9dd"
+
+BASELINE_TAGS = (
+    "refs/tags/docs-claim-check/v0.8.0",
+    "refs/tags/github-release-guide/v0.8.0",
+    "refs/tags/svg-infographic/v0.8.0",
+    "refs/tags/writing-quality-editor/v0.8.0",
+)
+
+LATEST_REF = "refs/tags/writing-quality-editor/v0.8.0"

--- a/tools/skillstead_validate/record_schema.py
+++ b/tools/skillstead_validate/record_schema.py
@@ -1,4 +1,4 @@
-"""Cutover-record canonical constants (DR-819 D8-1).
+"""Cutover-record canonical constants (fixed by the versioning decision record).
 
 These values are fixed by the decision record, not configuration. The full
 S1~S10 schema validation belongs to the cutover evaluator; the subset checked

--- a/tools/skillstead_validate/release_gate.py
+++ b/tools/skillstead_validate/release_gate.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from . import SEMVER_RE
+from . import SEMVER_RE, record_schema
 from .bump import default_step, step_of
 from .changelog import ChangelogError, topmost_released_version
 from .catalog import EN_HEADER, KO_HEADER, CatalogError, catalog_versions
@@ -248,19 +248,30 @@ def preflight(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[Fin
                         continue
                     try:
                         parent_table = catalog_versions(parent_text, header)
-                    except CatalogError:
+                    except CatalogError as err:
+                        # Unobservable parent state cannot prove the
+                        # same-commit condition (fail-closed — MR1R-F3).
+                        findings.append(Finding("D3-3", e.skill, f"parent {fname} catalog unreadable, same-commit introduction unprovable (fail-closed): {err}"))
                         continue
                     if e.skill in parent_table:
                         findings.append(Finding("D3-3", e.skill, f"{fname} catalog row existed before the target commit"))
 
     # I-10: inventory reduction requires an approved retirement marker; no
     # marker format exists until the playbook defines one — fail-closed.
-    # With no namespaced release at all AND an empty plan there is nothing to
-    # gate: pre-cutover no-op preflight is green (MR1-F8).
+    # No-op green must be activation-aware (MR1R-F8): "no namespaced release"
+    # is only pre-cutover when there is also no cutover-record trace in
+    # first-parent history — otherwise a full tag deletion would masquerade
+    # as the pre-cutover state and silence I-10.
     baseline_commit = _latest_release_commit(repo, target)
     if baseline_commit is None:
-        if plan.releases:
-            findings.append(Finding("I-10", "skills/", "no prior namespaced release observable from target (fail-closed)"))
+        try:
+            record_trace = git(repo, "log", "--first-parent", "--format=%H",
+                               target, "--", record_schema.RECORD_PATH).strip()
+        except GitError as e:
+            findings.append(Finding("GIT", record_schema.RECORD_PATH, f"record history unobservable (fail-closed): {e}"))
+            record_trace = "unobservable"
+        if plan.releases or record_trace:
+            findings.append(Finding("I-10", "skills/", "no prior namespaced release observable from target, but the state is not provably pre-cutover (fail-closed)"))
     else:
         try:
             before = dirs_at(repo, baseline_commit, "skills")

--- a/tools/skillstead_validate/release_gate.py
+++ b/tools/skillstead_validate/release_gate.py
@@ -1,0 +1,245 @@
+"""M2 release preflight and apply-tags (DR-819 E4·E5·E14; DR-818 §D2·§D3).
+
+Preflight judges a proposed release plan against the observed repository
+without mutating anything. ``apply_tags`` is the only supported tag-mutation
+path and re-runs preflight before creating refs. All observation failures are
+findings (fail-closed).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from . import SEMVER_RE
+from .bump import default_step, step_of
+from .changelog import ChangelogError, topmost_released_version
+from .catalog import EN_HEADER, KO_HEADER, CatalogError, catalog_versions
+from .findings import Finding
+from .frontmatter import FrontmatterError, parse_skill_frontmatter
+from .gitio import (GitError, dirs_at, file_at, first_parent_positions, git,
+                    peeled, tag_names)
+from .normalize import changed_payload_paths, payload_changed
+from .release_plan import ReleasePlan
+
+_SEMVER = re.compile(SEMVER_RE)
+_TAG_RE = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+\.\d+\.\d+)$")
+
+# D2-2: a human adjustment away from the path-default step must record its
+# reason. This line marker inside the release's CHANGELOG entry is the
+# machine-readable form (documented in docs/VERSIONING.md by this Work).
+ADJUSTMENT_MARKER = "Bump-Adjustment:"
+
+
+def namespace_tags(repo: Path, skill: str) -> dict[str, str]:
+    """{version: tag name} for one skill namespace; grammar violations excluded."""
+    result: dict[str, str] = {}
+    for name in tag_names(repo, f"{skill}/v*"):
+        m = _TAG_RE.match(name)
+        if m and m.group(1) == skill:
+            result[m.group(2)] = name
+    return result
+
+
+def previous_release(repo: Path, skill: str) -> tuple[str, str] | None:
+    """(version, tag name) of the previous release — highest version lineage
+    (DR-818 §D3-3), not creation time."""
+    tags = namespace_tags(repo, skill)
+    if not tags:
+        return None
+    version = max(tags, key=lambda v: tuple(int(x) for x in v.split(".")))
+    return version, tags[version]
+
+
+def _latest_release_commit(repo: Path, target: str) -> str | None:
+    """Target commit of the most recent namespaced release, by first-parent
+    order from ``target`` (I-10 baseline)."""
+    positions = first_parent_positions(repo, target)
+    best: tuple[int, str] | None = None
+    for name in tag_names(repo):
+        if not _TAG_RE.match(name):
+            continue
+        sha = peeled(repo, name)
+        if sha in positions:
+            if best is None or positions[sha] < best[0]:
+                best = (positions[sha], sha)
+    return best[1] if best else None
+
+
+def _entry_section(changelog_text: str, version: str) -> str | None:
+    lines = changelog_text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.startswith(f"## [{version}]"):
+            start = i
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if lines[j].startswith("## "):
+            end = j
+            break
+    return "\n".join(lines[start:end])
+
+
+def preflight(repo: Path, plan: ReleasePlan) -> list[Finding]:
+    findings: list[Finding] = []
+    try:
+        target = peeled(repo, plan.target_commit)
+    except GitError as e:
+        return [Finding("GIT", plan.target_commit, f"target unresolvable (fail-closed): {e}")]
+
+    try:
+        inventory = dirs_at(repo, target, "skills")
+    except GitError as e:
+        return [Finding("GIT", "skills/", f"inventory unobservable (fail-closed): {e}")]
+
+    # Per-entry structural checks.
+    for e in plan.releases:
+        if not _SEMVER.match(e.proposed_version):
+            findings.append(Finding("D3-3", e.skill, f"proposed_version {e.proposed_version!r} is not MAJOR.MINOR.PATCH"))
+            continue
+        expected_ref = f"refs/tags/{e.skill}/v{e.proposed_version}"
+        if e.proposed_ref != expected_ref:
+            findings.append(Finding("D3-3", e.skill, f"proposed_ref {e.proposed_ref!r} != {expected_ref!r}"))
+        if e.skill not in inventory:
+            findings.append(Finding("I-9", e.skill, "package absent at target commit"))
+            continue
+        # Tag uniqueness: same-precedence tag must not already exist.
+        existing = namespace_tags(repo, e.skill)
+        if e.proposed_version in existing:
+            findings.append(Finding("D3-3", e.skill, f"tag with version {e.proposed_version} already exists ({existing[e.proposed_version]})"))
+        prev = previous_release(repo, e.skill)
+        if e.previous_ref is None:
+            if prev is not None:
+                findings.append(Finding("D3-3", e.skill, f"previous_ref null but namespace has releases (latest {prev[1]})"))
+        else:
+            if prev is None:
+                findings.append(Finding("D3-3", e.skill, f"previous_ref {e.previous_ref!r} but namespace is empty"))
+            elif e.previous_ref not in (prev[1], f"refs/tags/{prev[1]}"):
+                findings.append(Finding("D3-3", e.skill, f"previous_ref {e.previous_ref!r} is not the previous release {prev[1]!r}"))
+    if findings:
+        return findings
+
+    # Changed-set equality (I-3 missing / I-4 extra) over previously released skills.
+    changed: set[str] = set()
+    for skill in sorted(inventory):
+        prev = previous_release(repo, skill)
+        if prev is None:
+            continue
+        try:
+            prev_target = peeled(repo, prev[1])
+            if payload_changed(repo, prev_target, target, skill):
+                changed.add(skill)
+        except GitError as e:
+            findings.append(Finding("GIT", skill, f"payload diff unobservable (fail-closed): {e}"))
+    planned_prior = {e.skill for e in plan.releases if e.previous_ref is not None}
+    for skill in sorted(changed - planned_prior):
+        findings.append(Finding("I-3", skill, "payload changed since previous release but not in release plan"))
+    for skill in sorted(planned_prior - changed):
+        findings.append(Finding("I-4", skill, "in release plan but payload unchanged (bookkeeping-only release)"))
+
+    # Per-entry release content checks.
+    for e in plan.releases:
+        skill_md = file_at(repo, target, f"skills/{e.skill}/SKILL.md")
+        changelog = file_at(repo, target, f"skills/{e.skill}/CHANGELOG.md")
+        if skill_md is None or changelog is None:
+            findings.append(Finding("I-9", e.skill, "SKILL.md or CHANGELOG.md absent at target"))
+            continue
+        try:
+            declared = parse_skill_frontmatter(skill_md).get("metadata.version")
+        except FrontmatterError as err:
+            findings.append(Finding("PARSE", e.skill, f"SKILL.md at target: {err}"))
+            continue
+        if declared != e.proposed_version:
+            findings.append(Finding("I-3", e.skill, f"metadata.version at target {declared!r} != proposed {e.proposed_version!r}"))
+        try:
+            top = topmost_released_version(changelog)
+        except ChangelogError as err:
+            findings.append(Finding("I-3", e.skill, f"CHANGELOG at target unreadable: {err}"))
+            continue
+        if top != e.proposed_version:
+            findings.append(Finding("I-3", e.skill, f"CHANGELOG topmost {top} != proposed {e.proposed_version} (new entry required)"))
+            continue
+
+        if e.previous_ref is not None:
+            prev = previous_release(repo, e.skill)
+            assert prev is not None  # structural checks passed
+            step = step_of(prev[0], e.proposed_version)
+            if step is None:
+                findings.append(Finding("I-6", e.skill, f"{prev[0]} -> {e.proposed_version} is not a single-step bump"))
+                continue
+            if step == "major":
+                findings.append(Finding("E14", e.skill, "major bump requires owner approval evidence; no evidence format exists yet (fail-closed)"))
+                continue
+            try:
+                prev_target = peeled(repo, prev[1])
+                paths = changed_payload_paths(repo, prev_target, target, e.skill)
+            except GitError as err:
+                findings.append(Finding("GIT", e.skill, f"changed paths unobservable (fail-closed): {err}"))
+                continue
+            default = default_step(paths)
+            if step != default:
+                section = _entry_section(changelog, e.proposed_version) or ""
+                if ADJUSTMENT_MARKER not in section:
+                    findings.append(Finding("I-6", e.skill, f"step {step} != path default {default} and CHANGELOG entry has no '{ADJUSTMENT_MARKER}' reason line"))
+        else:
+            # New-skill initial release (DR-818 §D3-3 ⓐ~ⓔ).
+            if e.proposed_version != "0.1.0":
+                findings.append(Finding("D3-3", e.skill, f"initial release must be 0.1.0, got {e.proposed_version}"))
+            license_ok = False
+            try:
+                fm = parse_skill_frontmatter(skill_md)
+                ptr = fm.get("license")
+                if ptr and file_at(repo, target, f"skills/{e.skill}/{ptr}") is not None:
+                    license_ok = True
+            except FrontmatterError:
+                pass
+            if not license_ok:
+                findings.append(Finding("I-9", e.skill, "license pointer must resolve at target (initial release)"))
+            for fname, header in (("README.md", EN_HEADER), ("README.ko.md", KO_HEADER)):
+                text = file_at(repo, target, fname)
+                if text is None:
+                    findings.append(Finding("I-7", e.skill, f"{fname} absent at target"))
+                    continue
+                try:
+                    table = catalog_versions(text, header)
+                except CatalogError as err:
+                    findings.append(Finding("I-7", e.skill, f"{fname}: {err}"))
+                    continue
+                if table.get(e.skill) != e.proposed_version:
+                    findings.append(Finding("I-7", e.skill, f"{fname} catalog row missing or version != {e.proposed_version} (initial release must add it in the same commit)"))
+
+    # I-10: inventory reduction requires an approved retirement marker; no
+    # marker format exists until the playbook defines one — fail-closed.
+    baseline_commit = _latest_release_commit(repo, target)
+    if baseline_commit is None:
+        findings.append(Finding("I-10", "skills/", "no prior namespaced release observable from target (fail-closed)"))
+    else:
+        try:
+            before = dirs_at(repo, baseline_commit, "skills")
+        except GitError as e:
+            findings.append(Finding("GIT", "skills/", f"I-10 baseline unobservable (fail-closed): {e}"))
+            before = None
+        if before is not None:
+            removed = before - inventory
+            if removed:
+                findings.append(Finding("I-10", ",".join(sorted(removed)), "inventory decreased without an approved retirement marker (fail-closed until the marker format is defined)"))
+
+    return findings
+
+
+def apply_tags(repo: Path, plan: ReleasePlan) -> list[str]:
+    """The only supported tag-mutation path: re-verify, then create the
+    planned tags at the target commit. Raises on any preflight finding."""
+    findings = preflight(repo, plan)
+    if findings:
+        raise RuntimeError("apply-tags refused; preflight findings:\n" + "\n".join(map(str, findings)))
+    target = peeled(repo, plan.target_commit)
+    created: list[str] = []
+    for e in plan.releases:
+        name = f"{e.skill}/v{e.proposed_version}"
+        git(repo, "tag", name, target)
+        created.append(name)
+    return created

--- a/tools/skillstead_validate/release_gate.py
+++ b/tools/skillstead_validate/release_gate.py
@@ -1,4 +1,4 @@
-"""M2 release preflight and apply-tags (DR-819 E4·E5·E14; DR-818 §D2·§D3).
+"""M2 release preflight and apply-tags (the payload-diff release gate).
 
 Preflight judges a proposed release plan against the observed repository
 without mutating anything. ``apply_tags`` is the only supported tag-mutation
@@ -45,7 +45,7 @@ def namespace_tags(repo: Path, skill: str) -> dict[str, str]:
 
 def previous_release(repo: Path, skill: str) -> tuple[str, str] | None:
     """(version, tag name) of the previous release — highest version lineage
-    (DR-818 §D3-3), not creation time."""
+    (version lineage, not creation time — see docs/VERSIONING.md)."""
     tags = namespace_tags(repo, skill)
     if not tags:
         return None
@@ -207,7 +207,7 @@ def preflight(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[Fin
                 if not _ADJUSTMENT_LINE.search(section):
                     findings.append(Finding("I-6", e.skill, f"step {step} != path default {default} and CHANGELOG entry has no standalone non-empty '{ADJUSTMENT_MARKER}' reason line"))
         else:
-            # New-skill initial release (DR-818 §D3-3 ⓐ~ⓔ).
+            # New-skill initial release (all artifacts land in one commit).
             if e.proposed_version != "0.1.0":
                 findings.append(Finding("D3-3", e.skill, f"initial release must be 0.1.0, got {e.proposed_version}"))
             license_ok = False
@@ -286,17 +286,27 @@ def preflight(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[Fin
     return findings
 
 
-def apply_tags(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[str]:
-    """The only supported tag-mutation path: re-verify, then create the
-    planned tags at the target commit in a single ref transaction (a partial
-    failure must not leave a subset of the tags behind). Raises on any
-    preflight finding. The remote boundary uses ``git push --atomic`` and is
-    wired by the release wrapper."""
+def apply_tags(repo: Path, plan: ReleasePlan, main_ref: str = "main",
+               remote: str = "origin") -> list[str]:
+    """The only supported tag-mutation path: re-verify, create the planned
+    tags locally in a single ref transaction, then PUBLISH them to the
+    remote with ``git push --atomic`` (R1-F1 — a local-only ref is not a
+    release, and the wrapper's ``--verify-tag`` checks the remote). A push
+    failure rolls the local refs back so the attempt leaves no half-state
+    and a retry is not blocked. Raises on any preflight finding or
+    publication failure (fail-closed)."""
     findings = preflight(repo, plan, main_ref)
     if findings:
         raise RuntimeError("apply-tags refused; preflight findings:\n" + "\n".join(map(str, findings)))
     target = peeled(repo, plan.target_commit)
     names = [f"{e.skill}/v{e.proposed_version}" for e in plan.releases]
-    stdin = "".join(f"create refs/tags/{name} {target}\n" for name in names)
-    git(repo, "update-ref", "--stdin", input_text=stdin)
+    refs = [f"refs/tags/{name}" for name in names]
+    git(repo, "update-ref", "--stdin",
+        input_text="".join(f"create {ref} {target}\n" for ref in refs))
+    try:
+        git(repo, "push", "--atomic", remote, *refs)
+    except GitError as e:
+        git(repo, "update-ref", "--stdin",
+            input_text="".join(f"delete {ref} {target}\n" for ref in refs))
+        raise RuntimeError(f"apply-tags: atomic publication to {remote!r} failed; local refs rolled back (fail-closed): {e}") from None
     return names

--- a/tools/skillstead_validate/release_gate.py
+++ b/tools/skillstead_validate/release_gate.py
@@ -20,15 +20,17 @@ from .frontmatter import FrontmatterError, parse_skill_frontmatter
 from .gitio import (GitError, dirs_at, file_at, first_parent_positions, git,
                     peeled, tag_names)
 from .normalize import changed_payload_paths, payload_changed
+from .package_check import run_repo_validation_at
 from .release_plan import ReleasePlan
 
 _SEMVER = re.compile(SEMVER_RE)
 _TAG_RE = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+\.\d+\.\d+)$")
 
 # D2-2: a human adjustment away from the path-default step must record its
-# reason. This line marker inside the release's CHANGELOG entry is the
-# machine-readable form (documented in docs/VERSIONING.md by this Work).
+# reason. The reason must be a standalone, non-empty marker line inside the
+# release's CHANGELOG entry (documented in docs/VERSIONING.md by this Work).
 ADJUSTMENT_MARKER = "Bump-Adjustment:"
+_ADJUSTMENT_LINE = re.compile(r"^Bump-Adjustment:[ \t]+\S.*$", re.MULTILINE)
 
 
 def namespace_tags(repo: Path, skill: str) -> dict[str, str]:
@@ -83,12 +85,23 @@ def _entry_section(changelog_text: str, version: str) -> str | None:
     return "\n".join(lines[start:end])
 
 
-def preflight(repo: Path, plan: ReleasePlan) -> list[Finding]:
+def preflight(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[Finding]:
     findings: list[Finding] = []
     try:
         target = peeled(repo, plan.target_commit)
     except GitError as e:
         return [Finding("GIT", plan.target_commit, f"target unresolvable (fail-closed): {e}")]
+
+    # The tag target must be a main first-parent commit (I-8 pre-mutation).
+    try:
+        positions = first_parent_positions(repo, main_ref)
+    except GitError as e:
+        return [Finding("GIT", main_ref, f"main history unobservable (fail-closed): {e}")]
+    if target not in positions:
+        return [Finding("I-8", plan.target_commit, f"target {target[:12]} is not on {main_ref} first-parent history")]
+    ordered = sorted(positions, key=positions.__getitem__)
+    idx = positions[target]
+    target_parent = ordered[idx + 1] if idx + 1 < len(ordered) else None
 
     try:
         inventory = dirs_at(repo, target, "skills")
@@ -106,10 +119,14 @@ def preflight(repo: Path, plan: ReleasePlan) -> list[Finding]:
         if e.skill not in inventory:
             findings.append(Finding("I-9", e.skill, "package absent at target commit"))
             continue
-        # Tag uniqueness: same-precedence tag must not already exist.
-        existing = namespace_tags(repo, e.skill)
-        if e.proposed_version in existing:
-            findings.append(Finding("D3-3", e.skill, f"tag with version {e.proposed_version} already exists ({existing[e.proposed_version]})"))
+        # Tag uniqueness: no existing tag may share the SemVer precedence —
+        # including grammar-violating aliases like `v1.3.0+build` (build
+        # metadata does not change precedence).
+        for name in tag_names(repo, f"{e.skill}/v*"):
+            rest = name[len(e.skill) + 2:]
+            if rest == e.proposed_version or rest.startswith(e.proposed_version + "+") \
+                    or rest.startswith(e.proposed_version + "-"):
+                findings.append(Finding("D3-3", e.skill, f"tag {name!r} shares the precedence of {e.proposed_version}"))
         prev = previous_release(repo, e.skill)
         if e.previous_ref is None:
             if prev is not None:
@@ -121,6 +138,11 @@ def preflight(repo: Path, plan: ReleasePlan) -> list[Finding]:
                 findings.append(Finding("D3-3", e.skill, f"previous_ref {e.previous_ref!r} is not the previous release {prev[1]!r}"))
     if findings:
         return findings
+
+    # Release-gate axis of I-1·I-7·I-9: the target commit must satisfy the
+    # full package + catalog validation (MR1-F1 — a deleted licence copy or a
+    # stale KO Version cell is a release defect, not only a CI-axis one).
+    findings.extend(run_repo_validation_at(repo, target))
 
     # Changed-set equality (I-3 missing / I-4 extra) over previously released skills.
     changed: set[str] = set()
@@ -182,8 +204,8 @@ def preflight(repo: Path, plan: ReleasePlan) -> list[Finding]:
             default = default_step(paths)
             if step != default:
                 section = _entry_section(changelog, e.proposed_version) or ""
-                if ADJUSTMENT_MARKER not in section:
-                    findings.append(Finding("I-6", e.skill, f"step {step} != path default {default} and CHANGELOG entry has no '{ADJUSTMENT_MARKER}' reason line"))
+                if not _ADJUSTMENT_LINE.search(section):
+                    findings.append(Finding("I-6", e.skill, f"step {step} != path default {default} and CHANGELOG entry has no standalone non-empty '{ADJUSTMENT_MARKER}' reason line"))
         else:
             # New-skill initial release (DR-818 §D3-3 ⓐ~ⓔ).
             if e.proposed_version != "0.1.0":
@@ -210,12 +232,35 @@ def preflight(repo: Path, plan: ReleasePlan) -> list[Finding]:
                     continue
                 if table.get(e.skill) != e.proposed_version:
                     findings.append(Finding("I-7", e.skill, f"{fname} catalog row missing or version != {e.proposed_version} (initial release must add it in the same commit)"))
+            # §D3-3 ⓒ~ⓔ land in ONE commit: neither the package nor a catalog
+            # row may predate the target commit (MR1-F3).
+            if target_parent is not None:
+                try:
+                    parent_dirs = dirs_at(repo, target_parent, "skills")
+                except GitError as err:
+                    findings.append(Finding("GIT", e.skill, f"parent inventory unobservable (fail-closed): {err}"))
+                    parent_dirs = set()
+                if e.skill in parent_dirs:
+                    findings.append(Finding("D3-3", e.skill, "package existed before the target commit — initial release must introduce ⓒ~ⓔ in one commit"))
+                for fname, header in (("README.md", EN_HEADER), ("README.ko.md", KO_HEADER)):
+                    parent_text = file_at(repo, target_parent, fname)
+                    if parent_text is None:
+                        continue
+                    try:
+                        parent_table = catalog_versions(parent_text, header)
+                    except CatalogError:
+                        continue
+                    if e.skill in parent_table:
+                        findings.append(Finding("D3-3", e.skill, f"{fname} catalog row existed before the target commit"))
 
     # I-10: inventory reduction requires an approved retirement marker; no
     # marker format exists until the playbook defines one — fail-closed.
+    # With no namespaced release at all AND an empty plan there is nothing to
+    # gate: pre-cutover no-op preflight is green (MR1-F8).
     baseline_commit = _latest_release_commit(repo, target)
     if baseline_commit is None:
-        findings.append(Finding("I-10", "skills/", "no prior namespaced release observable from target (fail-closed)"))
+        if plan.releases:
+            findings.append(Finding("I-10", "skills/", "no prior namespaced release observable from target (fail-closed)"))
     else:
         try:
             before = dirs_at(repo, baseline_commit, "skills")
@@ -230,16 +275,17 @@ def preflight(repo: Path, plan: ReleasePlan) -> list[Finding]:
     return findings
 
 
-def apply_tags(repo: Path, plan: ReleasePlan) -> list[str]:
+def apply_tags(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[str]:
     """The only supported tag-mutation path: re-verify, then create the
-    planned tags at the target commit. Raises on any preflight finding."""
-    findings = preflight(repo, plan)
+    planned tags at the target commit in a single ref transaction (a partial
+    failure must not leave a subset of the tags behind). Raises on any
+    preflight finding. The remote boundary uses ``git push --atomic`` and is
+    wired by the release wrapper."""
+    findings = preflight(repo, plan, main_ref)
     if findings:
         raise RuntimeError("apply-tags refused; preflight findings:\n" + "\n".join(map(str, findings)))
     target = peeled(repo, plan.target_commit)
-    created: list[str] = []
-    for e in plan.releases:
-        name = f"{e.skill}/v{e.proposed_version}"
-        git(repo, "tag", name, target)
-        created.append(name)
-    return created
+    names = [f"{e.skill}/v{e.proposed_version}" for e in plan.releases]
+    stdin = "".join(f"create refs/tags/{name} {target}\n" for name in names)
+    git(repo, "update-ref", "--stdin", input_text=stdin)
+    return names

--- a/tools/skillstead_validate/release_gate.py
+++ b/tools/skillstead_validate/release_gate.py
@@ -298,9 +298,14 @@ def apply_tags(repo: Path, plan: ReleasePlan, main_ref: str = "main",
     findings = preflight(repo, plan, main_ref)
     if findings:
         raise RuntimeError("apply-tags refused; preflight findings:\n" + "\n".join(map(str, findings)))
-    target = peeled(repo, plan.target_commit)
     names = [f"{e.skill}/v{e.proposed_version}" for e in plan.releases]
     refs = [f"refs/tags/{name}" for name in names]
+    if not refs:
+        # A refspec-less `git push` falls back to the default push behavior
+        # and would move the CURRENT BRANCH on the remote — an empty plan
+        # must be a strict no-op (R1R-F1).
+        return []
+    target = peeled(repo, plan.target_commit)
     git(repo, "update-ref", "--stdin",
         input_text="".join(f"create {ref} {target}\n" for ref in refs))
     try:

--- a/tools/skillstead_validate/release_plan.py
+++ b/tools/skillstead_validate/release_plan.py
@@ -1,0 +1,82 @@
+"""Release plan input for M2 (strict, fail-closed parsing).
+
+Shape:
+    {
+      "target_commit": "<sha or ref>",
+      "releases": [
+        {"skill": ..., "previous_ref": <ref or null>,
+         "proposed_version": "X.Y.Z", "proposed_ref": "refs/tags/<skill>/vX.Y.Z"}
+      ]
+    }
+
+Duplicate JSON keys are rejected — parsers disagree on last-wins vs
+first-wins, so a duplicated key has no single value.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+
+class PlanError(ValueError):
+    """Raised when the plan cannot be accepted as a single unambiguous value."""
+
+
+def _no_duplicates(pairs: list[tuple[str, object]]) -> dict:
+    d: dict = {}
+    for k, v in pairs:
+        if k in d:
+            raise PlanError(f"duplicate JSON key: {k!r}")
+        d[k] = v
+    return d
+
+
+@dataclass(frozen=True)
+class PlanEntry:
+    skill: str
+    previous_ref: str | None
+    proposed_version: str
+    proposed_ref: str
+
+
+@dataclass(frozen=True)
+class ReleasePlan:
+    target_commit: str
+    releases: tuple[PlanEntry, ...]
+
+
+_TOP_KEYS = {"target_commit", "releases"}
+_ENTRY_KEYS = {"skill", "previous_ref", "proposed_version", "proposed_ref"}
+
+
+def parse_plan(text: str) -> ReleasePlan:
+    try:
+        raw = json.loads(text, object_pairs_hook=_no_duplicates)
+    except json.JSONDecodeError as e:
+        raise PlanError(f"invalid JSON: {e}") from None
+    if not isinstance(raw, dict) or set(raw) != _TOP_KEYS:
+        raise PlanError(f"top-level keys must be exactly {sorted(_TOP_KEYS)}")
+    if not isinstance(raw["target_commit"], str) or not raw["target_commit"]:
+        raise PlanError("target_commit must be a non-empty string")
+    if not isinstance(raw["releases"], list):
+        raise PlanError("releases must be an array")
+    entries: list[PlanEntry] = []
+    seen: set[str] = set()
+    for item in raw["releases"]:
+        if not isinstance(item, dict) or set(item) != _ENTRY_KEYS:
+            raise PlanError(f"release entry keys must be exactly {sorted(_ENTRY_KEYS)}")
+        if not isinstance(item["skill"], str) or not item["skill"]:
+            raise PlanError("skill must be a non-empty string")
+        if item["previous_ref"] is not None and not isinstance(item["previous_ref"], str):
+            raise PlanError("previous_ref must be a string or null")
+        for key in ("proposed_version", "proposed_ref"):
+            if not isinstance(item[key], str) or not item[key]:
+                raise PlanError(f"{key} must be a non-empty string")
+        if item["skill"] in seen:
+            raise PlanError(f"duplicate release entry for skill {item['skill']!r}")
+        seen.add(item["skill"])
+        entries.append(PlanEntry(
+            skill=item["skill"], previous_ref=item["previous_ref"],
+            proposed_version=item["proposed_version"], proposed_ref=item["proposed_ref"]))
+    return ReleasePlan(target_commit=raw["target_commit"], releases=tuple(entries))

--- a/tools/skillstead_validate/source.py
+++ b/tools/skillstead_validate/source.py
@@ -34,9 +34,20 @@ class WorktreeSource(Source):
     def __init__(self, root: Path) -> None:
         self.root = root
 
+    def _resolve(self, rel: str) -> Path | None:
+        """Reject any path with a symlink component (fail-closed): a
+        symlinked licence or package directory would satisfy the checks
+        while escaping the self-contained-package contract (R1-F3)."""
+        path = self.root
+        for part in Path(rel).parts:
+            path = path / part
+            if path.is_symlink():
+                return None
+        return path if path.is_file() else None
+
     def read_text(self, rel: str) -> str | None:
-        path = self.root / rel
-        if not path.is_file():
+        path = self._resolve(rel)
+        if path is None:
             return None
         try:
             return path.read_text(encoding="utf-8")
@@ -44,8 +55,8 @@ class WorktreeSource(Source):
             return None
 
     def blob_id(self, rel: str) -> str | None:
-        path = self.root / rel
-        if not path.is_file():
+        path = self._resolve(rel)
+        if path is None:
             return None
         return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -61,10 +72,24 @@ class CommitSource(Source):
         self.repo = repo
         self.commit = commit
 
+    def _is_symlink(self, rel: str) -> bool:
+        """Symlinks live in git trees as mode-120000 blobs whose content is
+        the link target — reading one would validate the target string, not
+        a file. Reject them like the worktree source does (R1-F3)."""
+        try:
+            out = git(self.repo, "ls-tree", self.commit, "--", rel)
+        except GitError:
+            return False
+        return out.startswith("120000 ")
+
     def read_text(self, rel: str) -> str | None:
+        if self._is_symlink(rel):
+            return None
         return file_at(self.repo, self.commit, rel)
 
     def blob_id(self, rel: str) -> str | None:
+        if self._is_symlink(rel):
+            return None
         try:
             return git(self.repo, "rev-parse", f"{self.commit}:{rel}").strip()
         except GitError:

--- a/tools/skillstead_validate/source.py
+++ b/tools/skillstead_validate/source.py
@@ -1,0 +1,77 @@
+"""File-source abstraction so the same package checks run against a working
+tree (M1) or an arbitrary commit (M2 preflight at the release target)."""
+
+from __future__ import annotations
+
+import hashlib
+import posixpath
+from pathlib import Path
+
+from .gitio import GitError, dirs_at, file_at, git
+
+
+class Source:
+    """Read-only view of a repository state."""
+
+    def read_text(self, rel: str) -> str | None:
+        raise NotImplementedError
+
+    def blob_id(self, rel: str) -> str | None:
+        """Content identity token: equal ids ⟺ byte-equal content."""
+        raise NotImplementedError
+
+    def skill_dirs(self) -> list[str]:
+        raise NotImplementedError
+
+    @staticmethod
+    def inside_package(skill: str, pointer: str) -> bool:
+        """Path-containment check for license pointers (no filesystem)."""
+        joined = posixpath.normpath(posixpath.join("skills", skill, pointer))
+        return joined.startswith(f"skills/{skill}/")
+
+
+class WorktreeSource(Source):
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def read_text(self, rel: str) -> str | None:
+        path = self.root / rel
+        if not path.is_file():
+            return None
+        try:
+            return path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            return None
+
+    def blob_id(self, rel: str) -> str | None:
+        path = self.root / rel
+        if not path.is_file():
+            return None
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    def skill_dirs(self) -> list[str]:
+        skills = self.root / "skills"
+        if not skills.is_dir():
+            return []
+        return sorted(p.name for p in skills.iterdir() if p.is_dir())
+
+
+class CommitSource(Source):
+    def __init__(self, repo: Path, commit: str) -> None:
+        self.repo = repo
+        self.commit = commit
+
+    def read_text(self, rel: str) -> str | None:
+        return file_at(self.repo, self.commit, rel)
+
+    def blob_id(self, rel: str) -> str | None:
+        try:
+            return git(self.repo, "rev-parse", f"{self.commit}:{rel}").strip()
+        except GitError:
+            return None
+
+    def skill_dirs(self) -> list[str]:
+        try:
+            return sorted(dirs_at(self.repo, self.commit, "skills"))
+        except GitError:
+            return []

--- a/tools/skillstead_validate/tag_check.py
+++ b/tools/skillstead_validate/tag_check.py
@@ -1,0 +1,215 @@
+"""M3 continuous tag checks (DR-819 E6 first half; DR-818 §D3-2, DR-819 D6).
+
+Runs on every CI execution, not once at tag creation — tags are mutable, so
+creation-time checks guarantee nothing durable. Checks:
+
+* I-2  — the peeled target declares exactly the tag's version.
+* I-8  — the peeled target is a commit on ``main``.
+* I-3-ⓒ — durable relation: the expected target is derived *without looking
+  at the tag*. General tags: the oldest ``main`` first-parent commit where the
+  skill's declared version changed to the tag's version. Baseline tags (exact
+  ref membership in the cutover record's ``baseline_tags``): the first-parent
+  commit where the record with the current ``attempt`` was introduced.
+* I-5  — partial deletion of a multi-skill release: every skill whose version
+  changed at an observed release commit must still have its tag there.
+
+Comparisons use peeled commit SHAs (annotated and lightweight tags mix in
+this repository's history). Every unobservable input is a finding
+(fail-closed).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from .findings import Finding
+from .frontmatter import FrontmatterError, parse_skill_frontmatter
+from .gitio import GitError, dirs_at, file_at, git, peeled, tag_names
+
+RECORD_PATH = ".skillstead/cutover-record.json"
+_TAG_RE = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+\.\d+\.\d+)$")
+_TAG_SHAPE = re.compile(r"^[^/]+/v")
+
+
+class _RecordError(ValueError):
+    pass
+
+
+def _no_duplicates(pairs: list[tuple[str, object]]) -> dict:
+    d: dict = {}
+    for k, v in pairs:
+        if k in d:
+            raise _RecordError(f"duplicate JSON key: {k!r}")
+        d[k] = v
+    return d
+
+
+def _record_at(repo: Path, commit: str) -> dict | None:
+    """Minimal record read for M3: ``baseline_tags`` membership and
+    ``attempt`` only. Full S1~S10 schema validation belongs to the cutover
+    evaluator (M4). Unparseable content raises (fail-closed)."""
+    text = file_at(repo, commit, RECORD_PATH)
+    if text is None:
+        return None
+    try:
+        raw = json.loads(text, object_pairs_hook=_no_duplicates)
+    except (json.JSONDecodeError, _RecordError) as e:
+        raise _RecordError(str(e)) from None
+    if not isinstance(raw, dict):
+        raise _RecordError("record is not a JSON object")
+    tags = raw.get("baseline_tags")
+    attempt = raw.get("attempt")
+    if not isinstance(tags, list) or not all(isinstance(t, str) for t in tags):
+        raise _RecordError("baseline_tags must be a string array")
+    if not isinstance(attempt, int):
+        raise _RecordError("attempt must be an integer")
+    return {"baseline_tags": tags, "attempt": attempt}
+
+
+class _History:
+    """Cached first-parent observations along ``main``."""
+
+    def __init__(self, repo: Path, main_tip: str) -> None:
+        self.repo = repo
+        out = git(repo, "log", "--first-parent", "--format=%H", main_tip)
+        self.commits: list[str] = out.split()  # tip first
+        self._versions: dict[tuple[str, str], str | None] = {}
+
+    def version_at(self, commit: str, skill: str) -> str | None:
+        key = (commit, skill)
+        if key not in self._versions:
+            text = file_at(self.repo, commit, f"skills/{skill}/SKILL.md")
+            version: str | None = None
+            if text is not None:
+                try:
+                    version = parse_skill_frontmatter(text).get("metadata.version")
+                except FrontmatterError:
+                    version = None
+            self._versions[key] = version
+        return self._versions[key]
+
+    def oldest_version_change(self, skill: str, version: str) -> str | None:
+        """Oldest first-parent commit where the skill's declared version
+        changed to ``version`` (root counts as a change)."""
+        found: str | None = None
+        for i, commit in enumerate(self.commits):
+            if self.version_at(commit, skill) != version:
+                continue
+            parent = self.commits[i + 1] if i + 1 < len(self.commits) else None
+            if parent is None or self.version_at(parent, skill) != version:
+                found = commit  # keep scanning: oldest (deepest) wins
+        return found
+
+    def record_intro(self, attempt: int) -> str | None:
+        """Oldest first-parent commit whose record carries ``attempt``."""
+        found: str | None = None
+        for commit in self.commits:
+            try:
+                record = _record_at(self.repo, commit)
+            except _RecordError:
+                continue
+            if record is not None and record["attempt"] == attempt:
+                found = commit
+        return found
+
+
+def run_tag_checks(repo: Path, main_ref: str = "main") -> list[Finding]:
+    findings: list[Finding] = []
+    try:
+        main_tip = peeled(repo, main_ref)
+        history = _History(repo, main_tip)
+    except GitError as e:
+        return [Finding("GIT", main_ref, f"main history unobservable (fail-closed): {e}")]
+
+    record: dict | None = None
+    try:
+        record = _record_at(repo, main_tip)
+    except _RecordError as e:
+        findings.append(Finding("RECORD", RECORD_PATH, f"record unreadable (fail-closed): {e}"))
+    baseline_refs = set(record["baseline_tags"]) if record else set()
+
+    record_intro: str | None = None
+    if record is not None:
+        record_intro = history.record_intro(record["attempt"])
+        if record_intro is None:
+            findings.append(Finding("RECORD", RECORD_PATH, f"no first-parent commit introduces attempt {record['attempt']} (fail-closed)"))
+
+    try:
+        all_tags = tag_names(repo)
+    except GitError as e:
+        findings.append(Finding("GIT", "tags", f"tag list unobservable (fail-closed): {e}"))
+        return findings
+
+    namespaced: dict[str, tuple[str, str]] = {}  # name -> (skill, version)
+    for name in all_tags:
+        m = _TAG_RE.match(name)
+        if m:
+            namespaced[name] = (m.group(1), m.group(2))
+        elif _TAG_SHAPE.match(name):
+            findings.append(Finding("D3-3", name, "tag violates <name>/vMAJOR.MINOR.PATCH grammar"))
+
+    targets: dict[str, str] = {}
+    for name, (skill, version) in sorted(namespaced.items()):
+        try:
+            target = peeled(repo, name)
+        except GitError as e:
+            findings.append(Finding("GIT", name, f"tag target unobservable (fail-closed): {e}"))
+            continue
+        targets[name] = target
+
+        # I-8: target must be a commit on main.
+        try:
+            git(repo, "merge-base", "--is-ancestor", target, main_tip)
+            on_main = True
+        except GitError:
+            on_main = False
+        if not on_main:
+            findings.append(Finding("I-8", name, f"target {target[:12]} is not on {main_ref}"))
+
+        # I-2: declared version at the target equals the tag version.
+        declared = history.version_at(target, skill)
+        if declared != version:
+            findings.append(Finding("I-2", name, f"metadata.version at target is {declared!r}, tag says {version!r}"))
+
+        # I-3-ⓒ: expected target derived independently of the tag.
+        full_ref = f"refs/tags/{name}"
+        if full_ref in baseline_refs:
+            if record_intro is not None and target != record_intro:
+                findings.append(Finding("I-3-c", name, f"baseline tag target {target[:12]} != record introduction commit {record_intro[:12]}"))
+        else:
+            expected = history.oldest_version_change(skill, version) if on_main else None
+            if expected is None:
+                findings.append(Finding("I-3-c", name, f"no main first-parent commit introduces version {version} for {skill} (fail-closed)"))
+            elif target != expected:
+                findings.append(Finding("I-3-c", name, f"target {target[:12]} != expected {expected[:12]} (repoint suspected)"))
+
+    # I-5: at every observed release commit, every skill whose version changed
+    # there must still have its tag. Existence only — target correctness is
+    # I-3-ⓒ's job, and merging the two would leak the baseline exception into
+    # I-5 (DR-819 D6 requires the separation).
+    release_commits = set(targets.values())
+    position = {c: i for i, c in enumerate(history.commits)}
+    for commit in sorted(release_commits):
+        if commit not in position:
+            continue  # off-main targets already reported via I-8
+        idx = position[commit]
+        parent = history.commits[idx + 1] if idx + 1 < len(history.commits) else None
+        try:
+            skills_here = dirs_at(repo, commit, "skills")
+        except GitError as e:
+            findings.append(Finding("GIT", commit[:12], f"inventory unobservable (fail-closed): {e}"))
+            continue
+        for skill in sorted(skills_here):
+            version = history.version_at(commit, skill)
+            if version is None:
+                continue
+            changed = parent is None or history.version_at(parent, skill) != version
+            if not changed:
+                continue
+            tag = f"{skill}/v{version}"
+            if tag not in targets:
+                findings.append(Finding("I-5", tag, f"version changed at {commit[:12]} but the tag does not exist (partial deletion suspected)"))
+
+    return findings

--- a/tools/skillstead_validate/tag_check.py
+++ b/tools/skillstead_validate/tag_check.py
@@ -24,11 +24,12 @@ import json
 import re
 from pathlib import Path
 
+from . import record_schema
 from .findings import Finding
 from .frontmatter import FrontmatterError, parse_skill_frontmatter
 from .gitio import GitError, dirs_at, file_at, git, peeled, tag_names
 
-RECORD_PATH = ".skillstead/cutover-record.json"
+RECORD_PATH = record_schema.RECORD_PATH
 _TAG_RE = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+\.\d+\.\d+)$")
 _TAG_SHAPE = re.compile(r"^[^/]+/v")
 
@@ -47,9 +48,11 @@ def _no_duplicates(pairs: list[tuple[str, object]]) -> dict:
 
 
 def _record_at(repo: Path, commit: str) -> dict | None:
-    """Minimal record read for M3: ``baseline_tags`` membership and
-    ``attempt`` only. Full S1~S10 schema validation belongs to the cutover
-    evaluator (M4). Unparseable content raises (fail-closed)."""
+    """Record read for M3. Full S1~S10 belongs to the cutover evaluator, but
+    every field M3 *trusts* is validated against the canonical constants —
+    an arbitrary ``baseline_tags`` array would let a forged record widen the
+    baseline exception and bypass the durable relation (MR1-F5).
+    Unacceptable content raises (fail-closed)."""
     text = file_at(repo, commit, RECORD_PATH)
     if text is None:
         return None
@@ -59,12 +62,16 @@ def _record_at(repo: Path, commit: str) -> dict | None:
         raise _RecordError(str(e)) from None
     if not isinstance(raw, dict):
         raise _RecordError("record is not a JSON object")
-    tags = raw.get("baseline_tags")
+    if raw.get("schema") != record_schema.SCHEMA:
+        raise _RecordError(f"schema must be {record_schema.SCHEMA!r}")
+    if raw.get("phase") not in record_schema.PHASES:
+        raise _RecordError("phase must be 'prepared' or 'aborted'")
     attempt = raw.get("attempt")
-    if not isinstance(tags, list) or not all(isinstance(t, str) for t in tags):
-        raise _RecordError("baseline_tags must be a string array")
-    if not isinstance(attempt, int):
-        raise _RecordError("attempt must be an integer")
+    if not isinstance(attempt, int) or isinstance(attempt, bool) or attempt < 1:
+        raise _RecordError("attempt must be an integer >= 1")
+    tags = raw.get("baseline_tags")
+    if tags != list(record_schema.BASELINE_TAGS):
+        raise _RecordError("baseline_tags must equal the canonical four refs in order")
     return {"baseline_tags": tags, "attempt": attempt}
 
 
@@ -102,17 +109,21 @@ class _History:
                 found = commit  # keep scanning: oldest (deepest) wins
         return found
 
-    def record_intro(self, attempt: int) -> str | None:
-        """Oldest first-parent commit whose record carries ``attempt``."""
+    def record_intro(self, attempt: int) -> tuple[str | None, list[str]]:
+        """Oldest first-parent commit whose record carries ``attempt``, plus
+        the commits where a record exists but cannot be accepted — those are
+        fail-closed findings, not silent skips (MR1-F5)."""
         found: str | None = None
+        bad: list[str] = []
         for commit in self.commits:
             try:
                 record = _record_at(self.repo, commit)
             except _RecordError:
+                bad.append(commit)
                 continue
             if record is not None and record["attempt"] == attempt:
                 found = commit
-        return found
+        return found, bad
 
 
 def run_tag_checks(repo: Path, main_ref: str = "main") -> list[Finding]:
@@ -132,7 +143,9 @@ def run_tag_checks(repo: Path, main_ref: str = "main") -> list[Finding]:
 
     record_intro: str | None = None
     if record is not None:
-        record_intro = history.record_intro(record["attempt"])
+        record_intro, bad_commits = history.record_intro(record["attempt"])
+        for commit in bad_commits:
+            findings.append(Finding("RECORD", RECORD_PATH, f"record at {commit[:12]} is unreadable or non-canonical (fail-closed)"))
         if record_intro is None:
             findings.append(Finding("RECORD", RECORD_PATH, f"no first-parent commit introduces attempt {record['attempt']} (fail-closed)"))
 
@@ -185,31 +198,55 @@ def run_tag_checks(repo: Path, main_ref: str = "main") -> list[Finding]:
             elif target != expected:
                 findings.append(Finding("I-3-c", name, f"target {target[:12]} != expected {expected[:12]} (repoint suspected)"))
 
-    # I-5: at every observed release commit, every skill whose version changed
-    # there must still have its tag. Existence only — target correctness is
-    # I-3-ⓒ's job, and merging the two would leak the baseline exception into
-    # I-5 (DR-819 D6 requires the separation).
-    release_commits = set(targets.values())
+    # I-5: existence only — target correctness is I-3-ⓒ's job, and merging
+    # the two would leak the baseline exception into I-5 (DR-819 D6 requires
+    # the separation). Two derivations of the expected set:
+    #
+    # 1. Existing-tag anchored (works pre-record): at every observed release
+    #    commit, every skill whose version changed there must have its tag.
+    # 2. Record anchored (MR1-F6 — catches FULL deletion): from the record
+    #    introduction commit to the tip, every first-parent version change
+    #    must have its tag. Derived without looking at existing tags.
+    #
+    # Baseline refs are checked directly against the record list: all four
+    # must exist once any of them exists; zero existing baseline refs is the
+    # pending window the cutover evaluator owns, so M3 stays silent there.
+    reported_i5: set[str] = set()
     position = {c: i for i, c in enumerate(history.commits)}
-    for commit in sorted(release_commits):
-        if commit not in position:
-            continue  # off-main targets already reported via I-8
+
+    def _expect_changes_at(commit: str) -> None:
         idx = position[commit]
         parent = history.commits[idx + 1] if idx + 1 < len(history.commits) else None
         try:
             skills_here = dirs_at(repo, commit, "skills")
         except GitError as e:
             findings.append(Finding("GIT", commit[:12], f"inventory unobservable (fail-closed): {e}"))
-            continue
+            return
         for skill in sorted(skills_here):
             version = history.version_at(commit, skill)
             if version is None:
                 continue
-            changed = parent is None or history.version_at(parent, skill) != version
-            if not changed:
+            if parent is not None and history.version_at(parent, skill) == version:
                 continue
             tag = f"{skill}/v{version}"
-            if tag not in targets:
-                findings.append(Finding("I-5", tag, f"version changed at {commit[:12]} but the tag does not exist (partial deletion suspected)"))
+            if f"refs/tags/{tag}" in baseline_refs:
+                continue  # baseline existence is checked from the record list
+            if tag not in targets and tag not in reported_i5:
+                reported_i5.add(tag)
+                findings.append(Finding("I-5", tag, f"version changed at {commit[:12]} but the tag does not exist (deletion suspected)"))
+
+    for commit in sorted(set(targets.values())):
+        if commit in position:  # off-main targets already reported via I-8
+            _expect_changes_at(commit)
+
+    if record is not None and record_intro is not None:
+        existing_refs = {f"refs/tags/{name}" for name in namespaced}
+        present = [r for r in baseline_refs if r in existing_refs]
+        if present and len(present) < len(baseline_refs):
+            for ref in sorted(set(baseline_refs) - set(present)):
+                findings.append(Finding("I-5", ref, "baseline ref missing while others exist (partial deletion of the baseline set)"))
+        intro_idx = position.get(record_intro, len(history.commits))
+        for commit in history.commits[:intro_idx + 1]:
+            _expect_changes_at(commit)
 
     return findings

--- a/tools/skillstead_validate/tag_check.py
+++ b/tools/skillstead_validate/tag_check.py
@@ -1,4 +1,4 @@
-"""M3 continuous tag checks (DR-819 E6 first half; DR-818 §D3-2, DR-819 D6).
+"""M3 continuous tag checks (tag invariants and the durable expected-target relation).
 
 Runs on every CI execution, not once at tag creation — tags are mutable, so
 creation-time checks guarantee nothing durable. Checks:
@@ -199,7 +199,7 @@ def run_tag_checks(repo: Path, main_ref: str = "main") -> list[Finding]:
                 findings.append(Finding("I-3-c", name, f"target {target[:12]} != expected {expected[:12]} (repoint suspected)"))
 
     # I-5: existence only — target correctness is I-3-ⓒ's job, and merging
-    # the two would leak the baseline exception into I-5 (DR-819 D6 requires
+    # the two would leak the baseline exception into I-5 (the contract requires
     # the separation). Two derivations of the expected set:
     #
     # 1. Existing-tag anchored (works pre-record): at every observed release

--- a/tools/skillstead_validate/transport.py
+++ b/tools/skillstead_validate/transport.py
@@ -1,0 +1,66 @@
+"""GitHub Releases transport — separated from the pure evaluator (R0-F4).
+
+The transport owns pagination and the ``releases/latest`` lookup; any
+shortfall (mid-page failure, malformed page, non-zero subprocess) raises
+TransportError, which the evaluator maps to ``CV-DOMAIN`` (fail-closed).
+The evaluator only ever sees a completed, normalized observation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+PER_PAGE = 100
+
+
+class TransportError(RuntimeError):
+    pass
+
+
+def _default_runner(args: list[str]) -> str:
+    try:
+        proc = subprocess.run(args, capture_output=True, text=True, check=True)
+    except FileNotFoundError as e:
+        raise TransportError("gh executable not found") from e
+    except subprocess.CalledProcessError as e:
+        raise TransportError(f"{' '.join(args)}: {e.stderr.strip()}") from e
+    return proc.stdout
+
+
+def fetch_releases(repo_slug: str, runner=_default_runner) -> list[dict]:
+    """All release objects, every page walked to exhaustion."""
+    releases: list[dict] = []
+    page = 1
+    while True:
+        out = runner(["gh", "api",
+                      f"repos/{repo_slug}/releases?per_page={PER_PAGE}&page={page}"])
+        try:
+            batch = json.loads(out)
+        except json.JSONDecodeError as e:
+            raise TransportError(f"malformed releases page {page}: {e}") from None
+        if not isinstance(batch, list):
+            raise TransportError(f"releases page {page} is not an array")
+        releases.extend(batch)
+        if len(batch) < PER_PAGE:
+            return releases
+        page += 1
+
+
+def fetch_latest(repo_slug: str, runner=_default_runner) -> str | None:
+    """``tag_name`` of the repository Latest release, or None when there is
+    no release at all (GitHub answers 404)."""
+    try:
+        out = runner(["gh", "api", f"repos/{repo_slug}/releases/latest"])
+    except TransportError as e:
+        if "404" in str(e) or "Not Found" in str(e):
+            return None
+        raise
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError as e:
+        raise TransportError(f"malformed latest response: {e}") from None
+    tag = data.get("tag_name")
+    if not isinstance(tag, str):
+        raise TransportError("latest response has no tag_name")
+    return tag

--- a/tools/skillstead_validate/wrapper.py
+++ b/tools/skillstead_validate/wrapper.py
@@ -1,0 +1,255 @@
+"""M5 canonical release wrapper (DR-819 D8-2 — the only supported path for
+GitHub Release operations).
+
+Roles, fixed by the DR: run the ordered evaluator; check the requested
+operation against the verdict's allowed-operation matrix (judged on the
+combination verdict + CV code + action + recovery_mode); pre-publish checks
+(tag must already exist — the wrapper never creates a tag implicitly; title;
+P3 body marker; draft/prerelease flags); execute only the permitted
+``gh release create``/``edit``; re-run the evaluator right after publishing
+with the exact postcondition ``Latest == the tag just published`` (stronger
+than the evaluator's steady-state ``∈ argmax``); emit verdict + detail to
+the CI summary.
+
+Tag mutation is NOT here — M2 ``apply-tags`` owns it. Direct ``gh`` calls
+are an unsupported path; this is discipline, not a hard guarantee.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import record_schema
+from .cutover import P3_MARKER, Verdict, run_cutover
+from .gitio import GitError, git
+
+ACTIONS = ("create-draft", "publish", "edit-metadata")
+RECOVERY_MODES = ("none", "premature-accept-forward", "metadata-correction")
+_NAMESPACED_TAG = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+)\.(\d+)\.(\d+)$")
+
+
+class RequestError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ReleaseOperationRequest:
+    action: str
+    recovery_mode: str
+    tag: str
+    title: str
+    body: str
+    draft: bool
+    prerelease: bool
+    latest_intent: bool
+    owner_authorization: str | None
+
+
+_KEYS = {"action", "recovery_mode", "tag", "title", "body", "draft",
+         "prerelease", "latest_intent", "owner_authorization"}
+
+
+def parse_request(text: str) -> ReleaseOperationRequest:
+    def no_dup(pairs):
+        d = {}
+        for k, v in pairs:
+            if k in d:
+                raise RequestError(f"duplicate JSON key: {k!r}")
+            d[k] = v
+        return d
+    try:
+        raw = json.loads(text, object_pairs_hook=no_dup)
+    except json.JSONDecodeError as e:
+        raise RequestError(f"invalid JSON: {e}") from None
+    if not isinstance(raw, dict) or set(raw) != _KEYS:
+        raise RequestError(f"request keys must be exactly {sorted(_KEYS)}")
+    if raw["action"] not in ACTIONS:
+        raise RequestError(f"action must be one of {ACTIONS}")
+    if raw["recovery_mode"] not in RECOVERY_MODES:
+        raise RequestError(f"recovery_mode must be one of {RECOVERY_MODES}")
+    for key in ("tag", "title", "body"):
+        if not isinstance(raw[key], str) or not raw[key]:
+            raise RequestError(f"{key} must be a non-empty string")
+    for key in ("draft", "prerelease", "latest_intent"):
+        if not isinstance(raw[key], bool):
+            raise RequestError(f"{key} must be a boolean")
+    auth = raw["owner_authorization"]
+    if auth is not None and (not isinstance(auth, str) or not auth):
+        raise RequestError("owner_authorization must be null or a non-empty string")
+    needs_auth = raw["action"] == "edit-metadata" or raw["recovery_mode"] != "none"
+    if needs_auth and auth is None:
+        raise RequestError("owner_authorization is required for edit-metadata or any recovery_mode")
+    return ReleaseOperationRequest(**raw)
+
+
+@dataclass
+class WrapperResult:
+    pre_verdict: Verdict
+    executed: bool
+    commands: list[list[str]]
+    post_verdict: Verdict | None = None
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None and self.executed
+
+
+def _missing_baseline_tags(releases_raw: list[dict]) -> set[str]:
+    """Baseline refs with no PUBLISHED Release. Drafts do not count — they
+    are excluded from the verdict domain, and publishing an existing draft
+    for a missing baseline ref is exactly the allowed operation."""
+    present = {r.get("tag_name") for r in releases_raw
+               if isinstance(r, dict) and r.get("draft") is not True}
+    return {ref.removeprefix("refs/tags/") for ref in record_schema.BASELINE_TAGS
+            if ref.removeprefix("refs/tags/") not in present}
+
+
+def _allowed(verdict: Verdict, req: ReleaseOperationRequest,
+             releases_raw: list[dict]) -> str | None:
+    """W2 — return a refusal reason, or None when the operation is allowed.
+
+    The judgment key is the combination (verdict, CV code, action,
+    recovery_mode); recovery is context, never a blanket bypass."""
+    missing = _missing_baseline_tags(releases_raw)
+    if verdict.verdict in ("not-started", "aborted", "pending-tags"):
+        return f"no release operation is allowed in verdict {verdict.verdict!r}"
+    if verdict.verdict == "tags-ok":
+        if req.recovery_mode != "none":
+            return "recovery_mode must be none in tags-ok"
+        if req.action not in ("create-draft", "publish"):
+            return "only create-draft/publish are allowed in tags-ok"
+        if req.tag not in missing:
+            return "tags-ok only allows the record-declared baseline refs whose Release is missing"
+        return None
+    if verdict.verdict == "complete":
+        if req.recovery_mode != "none":
+            return "recovery_mode must be none in complete"
+        if req.action not in ("create-draft", "publish"):
+            return "metadata corrections require a red/CV-* recovery context"
+        return None
+    # verdict == red
+    if verdict.code in ("CV-RELEASE", "CV-LATEST-INITIAL", "CV-LATEST-STEADY"):
+        if req.action == "edit-metadata" and req.recovery_mode == "metadata-correction":
+            return None
+        return f"{verdict.code} allows owner-approved metadata correction only"
+    if verdict.code == "CV-PREMATURE":
+        if req.recovery_mode != "premature-accept-forward":
+            return "CV-PREMATURE requires recovery_mode=premature-accept-forward"
+        if req.action in ("create-draft", "publish") and req.tag in missing:
+            return None
+        if req.action == "edit-metadata":
+            return None  # Latest correction
+        return "CV-PREMATURE allows missing baseline Releases and Latest correction only"
+    return f"no release operation is allowed in red/{verdict.code}"
+
+
+def _precheck(repo: Path, req: ReleaseOperationRequest) -> str | None:
+    """W3 — pre-publish object checks. Never creates a tag implicitly."""
+    try:
+        git(repo, "rev-parse", "--verify", f"refs/tags/{req.tag}")
+    except GitError:
+        return f"tag {req.tag!r} does not exist — the wrapper never creates tags (M2 apply-tags owns that)"
+    m = _NAMESPACED_TAG.match(req.tag)
+    if not m:
+        return f"tag {req.tag!r} violates the namespaced grammar"
+    if req.action in ("create-draft", "publish"):
+        expected_title = f"{m.group(1)} {m.group(2)}.{m.group(3)}.{m.group(4)}"
+        if expected_title not in req.title:
+            return f"title must contain {expected_title!r} (P2)"
+        first = next((l.strip().strip("\r") for l in req.body.splitlines() if l.strip()), "")
+        if first != P3_MARKER:
+            return "body's first non-empty line must be the exact Latest marker (P3)"
+        if req.prerelease:
+            return "prerelease releases are rejected (P1)"
+    if req.action == "create-draft" and not req.draft:
+        return "create-draft requires draft=true"
+    if req.action == "publish":
+        if req.draft:
+            return "publish requires draft=false"
+        if not req.latest_intent:
+            return "publish requires latest_intent=true (every publish names --latest explicitly)"
+    return None
+
+
+def _default_execute(args: list[str]) -> None:
+    subprocess.run(args, check=True, capture_output=True, text=True)
+
+
+def _emit_summary(result: WrapperResult) -> None:
+    lines = [f"wrapper pre-verdict: {result.pre_verdict}"]
+    if result.post_verdict is not None:
+        lines.append(f"wrapper post-verdict: {result.post_verdict}")
+    if result.error:
+        lines.append(f"wrapper error: {result.error}")
+    text = "\n".join(lines)
+    print(text)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as f:
+            f.write(text + "\n")
+
+
+def run_wrapper(repo: Path, req: ReleaseOperationRequest, fetch,
+                main_ref: str = "main", now: int | None = None,
+                execute=_default_execute, repo_slug: str | None = None,
+                dry_run: bool = False) -> WrapperResult:
+    """``fetch() -> (releases_raw, latest_tag)`` supplies the Release
+    observation before and after the mutation (transport in live use,
+    injected in tests). ``execute(argv)`` performs the permitted gh call.
+    ``dry_run`` stops after the allowed-matrix and pre-publish checks."""
+    releases_raw, latest_tag = fetch()
+    pre = run_cutover(repo, main_ref, releases_raw, latest_tag, now=now)
+    result = WrapperResult(pre_verdict=pre, executed=False, commands=[])
+
+    refusal = _allowed(pre, req, releases_raw) or _precheck(repo, req)
+    if refusal:
+        result.error = refusal
+        _emit_summary(result)
+        return result
+
+    if dry_run:
+        _emit_summary(result)
+        return result
+
+    slug = ["--repo", repo_slug] if repo_slug else []
+    existing_draft = any(isinstance(r, dict) and r.get("tag_name") == req.tag
+                         and r.get("draft") is True for r in releases_raw)
+    if req.action == "create-draft":
+        cmd = ["gh", "release", "create", req.tag, *slug, "--draft",
+               "--title", req.title, "--notes", req.body]
+    elif req.action == "publish":
+        if existing_draft:
+            cmd = ["gh", "release", "edit", req.tag, *slug, "--draft=false",
+                   "--title", req.title, "--latest"]
+        else:
+            cmd = ["gh", "release", "create", req.tag, *slug,
+                   "--title", req.title, "--notes", req.body, "--latest"]
+    else:  # edit-metadata
+        cmd = ["gh", "release", "edit", req.tag, *slug,
+               "--title", req.title, "--notes", req.body]
+        if req.latest_intent:
+            cmd.append("--latest")
+    try:
+        execute(cmd)
+    except subprocess.CalledProcessError as e:
+        result.error = f"gh execution failed: {e.stderr or e}"
+        _emit_summary(result)
+        return result
+    result.executed = True
+    result.commands.append(cmd)
+
+    # W5 — post-mutation evaluator + exact postcondition on publish.
+    post_releases, post_latest = fetch()
+    result.post_verdict = run_cutover(repo, main_ref, post_releases, post_latest, now=now)
+    if req.action == "publish" and post_latest != req.tag:
+        result.error = f"postcondition failed: Latest is {post_latest!r}, expected {req.tag!r}"
+    elif result.post_verdict.verdict == "red":
+        result.error = f"post-mutation verdict is red: {result.post_verdict}"
+    _emit_summary(result)
+    return result

--- a/tools/skillstead_validate/wrapper.py
+++ b/tools/skillstead_validate/wrapper.py
@@ -1,4 +1,4 @@
-"""M5 canonical release wrapper (DR-819 D8-2 — the only supported path for
+"""M5 canonical release wrapper (the only supported path for
 GitHub Release operations).
 
 Roles, fixed by the DR: run the ordered evaluator; check the requested

--- a/tools/skillstead_validate/wrapper.py
+++ b/tools/skillstead_validate/wrapper.py
@@ -106,7 +106,7 @@ def _missing_baseline_tags(releases_raw: list[dict]) -> set[str]:
     are excluded from the verdict domain, and publishing an existing draft
     for a missing baseline ref is exactly the allowed operation."""
     present = {r.get("tag_name") for r in releases_raw
-               if isinstance(r, dict) and r.get("draft") is not True}
+               if isinstance(r, dict) and r.get("draft") is False}
     return {ref.removeprefix("refs/tags/") for ref in record_schema.BASELINE_TAGS
             if ref.removeprefix("refs/tags/") not in present}
 
@@ -198,6 +198,8 @@ def _precheck(repo: Path, req: ReleaseOperationRequest) -> str | None:
         return "prerelease releases are rejected (P1)"
     if req.action == "create-draft" and not req.draft:
         return "create-draft requires draft=true"
+    if req.action == "edit-metadata" and req.draft:
+        return "edit-metadata requires draft=false — the request must equal the intended final state (MR2R-F6)"
     if req.action == "publish":
         if req.draft:
             return "publish requires draft=false"
@@ -242,9 +244,10 @@ def run_wrapper(repo: Path, req: ReleaseOperationRequest, fetch,
         _emit_summary(result)
         return result
 
-    # The target of a create/publish must pass the pure normal tag gate
-    # right before the mutation (MR2-F7) — a complete verdict describes the
-    # repository, not this tag.
+    # The whole tag surface must pass the pure normal tag gate right before
+    # a create/publish (MR2-F7 · MR2R-F7) — the gate reports observation
+    # failures and repo-wide defects as findings, not exceptions, so ANY
+    # finding is fail-closed, not only ones naming the request tag.
     if req.action in ("create-draft", "publish"):
         try:
             gate_findings = run_tag_checks(repo, main_ref)
@@ -252,11 +255,10 @@ def run_wrapper(repo: Path, req: ReleaseOperationRequest, fetch,
             result.error = f"tag gate unobservable (fail-closed): {e}"
             _emit_summary(result)
             return result
-        for f in gate_findings:
-            if f.subject in (req.tag, f"refs/tags/{req.tag}"):
-                result.error = f"target tag fails the normal tag gate: {f}"
-                _emit_summary(result)
-                return result
+        if gate_findings:
+            result.error = f"normal tag gate is not green (fail-closed): {gate_findings[0]}"
+            _emit_summary(result)
+            return result
 
     if dry_run:
         _emit_summary(result)

--- a/tools/skillstead_validate/wrapper.py
+++ b/tools/skillstead_validate/wrapper.py
@@ -25,8 +25,9 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from . import record_schema
-from .cutover import P3_MARKER, Verdict, run_cutover
+from .cutover import P3_MARKER, Verdict, _release_p123, run_cutover
 from .gitio import GitError, git
+from .tag_check import run_tag_checks
 
 ACTIONS = ("create-draft", "publish", "edit-metadata")
 RECOVERY_MODES = ("none", "premature-accept-forward", "metadata-correction")
@@ -133,18 +134,44 @@ def _allowed(verdict: Verdict, req: ReleaseOperationRequest,
         if req.action not in ("create-draft", "publish"):
             return "metadata corrections require a red/CV-* recovery context"
         return None
-    # verdict == red
-    if verdict.code in ("CV-RELEASE", "CV-LATEST-INITIAL", "CV-LATEST-STEADY"):
-        if req.action == "edit-metadata" and req.recovery_mode == "metadata-correction":
-            return None
-        return f"{verdict.code} allows owner-approved metadata correction only"
+    # verdict == red — recovery binds to the OBSERVED defect (MR2-F8): the
+    # request tag must be the offending object (or the Latest candidate),
+    # never an arbitrary release.
+    domain = [r for r in releases_raw
+              if isinstance(r, dict) and r.get("draft") is False
+              and isinstance(r.get("tag_name"), str) and _NAMESPACED_TAG.match(r["tag_name"])]
+    stamps = [(r.get("published_at") or "") for r in domain]
+    argmax = {r["tag_name"] for r in domain if (r.get("published_at") or "") == max(stamps)} if domain else set()
+    if verdict.code == "CV-RELEASE":
+        if req.action != "edit-metadata" or req.recovery_mode != "metadata-correction":
+            return "CV-RELEASE allows owner-approved metadata correction only"
+        offending = {r["tag_name"] for r in domain if _release_p123(r)}
+        if req.tag not in offending:
+            return f"CV-RELEASE correction must target an offending release, not {req.tag!r}"
+        return None
+    if verdict.code in ("CV-LATEST-INITIAL", "CV-LATEST-STEADY"):
+        if req.action != "edit-metadata" or req.recovery_mode != "metadata-correction":
+            return f"{verdict.code} allows owner-approved metadata correction only"
+        if not req.latest_intent:
+            return f"{verdict.code} correction is a Latest correction — latest_intent must be true"
+        if verdict.code == "CV-LATEST-INITIAL":
+            expected = record_schema.LATEST_REF.removeprefix("refs/tags/")
+            if req.tag != expected:
+                return f"CV-LATEST-INITIAL correction must target {expected!r}"
+        elif req.tag not in argmax:
+            return f"CV-LATEST-STEADY correction must target an argmax(published_at) candidate"
+        return None
     if verdict.code == "CV-PREMATURE":
         if req.recovery_mode != "premature-accept-forward":
             return "CV-PREMATURE requires recovery_mode=premature-accept-forward"
         if req.action in ("create-draft", "publish") and req.tag in missing:
             return None
         if req.action == "edit-metadata":
-            return None  # Latest correction
+            if not req.latest_intent:
+                return "CV-PREMATURE Latest correction requires latest_intent=true"
+            if req.tag not in argmax:
+                return "CV-PREMATURE Latest correction must target an argmax(published_at) candidate"
+            return None
         return "CV-PREMATURE allows missing baseline Releases and Latest correction only"
     return f"no release operation is allowed in red/{verdict.code}"
 
@@ -158,15 +185,17 @@ def _precheck(repo: Path, req: ReleaseOperationRequest) -> str | None:
     m = _NAMESPACED_TAG.match(req.tag)
     if not m:
         return f"tag {req.tag!r} violates the namespaced grammar"
-    if req.action in ("create-draft", "publish"):
-        expected_title = f"{m.group(1)} {m.group(2)}.{m.group(3)}.{m.group(4)}"
-        if expected_title not in req.title:
-            return f"title must contain {expected_title!r} (P2)"
-        first = next((l.strip().strip("\r") for l in req.body.splitlines() if l.strip()), "")
-        if first != P3_MARKER:
-            return "body's first non-empty line must be the exact Latest marker (P3)"
-        if req.prerelease:
-            return "prerelease releases are rejected (P1)"
+    # P1~P3 hold for the INTENDED FINAL metadata of every action, including
+    # metadata corrections (MR2-F6): a correction that produces an invalid
+    # title/marker/prerelease state is not a correction.
+    expected_title = f"{m.group(1)} {m.group(2)}.{m.group(3)}.{m.group(4)}"
+    if expected_title not in req.title:
+        return f"title must contain {expected_title!r} (P2)"
+    first = next((l.strip().strip("\r") for l in req.body.splitlines() if l.strip()), "")
+    if first != P3_MARKER:
+        return "body's first non-empty line must be the exact Latest marker (P3)"
+    if req.prerelease:
+        return "prerelease releases are rejected (P1)"
     if req.action == "create-draft" and not req.draft:
         return "create-draft requires draft=true"
     if req.action == "publish":
@@ -213,6 +242,22 @@ def run_wrapper(repo: Path, req: ReleaseOperationRequest, fetch,
         _emit_summary(result)
         return result
 
+    # The target of a create/publish must pass the pure normal tag gate
+    # right before the mutation (MR2-F7) — a complete verdict describes the
+    # repository, not this tag.
+    if req.action in ("create-draft", "publish"):
+        try:
+            gate_findings = run_tag_checks(repo, main_ref)
+        except GitError as e:
+            result.error = f"tag gate unobservable (fail-closed): {e}"
+            _emit_summary(result)
+            return result
+        for f in gate_findings:
+            if f.subject in (req.tag, f"refs/tags/{req.tag}"):
+                result.error = f"target tag fails the normal tag gate: {f}"
+                _emit_summary(result)
+                return result
+
     if dry_run:
         _emit_summary(result)
         return result
@@ -220,18 +265,23 @@ def run_wrapper(repo: Path, req: ReleaseOperationRequest, fetch,
     slug = ["--repo", repo_slug] if repo_slug else []
     existing_draft = any(isinstance(r, dict) and r.get("tag_name") == req.tag
                          and r.get("draft") is True for r in releases_raw)
+    # Every command applies the VERIFIED request metadata exactly (MR2-F6):
+    # --verify-tag stops gh from implicitly creating a missing remote tag,
+    # and a draft publish re-applies title/notes/prerelease rather than
+    # trusting whatever the draft happened to contain.
     if req.action == "create-draft":
-        cmd = ["gh", "release", "create", req.tag, *slug, "--draft",
+        cmd = ["gh", "release", "create", req.tag, *slug, "--verify-tag", "--draft",
                "--title", req.title, "--notes", req.body]
     elif req.action == "publish":
         if existing_draft:
             cmd = ["gh", "release", "edit", req.tag, *slug, "--draft=false",
-                   "--title", req.title, "--latest"]
+                   "--prerelease=false", "--title", req.title, "--notes", req.body,
+                   "--latest"]
         else:
-            cmd = ["gh", "release", "create", req.tag, *slug,
+            cmd = ["gh", "release", "create", req.tag, *slug, "--verify-tag",
                    "--title", req.title, "--notes", req.body, "--latest"]
     else:  # edit-metadata
-        cmd = ["gh", "release", "edit", req.tag, *slug,
+        cmd = ["gh", "release", "edit", req.tag, *slug, "--prerelease=false",
                "--title", req.title, "--notes", req.body]
         if req.latest_intent:
             cmd.append("--latest")


### PR DESCRIPTION
per-skill versioning 계약을 집행하는 validator·CI를 신설한다.

- **M1** repo 검증(package 구조·license 자기완결·catalog Version 열) / **M2** release preflight·atomic tag 발행 / **M3** tag 지속 검사(repoint·삭제 검출) / **M4** cutover verdict evaluator / **M5** canonical release wrapper — 전부 Python 3.11+ stdlib, fail-closed.
- CI 3-workflow(event/periodic/release 격리), synthetic git repo fixture **115건**, `docs/VALIDATION.md`(EN)+`.ko.md`(KO).
- `skills/**` 무변경 (baseline freeze 준수). pin된 규격 reference validator는 조달 사실·교체 조건과 함께 문서화.

검증: suite 115/115 green · 실repo M1·M3 0 findings · cutover evaluator `not-started`(pre-cutover 정상 상태). manual cross-agent review 13라운드(driver Claude, reviewer Codex) 전 라운드 accept 종결.

🤖 Generated with [Claude Code](https://claude.com/claude-code)