### PR TITLE
test: cutover 실제 repo fixture를 현행화한다

### DIFF
--- a/tests/test_cutover.py
+++ b/tests/test_cutover.py
@@ -396,17 +396,23 @@ class CutoverFixture(unittest.TestCase):
         self.assertEqual((v.verdict, v.code), ("red", "CV-RELEASE"))
 
 
-class RealRepoNotStarted(unittest.TestCase):
-    def test_real_repo_is_not_started(self) -> None:
+class RealRepoBaselineSurface(unittest.TestCase):
+    EXPECTED_VERDICT = "tags-ok"
+
+    def test_real_repo_baseline_surface(self) -> None:
         # CI checks out a PR merge ref without a local `main` branch, so the
-        # remote-tracking ref is the portable main reference.
+        # remote-tracking ref is the portable main reference. The empty
+        # Release domain isolates the baseline refs while INSTALL pins remain
+        # at the baseline version; the live workflow validates public Releases.
+        # The first ordinary release that updates INSTALL pins must update this
+        # fixture in the same PR as the validator/release surface.
         import subprocess
         repo = Path(__file__).resolve().parent.parent
         has_origin = subprocess.run(
             ["git", "-C", str(repo), "rev-parse", "--verify", "origin/main"],
             capture_output=True).returncode == 0
         v = run_cutover(repo, "origin/main" if has_origin else "main", [], None)
-        self.assertEqual(v.verdict, "not-started", v)
+        self.assertEqual(v.verdict, self.EXPECTED_VERDICT, v)
 
 
 class InstallPinParsing(unittest.TestCase):


### PR DESCRIPTION
## Summary

- C3 시점의 `not-started`를 고정한 real-repo smoke fixture를 현재 baseline-ref 상태에 맞춘다.
- empty Release domain과 live M4의 실제 public Release domain 소유 경계를 명시한다.
- 첫 통상 release가 INSTALL pin을 갱신할 때 fixture도 같은 PR에서 전환하도록 남긴다.

## Scope

- 변경: `tests/test_cutover.py` 1개
- 무변경: evaluator, workflow, docs, `skills/**`, tag, GitHub Release, ruleset

## Validation

- targeted `RealRepoBaselineSurface`: 1 test OK
- full suite: 128 tests OK
- M1 repo validator: 0 finding(s)
- M3 tag validator: 0 finding(s)
- live M4: `tags-ok`
- `skills/**` tree: `bfc377a18f29e21a991d5a0df1786509ad7c0940`
- `git diff --check`: Pass
- public hygiene scan: clean

## Actions Impact

Skillstead는 public repository다. branch push의 `create`, PR 생성의 `pull_request`, squash
merge의 `push`와 branch auto-delete의 `delete` event가 hosted Actions를 실행한다.
