### PR TITLE
feat: skill development playbook과 lifecycle gate를 추가한다

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -133,6 +133,11 @@ V1은 두 시점에 사용할 수 있습니다. 비공개 github.com 저장소�
 최종 기준으로 관리하며, `.ko.md` 파일은 같은 내용을 담는 한국어 문서입니다. 의미가 달라지는 수정은
 두 언어 문서에 같은 pull request로 반영합니다.
 
+[`playbooks/skill-development`](./playbooks/skill-development/README.ko.md)는 스킬을 설계하고 검증하며
+독립적으로 검토하고 릴리스·은퇴시키는 저장소 표준입니다. Package template은 예약 identity인
+`sample-skill`을 바꾸기 전에는 설치할 수 없도록 설계했습니다. Release gate가 집행하는 retirement와
+major transition 추적 증거 규격은 [`docs/VALIDATION.ko.md`](./docs/VALIDATION.ko.md)에 있습니다.
+
 ## 공개 스킬의 품질 기준
 
 모든 공개 스킬은 다음 기준을 만족해야 합니다.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ The `github-release-guide` skill mirrors the playbook's rules inside its own sel
 canonical, and each document has a Korean mirror with the `.ko.md` suffix. Update both languages in the same pull
 request whenever the meaning changes.
 
+[`playbooks/skill-development`](./playbooks/skill-development/README.md) defines the repository standard for
+designing, validating, independently reviewing, releasing, and retiring a skill. Its package template is
+deliberately non-installable until the reserved `sample-skill` identity is replaced. The tracked retirement and
+major-transition evidence enforced by the release gates is specified in
+[`docs/VALIDATION.md`](./docs/VALIDATION.md).
+
 ## Quality and evidence bar
 
 Every public skill must have:

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -13,9 +13,9 @@
 
 | Mode | 내용 | 실행 시점 | 명령 |
 | --- | --- | --- | --- |
-| M1 | 저장소 검증 — package 구조, `metadata.version` ↔ CHANGELOG(I-1), 카탈로그 `Version` 열(I-7), package 완전성(I-9), 라이선스 사본 바이트 일치 | 모든 PR, `main` push, 매일 schedule | `PYTHONPATH=tools python3 -m skillstead_validate repo` |
-| M2 | 릴리스 preflight와 tag 생성 — 통상 payload diff gate와 exact-record baseline 분기, bump 단계 검사(I-6), inventory 보호(I-10), major bump 보호, 신규 skill 최초 릴리스, tag 고유성 | 릴리스 제안 시. dry-run 가능 | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` (`git push --atomic`으로 remote에 발행. push 실패 시 local ref rollback) |
-| M3 | tag 지속 검사 — 모든 namespaced tag의 I-2·I-5·I-8과 durable expected-target 관계를 매 실행 검사 (tag는 변경 가능하므로 생성 시점 검사만으로는 아무것도 담보되지 않음) | 모든 PR, push, tag 생성/삭제, 매일 schedule | `… tags --main-ref origin/main` |
+| M1 | 저장소 검증 — package 구조, `metadata.version` ↔ CHANGELOG(I-1), 카탈로그 `Version` 열(I-7), package 완전성(I-9), 라이선스 사본 바이트 일치, active identity 예약어 | 모든 PR, `main` push, 매일 schedule | `PYTHONPATH=tools python3 -m skillstead_validate repo` |
+| M2 | 릴리스 preflight와 tag 생성 — 통상 payload diff gate와 exact-record baseline 분기, bump 단계 검사(I-6), inventory·retirement 보호(I-10), major transition 승인, 신규 skill 최초 릴리스, tag 고유성 | 릴리스 제안 시. dry-run 가능 | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` (`git push --atomic`으로 remote에 발행. push 실패 시 local ref rollback) |
+| M3 | tag·retirement history 지속 검사 — 모든 namespaced tag의 I-2·I-5·I-8, durable expected-target 관계, retirement record 지속성과 identity 재활성화를 매 실행 검사 | 모든 PR, push, tag 생성/삭제, 매일 schedule | `… tags --main-ref origin/main` |
 | M4 | cutover verdict — cutover record·INSTALL pin·baseline ref·GitHub Releases에 대한 ordered evaluator | CI 상시 + 모든 릴리스 작업 전후 | `… cutover --live --repo-slug OWNER/REPO` |
 | M5 | canonical release wrapper — **GitHub Release 작업의 유일한 지원 경로** | 수동 또는 `release` workflow | `… release --request REQUEST.json --repo-slug OWNER/REPO [--dry-run]` |
 
@@ -70,11 +70,11 @@ I-4 finding입니다. payload는 정확히 두 개의 bookkeeping 산출물(`met
 `CHANGELOG.md`)을 제외합니다(`VERSIONING.ko.md` 참조).
 
 추가 검사: target commit은 전체 M1 검증을 통과하고 `main` first-parent history에 있어야 합니다.
-bump 단계는 경로 기본값과 일치해야 하고, major bump는 owner 승인 증거 형식이 확정되기 전까지
-무조건 거부되며, 승인된 retirement marker 없는 inventory 감소도 marker 형식 확정 전까지 무조건
-거부됩니다. 신규 skill의 최초 릴리스는 package와 양쪽 카탈로그 행을 target commit에서 함께
-도입해야 하고, 기존 tag와 SemVer precedence가 같은 버전(`+build` alias 포함)은 만들 수
-없습니다.
+bump 단계는 major transition 분기가 적용되는 경우를 제외하면 경로 기본값과 일치해야 합니다.
+한 단계 major transition에는 아래의 정확한 추적 승인 record가 필요하고, inventory 감소에는 아래의
+정확한 retirement record와 전체 제거 predicate가 필요합니다. 신규 skill의 최초 릴리스는 package와
+양쪽 카탈로그 행을 target commit에서 함께 도입해야 하고, 기존 tag와 SemVer precedence가 같은
+버전(`+build` alias 포함)은 만들 수 없습니다.
 
 일회성 baseline 분기는 target에 canonical prepared cutover record가 있을 때만 활성화됩니다. Plan은
 record의 `baseline_tags` 네 항목과 순서까지 같아야 하고, 모든 항목은 `previous_ref: null`과 버전
@@ -84,6 +84,103 @@ commit이어야 합니다. T1과 T2도 유지되어 최초 attempt는 `1`, 이�
 하지만 package·catalog 검사, tag 문법과 고유성, `main` ancestry, 네 ref의 exact atomicity, I-10은
 그대로 적용합니다. Baseline I-10은 target inventory를 `baseline_finalization_sha:skills`와 비교하며,
 감소가 하나라도 있으면 finding입니다.
+
+## 추적 transition 증거
+
+두 증거 유형은 모두 strict JSON object입니다. 알 수 없거나 중복된 key, 잘못된 type,
+path/content identity 불일치, 잘못된 날짜와 관측 불가 상태는 fail-closed입니다.
+`authorization_id`는 `owner-YYYYMMDD-<16 lowercase hex>` 형식이어야 하고 그 날짜는
+`approved_at`과 같아야 합니다. 이 식별자는 저장소 안에서 사용하는 allowlist handle이지 승인자를
+암호학적으로 증명하지 않습니다. Identity 권한은 owner가 통제하는 review와 merge 경계에 남습니다.
+
+자유 서술인 `reason`은 비어 있지 않은 중립 설명이어야 합니다. 비공개 tracker 식별자, local
+absolute path, 저장소·외부 URL을 포함할 수 없습니다. Validator는 이 한정된 hygiene pattern을
+검사합니다. 그 밖의 민감하거나 식별 가능한 내용은 owner가 정확한 record와 diff를 검토하는 것이
+최종 기준입니다.
+
+### Retirement record
+
+경로: `.skillstead/retirements/<skill>.json`
+
+```json
+{
+  "schema_version": 1,
+  "skill": "<skill>",
+  "last_release_ref": "<skill>/vX.Y.Z 또는 null",
+  "authorization_id": "owner-YYYYMMDD-<16 lowercase hex>",
+  "approved_at": "YYYY-MM-DD",
+  "reason": "<중립적이고 공개 가능한 설명>",
+  "replacement": null
+}
+```
+
+Package, 양쪽 active catalog row, 양쪽 INSTALL pin은 같은 target tree에서 모두 사라져야 합니다.
+`README.md`에는 `## Retired skills`, `README.ko.md`에는 `## 은퇴한 스킬` table과 각 언어의
+3열 header가 있어야 합니다. 두 table에는 다음 material row를 정확히 추가해야 합니다.
+
+```text
+| `<skill>` | `<last_release_ref 또는 unreleased>` | [record](./.skillstead/retirements/<skill>.json) |
+```
+
+`last_release_ref`는 관측 가능한 최신 namespaced release와 같아야 합니다. 그런 release가 하나도
+없을 때만 `null`이어야 하므로, release가 있는데 `null`인 경우와 release가 없는데 string인 경우를
+모두 fail-closed합니다.
+
+M2는 target inventory를 관측 가능한 최신 release commit과 target의 immediate parent inventory
+합집합에 비교합니다. Parent 비교는 최신 release 뒤 도입됐지만 아직 release되지 않은 package를 이
+target에서 제거하는 경우를 포함하며, 이때 `last_release_ref: null`을 사용해야 합니다.
+
+Record는 package, 양쪽 active catalog row, 양쪽 INSTALL pin을 제거하고 두 retired-table row를
+추가하는 동일한 `main` first-parent commit에서 처음 나타나야 합니다. Record만 먼저 merge하면 안
+됩니다. Split merge는 active package와 retirement record가 공존한 이력을 영구히 남기므로 이후
+모든 M3가 red를 유지합니다. Record 삭제나 재작성으로는 이 history를 복구할 수 없습니다.
+
+그 뒤 M3가 전체 `main` first-parent history를 읽습니다. 유효한 retirement record가 한 번
+나타나면 고정 path와 semantic value가 계속 존재해야 합니다. 삭제, rename, mutation,
+delete-and-restore, retired identity 재활성화는 finding입니다. M3는 지속적인 release-operation
+gate이므로 required check가 없는 환경에서 위반이 이미 merge되면 merge 후 red가 됩니다. 이 문서는
+validator가 모든 merge를 막는다고 주장하지 않습니다. False positive나 contract 결함의 복구에는
+owner 승인 contract amendment가 필요합니다. Record 직접 수정이나 history 편집은 지원하지 않습니다.
+
+V1은 공개 전 identity 변경만 지원합니다. 공개 후 이름 변경은 in-place rename이 아닙니다. 기존
+identity는 retirement로 처리하고 새 identity는 별도 승인된 skill로 도입합니다.
+
+### Major transition 승인 record
+
+경로: `.skillstead/major-approvals/<skill>-v<proposed_version>.json`
+
+```json
+{
+  "schema_version": 1,
+  "skill": "<skill>",
+  "previous_ref": "<skill>/vX.Y.Z",
+  "proposed_version": "X.Y.Z",
+  "authorization_id": "owner-YYYYMMDD-<16 lowercase hex>",
+  "approved_at": "YYYY-MM-DD",
+  "reason": "<중립적이고 공개 가능한 설명>"
+}
+```
+
+이 record는 제안이 한 단계 major transition일 때만 적용됩니다. Path, `skill`, `previous_ref`,
+`proposed_version`이 해당 transition에 결속합니다. Payload는 여전히 정확한 pull request review와
+merge로 승인하며, 이 record가 임의 payload를 승인하지는 않습니다. 그 사이 다른 release가 생기면
+관측되는 최신 `previous_ref`가 바뀌므로 record는 fail-closed로 무효가 됩니다.
+
+V1에서 major-approval record에는 retirement record와 달리 first-parent 지속성 권한을 부여하지
+않습니다. Immutable version tag target이 승인된 transition 증거를 보존하고, tag precedence가
+version 재사용을 막으며, M3가 tag 삭제와 retarget을 차단합니다. 이 lifecycle 비대칭은 의도한
+것입니다. Retirement record는 현재 inventory의 부재를 계속 승인하지만 major-approval record는
+완료된 transition 하나만 승인합니다.
+
+### Template identity와 validator 회전
+
+`templates/skill-package/`는 disposable scaffold입니다. `sample-skill`은 예약 identity이므로 active
+`skills/` 아래에 있으면 M1이 거부합니다. Materialized package를 검증하기 전에 모든 identity
+surface를 바꾸십시오. Template 안에는 두 번째 package validator가 없습니다.
+
+INSTALL pin, lifecycle-state syntax 또는 다른 production validator contract를 회전하는 변경은 같은
+pull request에서 production validator와 관련 real-repository fixture를 함께 갱신해야 합니다.
+그러면 문서, 실행 gate, consumer 형태 example이 한 revision에 유지됩니다.
 
 **Bump-Adjustment marker.** 제안된 단계가 경로 기본값과 다르면 해당 릴리스의 CHANGELOG entry에
 독립된, 비어 있지 않은 사유 줄이 있어야 합니다:

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -15,9 +15,9 @@ verdict, never a silent pass.
 
 | Mode | What | When it runs | Command |
 | --- | --- | --- | --- |
-| M1 | Repository validation — package structure, `metadata.version` ↔ CHANGELOG (I-1), catalog `Version` columns (I-7), package completeness (I-9), licence copy byte-equality | every PR, push to `main`, daily schedule | `PYTHONPATH=tools python3 -m skillstead_validate repo` |
-| M2 | Release preflight and tag creation — ordinary payload-diff gate plus the exact-record baseline branch, bump-step check (I-6), inventory guard (I-10), major-bump guard, new-skill initial release, tag uniqueness | invoked for a proposed release; dry-runnable | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` (publishes to the remote with `git push --atomic`; a push failure rolls local refs back) |
-| M3 | Continuous tag checks — I-2, I-5, I-8 and the durable expected-target relation for every namespaced tag, on every run (tags are mutable; creation-time checks alone guarantee nothing) | every PR, push, tag create/delete, daily schedule | `… tags --main-ref origin/main` |
+| M1 | Repository validation — package structure, `metadata.version` ↔ CHANGELOG (I-1), catalog `Version` columns (I-7), package completeness (I-9), licence copy byte-equality, and reserved active identities | every PR, push to `main`, daily schedule | `PYTHONPATH=tools python3 -m skillstead_validate repo` |
+| M2 | Release preflight and tag creation — ordinary payload-diff gate plus the exact-record baseline branch, bump-step check (I-6), inventory/retirement guard (I-10), major-transition approval, new-skill initial release, tag uniqueness | invoked for a proposed release; dry-runnable | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` (publishes to the remote with `git push --atomic`; a push failure rolls local refs back) |
+| M3 | Continuous tag and retirement-history checks — I-2, I-5, I-8, the durable expected-target relation for every namespaced tag, and retirement-record persistence/reactivation on every run | every PR, push, tag create/delete, daily schedule | `… tags --main-ref origin/main` |
 | M4 | Cutover verdict — the ordered evaluator over the cutover record, INSTALL pins, baseline refs, and GitHub Releases | CI runs + before/after every release operation | `… cutover --live --repo-slug OWNER/REPO` |
 | M5 | Canonical release wrapper — **the only supported path for GitHub Release operations** | manual, or the `release` workflow | `… release --request REQUEST.json --repo-slug OWNER/REPO [--dry-run]` |
 
@@ -79,12 +79,12 @@ I-4 finding. Payload excludes exactly two bookkeeping artifacts: the
 
 Additional checks: the target commit must satisfy the full M1 validation and
 sit on `main` first-parent history; the bump step must match the path-default
-step; a major bump is rejected unconditionally until an owner-approval
-evidence format exists; an inventory reduction without an approved retirement
-marker is rejected unconditionally until the marker format exists; a new
-skill's initial release must introduce the package and both catalog rows in
-the target commit itself; no existing tag may share the proposed version's
-SemVer precedence (including `+build` aliases).
+step unless the major-transition branch applies; a single-step major
+transition requires the exact tracked approval record below; an inventory
+reduction requires the exact retirement record and full-removal predicate
+below; a new skill's initial release must introduce the package and both
+catalog rows in the target commit itself; no existing tag may share the
+proposed version's SemVer precedence (including `+build` aliases).
 
 The one-time baseline branch activates only when the target carries the
 canonical prepared cutover record. The plan must equal the record's four
@@ -96,6 +96,118 @@ new-skill `0.1.0`/same-commit rules do not apply to this baseline, but
 package/catalog checks, tag grammar and uniqueness, `main` ancestry, exact
 four-ref atomicity, and I-10 remain active. Baseline I-10 compares the target
 inventory with `baseline_finalization_sha:skills`; any decrease is a finding.
+
+## Tracked transition evidence
+
+Both evidence types are strict JSON objects. Unknown or duplicate keys, wrong
+types, path/content identity mismatches, malformed dates, and unobservable
+state fail closed. `authorization_id` must match
+`owner-YYYYMMDD-<16 lowercase hex>` and its date must equal `approved_at`.
+The identifier is an allowlisted repository-local handle, not cryptographic
+proof of the approving person. Identity authority remains the owner-controlled
+review and merge boundary.
+
+Free-text `reason` must be non-empty and neutral. It must not contain private
+tracker identifiers, local absolute paths, or repository/external URLs. The
+validator applies those bounded hygiene patterns; owner review of the exact
+record and diff remains authoritative for other sensitive or identifying
+content.
+
+### Retirement record
+
+Path: `.skillstead/retirements/<skill>.json`
+
+```json
+{
+  "schema_version": 1,
+  "skill": "<skill>",
+  "last_release_ref": "<skill>/vX.Y.Z or null",
+  "authorization_id": "owner-YYYYMMDD-<16 lowercase hex>",
+  "approved_at": "YYYY-MM-DD",
+  "reason": "<neutral public-safe explanation>",
+  "replacement": null
+}
+```
+
+The package, both active catalog rows, and both INSTALL pins must disappear in
+the same target tree. `README.md` must carry a `## Retired skills` table and
+`README.ko.md` a `## 은퇴한 스킬` table, with localized three-column headers.
+Both tables must add this exact material row:
+
+```text
+| `<skill>` | `<last_release_ref or unreleased>` | [record](./.skillstead/retirements/<skill>.json) |
+```
+
+`last_release_ref` must equal the latest observable namespaced release. It must
+be `null` only when no such release exists; a string in the no-release case and
+`null` in the released case both fail closed.
+
+M2 compares the target inventory with the union of the latest observable
+release commit and the target's immediate parent. The parent comparison covers
+a never-released package introduced after the latest release and removed by
+this target; it must use `last_release_ref: null`.
+
+The record must first appear in the same `main` first-parent commit that removes
+the package, both active catalog rows, and both INSTALL pins and adds both
+retired-table rows. Never merge the record first. A split merge permanently
+records an active package coexisting with its retirement record, so every later
+M3 run remains red; deleting or rewriting the record cannot repair that
+history.
+
+M3 reads the complete `main` first-parent history. Once a valid retirement
+record appears, its fixed path and semantic value must remain present. Deletion,
+rename, mutation, delete-and-restore, and reactivation of the retired identity
+are findings. Because M3 is a continuous release-operation gate, a violation
+already merged into an environment without required checks becomes red after
+merge; this document does not claim the validator prevents every merge.
+Recovery from a false positive or contract defect requires an owner-approved
+contract amendment. Direct record repair or history editing is unsupported.
+
+V1 supports identity changes only before publication. A post-publication name
+change is not an in-place rename: handle the old identity as retirement and
+introduce the new identity as a separately approved skill.
+
+### Major-transition approval record
+
+Path: `.skillstead/major-approvals/<skill>-v<proposed_version>.json`
+
+```json
+{
+  "schema_version": 1,
+  "skill": "<skill>",
+  "previous_ref": "<skill>/vX.Y.Z",
+  "proposed_version": "X.Y.Z",
+  "authorization_id": "owner-YYYYMMDD-<16 lowercase hex>",
+  "approved_at": "YYYY-MM-DD",
+  "reason": "<neutral public-safe explanation>"
+}
+```
+
+The record applies only when the proposal is a single-step major transition.
+Its path, `skill`, `previous_ref`, and `proposed_version` bind it to that
+transition. The payload is still authorized by exact pull-request review and
+merge; the record does not approve arbitrary content. Any intervening release
+changes the latest observable `previous_ref` and invalidates the record
+fail-closed.
+
+Unlike retirement records, major-approval records are not first-parent
+persistence authorities in v1. The immutable version tag target preserves the
+accepted transition evidence, tag precedence prevents version reuse, and M3
+blocks tag deletion or retargeting. This lifecycle asymmetry is intentional:
+retirement records continue to authorize absence from the current inventory,
+while major-approval records authorize one completed transition.
+
+### Template identity and validator rotation
+
+`templates/skill-package/` is disposable scaffolding. `sample-skill` is a
+reserved identity, and M1 rejects it under active `skills/`; replace every
+identity surface before validating the materialized package. The template
+contains no second package validator.
+
+When a change rotates an INSTALL pin, lifecycle-state syntax, or another
+production validator contract, update the production validator and its
+real-repository fixture in the same pull request. This keeps documentation,
+the executable gate, and the consumer-shaped example on one revision.
 
 **Bump-Adjustment marker.** When the proposed step differs from the
 path-default step, the release's CHANGELOG entry must contain a standalone,

--- a/docs/VERSIONING.ko.md
+++ b/docs/VERSIONING.ko.md
@@ -85,6 +85,9 @@ heading입니다. `[Unreleased]` heading은 버전으로 보지 않고 건너뜁
 | 그 밖의 변경 | patch |
 | `1.0.0` 이상으로의 승격 | major — owner의 명시적 승인이 필요합니다 |
 
+실행 가능한 major transition 증거와 binding contract는
+[`VALIDATION.ko.md`](./VALIDATION.ko.md#major-transition-승인-record)에 정의합니다.
+
 변경의 성격이 모호하면 파일 위치로 판단합니다. `SKILL.md` 본문, `references/`, `scripts/`(fixture 제외),
 `agents/`는 기본이 minor이고, `README*.md`, `LICENSE*`, `assets/`, fixture는 기본이 patch입니다. 릴리스에서
 기본값을 어느 방향으로든 조정할 수 있지만, 그 사유를 CHANGELOG 항목에 적어야 합니다.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -86,6 +86,9 @@ produces, not the reason for one, so changing only them does not make a release.
 | Everything else | patch |
 | Promotion to `1.0.0` or above | major — requires explicit owner approval |
 
+The executable major-transition evidence and binding contract is specified in
+[`VALIDATION.md`](./VALIDATION.md#major-transition-approval-record).
+
 When the nature of a change is unclear, the file's location decides: `SKILL.md` body, `references/`,
 `scripts/` (excluding fixtures), and `agents/` default to minor; `README*.md`, `LICENSE*`, `assets/`,
 and fixtures default to patch. A release may override the default in either direction, but the reason

--- a/playbooks/README.ko.md
+++ b/playbooks/README.ko.md
@@ -8,16 +8,15 @@ Maintainer용 참고 문서(playbook) 영역입니다. 설치형 skill이 아니
 | Playbook | 용도 |
 | --- | --- |
 | [`public-release/`](./public-release/README.ko.md) | 비공개 저장소를 공개로 전환하고 이후를 검증할 때 쓰는 범용 체크리스트·템플릿 |
+| [`skill-development/`](./skill-development/README.ko.md) | Skill 개발을 위한 package, naming, validation, review, release, retirement 표준 |
 
-## public-release Provenance
+## public-release History
 
-`public-release/`의 문서 중 **기존 6개**(README, checklist, sweep, settings template, post-public
-verification, social template)는 독립 private repository `kyungseo/public-release-playbook`의
-`5594aef` snapshot을 2026-07-17에 이 저장소로 옮긴 것입니다. 공개해도 안전한 시점의 파일만 가져왔고
-Git 이력은 이관하지 않았습니다. 편입 당시 6개 파일은 원본 snapshot과 내용이 같았습니다.
-`recurring-release-protection-checkpoint.md`는 원본에 없었으며, 편입 뒤 첫 release protection 보강
-(2026-07-17)에서 새로 작성한 7번째 문서입니다. 이제 모든 문서는 이 repository의 일반 PR로 변경할
-수 있으며, 전부 [Apache-2.0](../LICENSE) license 범위에 포함됩니다.
+`public-release/`의 최초 6개 문서는 2026-07-17에 독립적으로 관리되던 public-safe snapshot에서
+편입했으며 Git history는 가져오지 않았습니다. `recurring-release-protection-checkpoint.md`는 이후
+7번째 문서로 추가했습니다. 원본 identity와 local revision은 public operating contract에 포함하지
+않습니다. 이제 모든 문서는 이 repository의 일반 pull request로 변경하며
+[Apache-2.0](../LICENSE) license 범위에 포함됩니다.
 
 이 playbook 문서들은 범용 release 절차의 최종 기준이며,
 [`skills/github-release-guide`](../skills/github-release-guide)는 같은 규칙을 자체 패키지에 포함한 설치형
@@ -25,3 +24,6 @@ mirror입니다. 두 문서의 내용이 서로 다를 경우에는 이 playbook
 최종 기준으로 관리하며, `.ko.md` 파일은 같은 내용을 담는 한국어 문서입니다. 의미가 달라지는 수정은
 두 언어 문서에 같은 pull request로 반영합니다. English와 한국어 문서의 내용이 서로 다르면 English
 문서를 기준으로 판단합니다.
+
+`skill-development/`는 authoring·lifecycle 규칙의 canonical maintainer reference입니다. 설치된
+skill이 이 playbook에 의존하도록 만들지는 않습니다.

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -8,16 +8,14 @@ on these files at installation time.
 | Playbook | Purpose |
 | --- | --- |
 | [`public-release/`](./public-release/README.md) | Generic checklists and templates for taking a private repository public and verifying it afterward |
+| [`skill-development/`](./skill-development/README.md) | Package, naming, validation, review, release, and retirement standard for developing skills |
 
-## public-release Provenance
+## public-release History
 
-Six documents in `public-release/`—the README, checklist, sensitive-information sweep, repository settings
-template, post-public verification, and social template—were consolidated from snapshot `5594aef` of the
-independent private repository `kyungseo/public-release-playbook` on 2026-07-17. The Git history was not imported;
-the consolidation used a public-safe snapshot, and the six files matched that source snapshot at the time of
-import. `recurring-release-protection-checkpoint.md` was not part of the snapshot. It was added as the seventh
-document in the first release-protection update after consolidation (2026-07-17). All
-documents may now change through this repository's normal pull-request process and are covered by the
+The initial six `public-release/` documents were consolidated from an independently maintained, public-safe
+snapshot on 2026-07-17 without importing its Git history. `recurring-release-protection-checkpoint.md` was added
+later as the seventh document. The source identity and local revision are not part of the public operating
+contract. All documents now change through this repository's normal pull-request process and are covered by the
 [Apache-2.0 license](../LICENSE).
 
 These playbooks are the canonical source for generic release mechanics.
@@ -25,3 +23,6 @@ These playbooks are the canonical source for generic release mechanics.
 two copies conflict, follow the playbooks. English is the canonical language; Korean mirrors use the `.ko.md`
 suffix and must carry the same semantic changes in the same pull request. If the English and Korean versions
 conflict, follow the English version.
+
+`skill-development/` is the canonical maintainer reference for authoring and lifecycle rules. It does not make an
+installed skill depend on the playbook.

--- a/playbooks/skill-development/README.ko.md
+++ b/playbooks/skill-development/README.ko.md
@@ -1,0 +1,44 @@
+# Skill Development Playbook
+
+[English](./README.md) · **한국어**
+
+Skillstead skill을 설계하고 검증·리뷰·릴리스하며, 필요한 경우 은퇴시킬 때 사용하는 maintainer
+참고 문서입니다. 설치형 skill이 아니며, 설치된 package는 이 디렉터리 없이도 완전해야 합니다.
+
+## 시작 순서
+
+1. [package 표준](./skill-package-standard.ko.md)을 읽습니다.
+2. [개발 절차](./skill-development-procedure.ko.md)를 따릅니다.
+3. [skill-package template](./templates/skill-package/)을 disposable workspace에 복사하고 예약된
+   identity를 교체한 뒤 materialized package를 검증합니다.
+4. 필요한 경우 scenario, expected outcome, validation ledger, review relay, release note template을
+   사용합니다.
+5. 프로젝트별 결정과 raw review evidence는 대상 repository에 남깁니다.
+
+## 문서
+
+| 경로 | 용도 |
+| --- | --- |
+| [`skill-package-standard.ko.md`](./skill-package-standard.ko.md) | package, intent, naming, safety, evidence, bilingual, review 기준 |
+| [`skill-development-procedure.ko.md`](./skill-development-procedure.ko.md) | intent brief부터 release 또는 retirement까지의 순서 |
+| [`templates/skill-package/`](./templates/skill-package/) | 예약 identity를 사용하는 유효한 시작 package |
+| [`templates/scenarios.ko.md`](./templates/scenarios.ko.md) | positive·negative scenario template |
+| [`templates/expected-outcomes.ko.md`](./templates/expected-outcomes.ko.md) | 분리된 answer key template |
+| [`templates/validation-ledger.ko.md`](./templates/validation-ledger.ko.md) | 반복 가능한 evidence·claim ledger |
+| [`templates/cross-review-relay.ko.md`](./templates/cross-review-relay.ko.md) | 역할 중립 independent review packet과 bounded-round 기록 |
+| [`templates/release-note.ko.md`](./templates/release-note.ko.md) | skill별 release note template |
+| [`examples/standard-gap-mapping.ko.md`](./examples/standard-gap-mapping.ko.md) | 현재 catalog와 표준의 mapping |
+| [`examples/disposable-sample-validation.ko.md`](./examples/disposable-sample-validation.ko.md) | package template의 official-validator proof |
+
+English가 canonical입니다. `.ko.md` 파일은 동일한 핵심 주장·조건·위험·행동을 자연스러운 한국어로
+전달합니다. 의미가 달라지는 변경은 두 언어에 같은 pull request로 반영합니다.
+
+## 권위 경계
+
+이 playbook은 authoring 표준을 소유합니다. 실행 가능한 repository·release gate는
+[`docs/VALIDATION.ko.md`](../../docs/VALIDATION.ko.md)가 소유합니다. 누가 변경을 승인할지는 대상
+repository의 approval workflow가 결정합니다. Review 도구는 리뷰를 실행하거나 기록할 수 있지만,
+해당 작업이 선언한 역할·evidence·결정 경계를 대신하지 않습니다.
+
+문서와 executable gate가 충돌하면 중단합니다. 문서로 gate를 약화하거나 절차를 임의로 다시 해석하지
+말고, contract를 해결한 뒤 문서와 fixture를 함께 갱신합니다.

--- a/playbooks/skill-development/README.md
+++ b/playbooks/skill-development/README.md
@@ -1,0 +1,43 @@
+# Skill Development Playbook
+
+**English** · [한국어](./README.ko.md)
+
+Use this playbook to design, validate, review, release, and—when necessary—retire a Skillstead skill. It is a
+maintainer reference, not an installable skill. An installed package must remain complete without this directory.
+
+## Start Here
+
+1. Read the [package standard](./skill-package-standard.md).
+2. Follow the [development procedure](./skill-development-procedure.md).
+3. Copy the [skill-package template](./templates/skill-package/) into a disposable workspace, replace its
+   reserved identity, and validate the materialized package.
+4. Use the scenario, expected-outcome, validation-ledger, review-relay, and release-note templates as needed.
+5. Keep project-specific decisions and raw review evidence in the target repository.
+
+## Documents
+
+| Path | Purpose |
+| --- | --- |
+| [`skill-package-standard.md`](./skill-package-standard.md) | Package, intent, naming, safety, evidence, bilingual, and review requirements |
+| [`skill-development-procedure.md`](./skill-development-procedure.md) | Ordered path from intent brief through release or retirement |
+| [`templates/skill-package/`](./templates/skill-package/) | Valid concrete starting package with a reserved identity |
+| [`templates/scenarios.md`](./templates/scenarios.md) | Positive and negative scenario template |
+| [`templates/expected-outcomes.md`](./templates/expected-outcomes.md) | Separate answer-key template |
+| [`templates/validation-ledger.md`](./templates/validation-ledger.md) | Repeatable evidence and claim ledger |
+| [`templates/cross-review-relay.md`](./templates/cross-review-relay.md) | Role-neutral independent-review packet and bounded-round record |
+| [`templates/release-note.md`](./templates/release-note.md) | Per-skill release-note template |
+| [`examples/standard-gap-mapping.md`](./examples/standard-gap-mapping.md) | Mapping of the current catalog to the standard |
+| [`examples/disposable-sample-validation.md`](./examples/disposable-sample-validation.md) | Official-validator proof for the package template |
+
+English is canonical. Korean mirrors carry the same material claims, conditions, risks, and actions in files with
+the `.ko.md` suffix. Update both languages in the same pull request.
+
+## Authority Boundary
+
+This playbook owns the authoring standard. [`docs/VALIDATION.md`](../../docs/VALIDATION.md) owns executable
+repository and release gates. A target repository's approval workflow owns who may approve changes. Review tools
+may execute or persist the review, but they do not replace the role, evidence, and decision boundaries declared
+for the work.
+
+If prose and an executable gate conflict, stop. Do not weaken the gate in prose or silently reinterpret the
+procedure; resolve the contract and update its documentation and fixtures together.

--- a/playbooks/skill-development/examples/disposable-sample-validation.ko.md
+++ b/playbooks/skill-development/examples/disposable-sample-validation.ko.md
@@ -1,0 +1,25 @@
+# Disposable Package Validation
+
+Repository test `test_materialized_template_passes_production_m1`은 두 번째 validator나 reserved-name
+bypass 없이 concrete package template을 유효한 active package로 만들 수 있음을 확인합니다.
+
+## Procedure
+
+1. M1을 이미 통과하는 disposable synthetic repository를 만듭니다.
+2. `playbooks/skill-development/templates/skill-package/`을 복사합니다.
+3. 모든 `sample-skill` identity를 `example-skill`로 교체합니다.
+4. Synthetic repository의 root license를 package license에 덮어씁니다.
+5. 일치하는 English·한국어 active catalog row를 추가합니다.
+6. Production `run_repo_validation` entrypoint를 실행합니다.
+
+예상 결과: finding 0건.
+
+Control: `sample-skill`을 교체하지 않고 active inventory에 복사하면 `RESERVED-NAME` finding이
+발생합니다.
+
+## Evidence Boundary
+
+이 fixture는 M1 기준 package shape, identity replacement, license byte equality,
+changelog/version agreement, catalog coverage를 확인합니다. Trigger behavior, runtime support, release
+readiness, public-user adoption은 증명하지 않습니다. 기록 output에는 repository-relative path만
+사용하고 temporary-directory 이름을 공개하지 않습니다.

--- a/playbooks/skill-development/examples/disposable-sample-validation.md
+++ b/playbooks/skill-development/examples/disposable-sample-validation.md
@@ -1,0 +1,24 @@
+# Disposable Package Validation
+
+The repository test `test_materialized_template_passes_production_m1` proves that the concrete package template
+can become a valid active package without a second validator or a reserved-name bypass.
+
+## Procedure
+
+1. Create a disposable synthetic repository that already passes M1.
+2. Copy `playbooks/skill-development/templates/skill-package/`.
+3. Replace every `sample-skill` identity with `example-skill`.
+4. Copy the synthetic repository's root license over the package license.
+5. Add matching English and Korean active catalog rows.
+6. Run the production `run_repo_validation` entrypoint.
+
+Expected result: zero findings.
+
+Control: copying the package into active inventory without replacing `sample-skill` produces
+`RESERVED-NAME`.
+
+## Evidence Boundary
+
+This fixture proves package shape, identity replacement, license byte equality, changelog/version agreement, and
+catalog coverage under M1. It does not prove trigger behavior, runtime support, release readiness, or public-user
+adoption. Paths in recorded output must be repository-relative; do not publish temporary-directory names.

--- a/playbooks/skill-development/examples/standard-gap-mapping.ko.md
+++ b/playbooks/skill-development/examples/standard-gap-mapping.ko.md
@@ -1,0 +1,31 @@
+# Current Catalog Standard Mapping
+
+현재 package 4개를 authoring 표준에 대조한 결과입니다. 적용 가능성을 기록하며 runtime·maturity
+claim은 변경하지 않습니다.
+
+| 표준 영역 | docs-claim-check | github-release-guide | svg-infographic | writing-quality-editor |
+| --- | --- | --- | --- | --- |
+| EN/KO package README | adopt — pair 존재 | adopt — pair 존재 | adopt — pair 존재 | adopt — pair 존재 |
+| Folder = frontmatter name | adopt — M1 | adopt — M1 | adopt — M1 | adopt — M1 |
+| Use·do-not-use 경계 | adopt — 명시됨 | adopt — 명시됨 | adopt — 명시됨 | adopt — 명시됨 |
+| Self-contained license | adopt — M1 byte equality | adopt — M1 byte equality | adopt — M1 byte equality | adopt — M1 byte equality |
+| 상세 `references/` 분리 | not applicable — compact package contract | adapt — profile reference | adapt — authoring/archetype reference | adapt — editing/adaptation reference |
+| Required-reference failure | not applicable — required package reference 없음 | adopt — profile 누락 시 Guided mutation 차단 | adopt — required authoring reference 누락 시 automated path 차단 | adopt — required reference 누락 시 revision 차단 |
+| Mutation approval | adopt — advisory/no-edit 경계 | adopt — action별 approval | adopt — output path·system change approval | adopt — host workflow·mutation boundary |
+| Fresh-context evidence | adapt — synthetic assessment evidence | adapt — release-profile evidence | adopt — frozen fresh-context brief | adopt — fresh-context behavior fixture |
+
+## Gap과 disposition
+
+- **Naming lifecycle:** 현재 public identity는 input이며 rename 후보가 아닙니다. 새 pre-publication
+  naming procedure는 future package에 적용하고 공개 후 in-place rename은 지원하지 않습니다.
+- **Independent review evidence:** future material package change에 review가 필요하면 relay template을
+  사용합니다. 모든 과거 변경이 새 template을 사용했다고 소급해서 주장하지 않습니다.
+- **Bilingual parity:** 현재 pair가 존재하고 repository validation은 green입니다. 문장 수 일치는
+  gate가 아니므로 material parity는 계속 review obligation입니다.
+- **Scripts:** `svg-infographic`은 executable script와 기존 runtime fixture를 소유합니다. V1
+  authoring template에는 script가 없으며 script-runtime claim도 하지 않습니다.
+
+## Evidence Boundary
+
+현재 package tree와 production repository validator를 근거로 한 mapping입니다. 새로운 runtime,
+locale, provider, maturity support를 증명하지 않습니다.

--- a/playbooks/skill-development/examples/standard-gap-mapping.md
+++ b/playbooks/skill-development/examples/standard-gap-mapping.md
@@ -1,0 +1,31 @@
+# Current Catalog Standard Mapping
+
+This mapping checks four current packages against the authoring standard. It records applicability; it does not
+change their runtime or maturity claims.
+
+| Standard area | docs-claim-check | github-release-guide | svg-infographic | writing-quality-editor |
+| --- | --- | --- | --- | --- |
+| EN/KO package README | adopt — pair present | adopt — pair present | adopt — pair present | adopt — pair present |
+| Folder = frontmatter name | adopt — M1 | adopt — M1 | adopt — M1 | adopt — M1 |
+| Use and do-not-use boundary | adopt — explicit | adopt — explicit | adopt — explicit | adopt — explicit |
+| Self-contained license | adopt — M1 byte equality | adopt — M1 byte equality | adopt — M1 byte equality | adopt — M1 byte equality |
+| Detailed `references/` split | not applicable — compact package contract | adapt — profile references | adapt — authoring/archetype references | adapt — editing/adaptation references |
+| Required-reference failure | not applicable — no required package reference | adopt — missing profile blocks Guided mutation | adopt — missing required authoring reference blocks automated path | adopt — missing required reference blocks revision |
+| Mutation approval | adopt — advisory/no-edit boundary | adopt — per-action approval | adopt — output-path and system-change approval | adopt — host workflow and mutation boundary |
+| Fresh-context evidence | adapt — synthetic assessment evidence | adapt — release-profile evidence | adopt — frozen fresh-context briefs | adopt — fresh-context behavior fixtures |
+
+## Gaps And Dispositions
+
+- **Naming lifecycle:** existing public identities are inputs, not rename candidates. The new pre-publication naming
+  procedure applies to future packages; post-publication in-place rename remains unsupported.
+- **Independent review evidence:** use the relay template when a future material package change needs review. This
+  mapping does not retroactively claim that every historical change used the new template.
+- **Bilingual parity:** current pairs are present and repository validation is green. Material parity remains a
+  review obligation because sentence-count equality is not a gate.
+- **Scripts:** `svg-infographic` contains executable scripts and owns their existing runtime fixtures. The v1
+  authoring template deliberately contains no script and makes no script-runtime claim.
+
+## Evidence Boundary
+
+The mapping is based on the current package trees and production repository validator. It does not establish
+support for a new runtime, locale, provider, or maturity level.

--- a/playbooks/skill-development/skill-development-procedure.ko.md
+++ b/playbooks/skill-development/skill-development-procedure.ko.md
@@ -1,0 +1,111 @@
+# Skill Development Procedure
+
+[English](./skill-development-procedure.md) · **한국어**
+
+사용자 권한이나 public support claim을 실수로 넓히지 않으면서 intent를 self-contained,
+evidence-backed skill로 만드는 절차입니다.
+
+## 1. 작업 범위 설정
+
+사용자 결과, non-goal, 변경 파일, validation, risk, reversal cost, approval owner를 기록합니다.
+Package 내부 guidance를 적용하기 전에 host repository의 artifact·state·release·mutation workflow를
+확인합니다.
+
+Intent가 구체화된 뒤에만 working name을 정합니다. 아직 public catalog row, install pin, release
+identity는 만들지 않습니다.
+
+## 2. Intent contract 작성
+
+Named, natural-language, negative, ambiguous, mutation, host-precedence scenario를 작성합니다.
+Expected outcome은 별도 answer key에 둡니다. Fresh reviewer가 볼 수 있는 input 범위를 명시합니다.
+
+다음을 확인합니다.
+
+- skill을 선택해야 하는 요청과 선택하면 안 되는 요청;
+- read-only 또는 no-mutation 기본값;
+- explicit approval이 필요한 행동;
+- 안전한 failure·recovery;
+- runtime·locale evidence가 필요한 claim.
+
+## 3. 공개 전 identity 확정
+
+Working-name 후보를 행동의 명확성, collision, folder/frontmatter 정합성, 길이로 비교합니다.
+Trigger-overlap case를 실행합니다. 그다음 Owner가 첫 public catalog 등록 또는 release 전에 canonical
+name을 유지하거나 변경합니다.
+
+이름을 바꾸면 folder, frontmatter, display text, README link, install command, example, index,
+validation fixture, 예정된 release identity를 승인된 한 변경에서 갱신합니다. V1은 공개 후 in-place
+rename을 지원하지 않습니다.
+
+## 4. Package materialization
+
+`templates/skill-package/`을 disposable repository에 복사합니다. `skills/`로 옮기기 전에 모든
+`sample-skill` identity를 교체해야 합니다. Production validator는 active inventory의 예약 이름을
+거부합니다.
+
+Package를 self-contained하게 유지합니다. Repository root license를 byte-for-byte로 복사합니다.
+Entrypoint 사용성이 나빠질 때만 required reference를 추가합니다. 동작에 꼭 필요하고 symlink
+invocation positive·negative fixture가 준비되지 않았다면 executable script를 추가하지 않습니다.
+
+## 5. 사용자 문서 작성
+
+그럴듯한 일반 설명이 아니라 intent·evidence ledger를 근거로 작성합니다. Use·do-not-use case,
+approval·mutation boundary, failure behavior, host-workflow precedence를 적습니다. 관측한 evidence보다
+runtime, locale, maturity를 확대하지 않습니다.
+
+English를 canonical로 작성합니다. 한국어 mirror는 문장 구조를 복사하지 않고 핵심 의미를 보존하면서
+한국어 독자에게 자연스럽게 구성합니다.
+
+## 6. Validation
+
+최소 검증:
+
+1. materialized disposable repository에 official M1 repository validator 실행;
+2. 적용 가능한 positive, negative, ambiguous, mutation, host-precedence scenario 실행;
+3. package license containment와 byte equality 확인;
+4. folder/frontmatter/catalog/install/release identity 확인;
+5. English·한국어 claim, condition, link, limitation, next action 확인;
+6. public evidence를 repository-relative path로 정리;
+7. raw result와 residual risk를 validation ledger에 기록.
+
+Template 안에 두 번째 package validator를 만들지 않습니다.
+
+## 7. Review
+
+Independent review가 변경 위험에 비례할 때 `templates/cross-review-relay.ko.md`를 사용합니다.
+Repository의 기존 review workflow나 review-recording tool이 relay를 실행할 수 있습니다.
+
+Reviewer는 문장뿐 아니라 contract와 evidence를 검토합니다. Driver는 모든 finding을 disposition합니다.
+Recheck는 열린 named finding만 다룹니다. Blocker, scope expansion, round bound 소진 뒤 미합의는
+arbiter에게 올립니다. Review approval 자체는 commit, publication, tag 변경, release operation을
+승인하지 않습니다.
+
+## 8. Integration과 release
+
+Package, fixture, evidence가 일치한 뒤 root catalog와 maintainer entrypoint를 갱신합니다. Per-skill
+versioning·release gate를 따릅니다. INSTALL pin, validator lifecycle state, supported syntax가 바뀌면
+production validator와 관련 real-repository fixture를 같은 pull request에서 회전합니다.
+
+Publish 전에 release note를 준비합니다. Versioned unit은 하나의 `skills/<name>/` package입니다.
+GitHub source archive는 repository snapshot이며 standalone package artifact가 아닙니다.
+
+Merge-to-tag 구간의 임시 red를 숨기지 않습니다. 실제 merge target과 remote ref를 관측한 뒤 문서에
+정한 bounded path만 다시 실행합니다. 예상하지 못한 code나 partial ref는 Owner가 결정합니다.
+
+## 9. 지원 종료 시 retirement
+
+Retirement는 active skill에 적용하며 disposable pre-publication material에는 적용하지 않습니다.
+
+1. Package, 양쪽 active catalog row, 양쪽 INSTALL 문서, reference, support claim을 inventory합니다.
+2. [`docs/VALIDATION.ko.md`](../../docs/VALIDATION.ko.md)의 strict schema를 따르는
+   `.skillstead/retirements/<skill>.json`, package·catalog·pin 제거, 양쪽 retired-table row를 하나의
+   merge candidate로 준비합니다.
+3. Record가 full removal과 동일한 `main` first-parent merge commit에서 처음 나타나는지 확인합니다.
+   Record만 먼저 merge하면 permanent M3 red history가 생깁니다.
+4. Current `main`을 기반으로 한 disposable repository에서 예상 merge tree를 한 commit으로 만든 뒤
+   M1, M2 preflight, 해당 commit을 `--main-ref`로 지정한 M3, link, public-hygiene check를 실행합니다.
+5. Owner가 merge 전에 exact record, 예상 merge commit, full-removal diff를 검토합니다.
+
+Tracked record는 변경 없이 남깁니다. 같은 identity로 package를 다시 추가하는 것은 지원하지 않습니다.
+False positive나 contract defect는 Owner가 승인한 contract amendment로 해결하며, history를 수정하거나
+record를 직접 고치는 것은 지원되는 recovery가 아닙니다.

--- a/playbooks/skill-development/skill-development-procedure.md
+++ b/playbooks/skill-development/skill-development-procedure.md
@@ -1,0 +1,110 @@
+# Skill Development Procedure
+
+**English** · [한국어](./skill-development-procedure.ko.md)
+
+This procedure turns an intent into a self-contained, evidence-backed skill without expanding user authority or
+public support claims by accident.
+
+## 1. Frame The Work
+
+Record the target user outcome, non-goals, affected files, validation, risk, reversal cost, and approval owner.
+Identify the host repository's artifact, state, release, and mutation workflows before applying package-local
+guidance.
+
+Choose a working name only after the intent is concrete. Do not create public catalog rows, install pins, or
+release identity yet.
+
+## 2. Build The Intent Contract
+
+Write named, natural-language, negative, ambiguous, mutation, and host-precedence scenarios. Keep expected
+outcomes in a separate answer key. State which inputs a fresh reviewer may see.
+
+Confirm:
+
+- what selects the skill and what does not;
+- the read-only or no-mutation default;
+- actions requiring explicit approval;
+- safe failure and recovery;
+- claims that require runtime or locale evidence.
+
+## 3. Lock The Pre-Publication Identity
+
+Compare working-name candidates for action clarity, collisions, folder/frontmatter consistency, and length.
+Run trigger-overlap cases. The owner then retains or changes the canonical name before the first public catalog
+entry or release.
+
+If the name changes, update the folder, frontmatter, display text, README links, install commands, examples,
+indexes, validation fixtures, and planned release identity in the same approved change. V1 does not support an
+in-place rename after publication.
+
+## 4. Materialize The Package
+
+Copy `templates/skill-package/` into a disposable repository. Replace every `sample-skill` identity before moving
+it under `skills/`; the production validator rejects that reserved name in active inventory.
+
+Keep the package self-contained. Copy the repository's root license byte-for-byte. Add required references only
+when the entrypoint would otherwise become hard to use. Do not add executable scripts unless the behavior needs
+them and symlink invocation has positive and negative fixtures.
+
+## 5. Compose User-Facing Guidance
+
+Write from the intent and evidence ledger, not from a plausible generic story. State use and do-not-use cases,
+approval and mutation boundaries, failure behavior, and host-workflow precedence. Do not promote runtime, locale,
+or maturity beyond observed evidence.
+
+Write English as canonical. Adapt the Korean mirror for Korean readers while preserving material meaning rather
+than copying sentence structure.
+
+## 6. Validate
+
+At minimum:
+
+1. run the official M1 repository validator on the materialized disposable repository;
+2. run positive, negative, ambiguous, mutation, and host-precedence scenarios that apply;
+3. verify package license containment and byte equality;
+4. verify folder/frontmatter/catalog/install/release identity;
+5. audit English/Korean claims, conditions, links, limitations, and next actions;
+6. sanitize public evidence to repository-relative paths;
+7. record raw results and residual risk in the validation ledger.
+
+Do not implement a second package validator inside the template.
+
+## 7. Review
+
+Use `templates/cross-review-relay.md` when independent review is proportionate to the change. A repository's
+existing review workflow or review-recording tool may execute the relay.
+
+The reviewer attacks the contract and evidence, not only prose. The driver dispositions every finding. Recheck
+only open named findings. An unresolved blocker, scope expansion, or exhausted round bound goes to the arbiter.
+Approval of the review does not itself authorize commit, publication, tag changes, or release operations.
+
+## 8. Integrate And Release
+
+Update the root catalog and maintainer entrypoint only after the package, fixtures, and evidence agree. Follow
+the per-skill versioning and release gates. If an INSTALL pin, validator lifecycle state, or supported syntax
+changes, rotate the production validator and related real-repository fixture in the same pull request.
+
+Prepare the release note before publishing. The versioned unit is one `skills/<name>/` package; a GitHub source
+archive is a repository snapshot, not a standalone package artifact.
+
+During the merge-to-tag window, do not suppress a temporary red result. Re-run only the documented bounded path
+after the actual merge target and remote refs are observable. Unexpected codes or partial refs require an owner
+decision.
+
+## 9. Retire When Support Ends
+
+Retirement applies to an active skill, not disposable pre-publication material.
+
+1. Inventory the package, both active catalog rows, both INSTALL documents, references, and support claims.
+2. Prepare `.skillstead/retirements/<skill>.json` with the strict schema in
+   [`docs/VALIDATION.md`](../../docs/VALIDATION.md), the package/catalog/pin removals, and both retired-table rows
+   as one merge candidate.
+3. Ensure the record first appears in the same `main` first-parent merge commit as the full removal. Never merge
+   the record alone: a record-first split merge creates a permanent M3 red history.
+4. In a disposable repository based on current `main`, materialize the expected merge tree as one commit and run
+   M1, an M2 preflight, M3 against that commit as `--main-ref`, links, and public-hygiene checks.
+5. The owner reviews the exact record, expected merge commit, and full-removal diff before merge.
+
+The tracked record remains unchanged. Re-adding the package under that identity is unsupported. A false positive
+or contract defect requires an owner-approved contract amendment; editing history or repairing the record
+directly is not a supported recovery path.

--- a/playbooks/skill-development/skill-package-standard.ko.md
+++ b/playbooks/skill-development/skill-package-standard.ko.md
@@ -1,0 +1,105 @@
+# Skill Package Standard
+
+[English](./skill-package-standard.md) · **한국어**
+
+Skillstead skill에 필요한 최소 package·evidence contract를 설명합니다. 각 규칙은 명시된 조건이
+성립할 때만 적용하며, 일부 package에서 관측한 패턴을 모든 skill의 의무로 일반화하지 않습니다.
+
+## Package 경계
+
+설치 단위는 완전한 `skills/<name>/` 폴더입니다. 설치 뒤에는 `playbooks/`, repository 전용 example,
+private note, package 밖의 파일에 의존하면 안 됩니다.
+
+필수 항목:
+
+- lowercase-hyphen `name`, 정확한 사용·비사용 경계, package 내부 license pointer,
+  `MAJOR.MINOR.PATCH` 형식의 `metadata.version`을 가진 `SKILL.md`;
+- 최상단 released version이 `metadata.version`과 같은 `CHANGELOG.md`;
+- root Apache-2.0 license와 byte가 같은 사본;
+- instruction에 필요한 모든 required reference, script, asset, agent file.
+
+`SKILL.md` entrypoint는 얇게 유지합니다. 상세 내용이 entrypoint를 흐리게 할 때만 `references/`로
+분리합니다. 안전하거나 정확한 행동에 reference가 필수라면 반드시 로드하도록 지시하고, 읽을 수 없으면
+fail-closed합니다. Optional reference는 한계를 밝히고 degrade할 수 있습니다.
+
+## Intent와 안전
+
+문서를 쓰기 전에 다음을 기록합니다.
+
+- 사용자 결과와 skill 이름을 직접 쓰는 예시;
+- 자연어로 요청했을 때 skill을 선택해야 하는 사례;
+- 비슷하지만 선택하면 안 되는 사례;
+- ambiguous case와 read-only 또는 no-mutation 기본값;
+- mutation, approval, destructive effect, recovery;
+- 우선 적용해야 하는 host artifact workflow.
+
+Description에는 skill이 하는 일과 하지 않는 일을 함께 적습니다. 자연어 요청만으로 mutation authority를
+넓히면 안 됩니다. Host가 문서 분류, repository state, release approval 같은 artifact workflow를
+소유한다면 package 내부의 writing·analysis guidance보다 먼저 그 workflow를 따릅니다.
+
+## Naming lifecycle
+
+1. intent와 trigger example을 작성합니다.
+2. working name을 정합니다.
+3. 행동의 명확성, collision, 64자 lowercase-hyphen 제한으로 후보를 비교합니다.
+4. trigger-overlap fixture를 실행합니다.
+5. folder, frontmatter, display text, README, install pin, index, release identity를 하나의 map으로 확인합니다.
+6. Owner가 첫 public catalog 등록 또는 release 전에 canonical name을 유지하거나 변경합니다.
+7. 이름을 바꾸면 승인된 한 변경에서 pre-publication rename cascade를 닫습니다.
+
+Template identity `sample-skill`은 예약어입니다. `skills/` 아래에 materialize하기 전에 반드시
+교체해야 합니다. V1은 공개 후 in-place identity rename을 지원하지 않습니다. 필요해지면 기존
+identity의 retirement와 새 identity의 신규 skill 도입을 별도 승인 작업으로 다룹니다.
+
+Naming example은 절차만 보여 주며 다른 product의 canonical name을 결정하지 않습니다.
+
+## Validation과 claim
+
+Scenario와 expected outcome을 분리합니다. 적용 가능한 경우 positive, negative, ambiguous, mutation,
+host-precedence, fresh-context case를 포함합니다. 정확한 package revision, runtime/capability surface,
+input, output, finding, residual risk를 기록합니다.
+
+문서 리뷰가 성공했거나 참여 agent 수가 많다는 이유로 support를 추론하지 않습니다. Runtime, locale,
+maturity claim은 관측한 evidence 범위로 제한합니다. Public evidence에는 repository-relative path를
+사용하고 username, local absolute path, private tracker identifier, model/session identity, 무관한
+comparison provenance를 제거합니다.
+
+두 언어가 있으면 English package guidance가 canonical입니다. 한국어 문서는 claim, condition, risk,
+identifier, link, limitation, approval, next action을 보존해야 하며 문장 수가 같을 필요는 없습니다.
+
+## Independent review
+
+Public behavior, approval·mutation boundary, release·retirement, 여러 consumer surface 또는 실질적인
+reversal cost에 영향을 주는 변경에는 independent review를 사용합니다. 작은 기계적 변경은 대상
+repository가 별도로 요구하지 않는 한 필수가 아닙니다.
+
+도구 이름 대신 역할을 사용합니다.
+
+- `driver`: scope, evidence, change, finding disposition 소유;
+- `reviewer`: 전제, fixture, hidden cost, unsupported claim 검토;
+- `specialist`: 필요할 때 한정된 concern 검토;
+- `arbiter`: 미해결 정책, scope expansion, 최종 approval 결정.
+
+Target revision, review scope, finding, driver response, residual risk, arbiter decision을 artifact로
+남깁니다. Driver는 finding마다 `accept`, `revise`, `defend`, `needs-user`를 기록합니다. Recheck는
+열린 named finding만 다루며 전체 설계를 다시 열지 않습니다. 시작 전에 round bound 또는 escalation
+규칙을 정하고, bound에 도달해도 합의되지 않으면 무한 반복하지 않고 arbiter가 결정합니다.
+
+Agent가 여러 명이라고 독립성이 증명되지는 않습니다. Reviewer의 fresh context 여부, answer key를
+보지 않았는지, agent별 artifact 또는 격리된 tree를 사용했는지 기록합니다. Host review workflow나
+review-recording tool이 이 contract를 실행할 수 있지만, package는 특정 product 하나를 요구하면
+안 됩니다.
+
+## Release, retirement, change control
+
+[`docs/VERSIONING.ko.md`](../../docs/VERSIONING.ko.md)와
+[`docs/VALIDATION.ko.md`](../../docs/VALIDATION.ko.md)를 따릅니다. Major transition에는 target-bound
+tracked approval record가 필요합니다. 이 record는 version transition만 승인하며 payload approval은
+exact pull request review·merge에 남습니다.
+
+Active skill을 제거하려면 retirement record와 full-removal predicate가 필요합니다. Retirement
+record는 durable evidence이므로 삭제·변경하거나 package를 조용히 다시 추가해 우회할 수 없습니다.
+과거 문서는 맥락으로 남길 수 있지만 active install·support claim처럼 읽히면 안 됩니다.
+
+Release가 INSTALL pin, validator lifecycle state, supported syntax를 바꾸면 production validator와
+관련 real-repository fixture를 같은 pull request에서 갱신합니다.

--- a/playbooks/skill-development/skill-package-standard.md
+++ b/playbooks/skill-development/skill-package-standard.md
@@ -1,0 +1,105 @@
+# Skill Package Standard
+
+**English** · [한국어](./skill-package-standard.ko.md)
+
+This standard describes the minimum package and evidence contract for a Skillstead skill. Apply a rule only when
+its stated condition holds; do not turn an observed pattern into a universal requirement.
+
+## Package Boundary
+
+An installable skill is the complete `skills/<name>/` folder. It must not depend on `playbooks/`, repository-only
+examples, private notes, or files outside its package after installation.
+
+Required:
+
+- `SKILL.md` with lowercase-hyphen `name`, an accurate use/do-not-use description, a package-contained license
+  pointer, and `metadata.version` in `MAJOR.MINOR.PATCH` form;
+- `CHANGELOG.md` whose top released version equals `metadata.version`;
+- a byte-identical copy of the root Apache-2.0 license;
+- every required reference, script, asset, or agent file needed by the instructions.
+
+Use a thin `SKILL.md` entrypoint. Move detailed material to `references/` only when that keeps the entrypoint
+focused. If a reference is required for a safe or correct action, instruct the agent to load it and fail closed
+when it cannot be read. Optional references may degrade explicitly.
+
+## Intent And Safety
+
+Before writing prose, record:
+
+- the user outcome and named-skill examples;
+- natural-language requests that should select the skill;
+- similar requests that should not select it;
+- ambiguous cases and their read-only or no-mutation default;
+- mutations, approvals, destructive effects, and recovery;
+- host-provided artifact workflows that take precedence.
+
+The description must say what the skill does and does not do. A natural request must not silently widen mutation
+authority. When the host owns an artifact workflow—such as document classification, repository state, or release
+approval—follow that workflow before applying package-local writing or analysis guidance.
+
+## Naming Lifecycle
+
+1. Write the intent and trigger examples.
+2. Choose a working name.
+3. Compare candidates for action clarity, collisions, and the 64-character lowercase-hyphen limit.
+4. Run trigger-overlap fixtures.
+5. Verify folder, frontmatter, display text, README, install pins, indexes, and release identity as one map.
+6. The owner retains or changes the canonical name before the first public catalog entry or release.
+7. If it changes, close the pre-publication rename cascade in one approved change.
+
+The template identity `sample-skill` is reserved. It must be replaced before materialization under `skills/`.
+Post-publication in-place identity rename is unsupported in v1. If that need appears, treat the existing identity
+as a retirement candidate and the new identity as a new skill in separately approved work.
+
+Naming examples demonstrate the procedure; they do not decide another product's canonical name.
+
+## Validation And Claims
+
+Keep scenarios separate from expected outcomes. Include positive, negative, ambiguous, mutation, host-precedence,
+and fresh-context cases when they apply. Record the exact package revision, runtime/capability surface, inputs,
+outputs, findings, and residual risk.
+
+Do not infer support from successful prose review or from the number of agents involved. Runtime, locale, and
+maturity claims must be limited to observed evidence. Sanitize public evidence: use repository-relative paths and
+remove usernames, local absolute paths, private tracker identifiers, model/session identity, and unrelated
+comparison provenance.
+
+English package guidance is canonical when both languages exist. Korean material must preserve claims,
+conditions, risks, identifiers, links, limitations, approvals, and next actions; matching sentence counts are
+not required.
+
+## Independent Review
+
+Use independent review when the change affects public behavior, approval or mutation boundaries, release or
+retirement, multiple consumer surfaces, or has material reversal cost. Small mechanical changes do not require it
+unless the target repository says otherwise.
+
+Use role names rather than tool names:
+
+- `driver`: owns the scope, evidence, change, and finding disposition;
+- `reviewer`: challenges the premise, fixtures, hidden cost, and unsupported claims;
+- `specialist`: reviews one bounded concern when needed;
+- `arbiter`: decides unresolved policy, scope expansion, and final approval.
+
+Persist the target revision, review scope, findings, driver response, residual risk, and arbiter decisions. The
+driver marks each finding `accept`, `revise`, `defend`, or `needs-user`. Rechecks cover open named findings, not
+the whole design again. Set a round bound or escalation rule before starting; reaching it without convergence is
+an arbiter decision, not permission to continue indefinitely.
+
+Multiple agents do not prove independence. Record whether the reviewer had fresh context, whether an answer key
+was hidden, and whether agents owned separate artifacts or worked in isolated trees. A host review workflow or
+review-recording tool may implement this contract; the package must not require one named product.
+
+## Release, Retirement, And Change Control
+
+Follow [`docs/VERSIONING.md`](../../docs/VERSIONING.md) and
+[`docs/VALIDATION.md`](../../docs/VALIDATION.md). A major transition requires a target-bound tracked approval
+record. That record approves the version transition, not the payload; payload approval remains with exact pull
+request review and merge.
+
+Removing an active skill requires a retirement record and the full removal predicate. A retirement record is
+durable evidence and cannot be deleted, changed, or bypassed by silently re-adding the package. Historical prose
+may remain as context, but it must not read as an active install or support claim.
+
+If a release changes an INSTALL pin, validator lifecycle state, or supported syntax, update the production
+validator and the related real-repository fixture in the same pull request.

--- a/playbooks/skill-development/templates/cross-review-relay.ko.md
+++ b/playbooks/skill-development/templates/cross-review-relay.ko.md
@@ -1,0 +1,97 @@
+# Independent Review Relay Template
+
+Skill 변경에 independent review가 필요한 경우 사용합니다. 이 template은 portable evidence contract를
+정의하며 host workflow나 review-recording tool이 실행할 수 있습니다.
+
+## Setup
+
+Target:
+
+- Package와 exact revision:
+- Review purpose:
+
+Roles:
+
+- Driver:
+- Reviewer:
+- Specialist, optional:
+- Arbiter:
+
+Round rule:
+
+- Initial review:
+- Named-finding recheck 최대 횟수 또는 escalation 조건:
+
+Non-goals:
+
+- ...
+
+Artifact ownership:
+
+- Driver 소유 파일:
+- Reviewer output 경로:
+- Isolation 또는 separate-tree 규칙:
+
+## Relay Packet
+
+Current state:
+
+- 변경 파일:
+- 완료한 validation:
+- Known limitation:
+
+Review objective:
+
+- ...
+
+Must check:
+
+1. intent와 trigger selection;
+2. negative, ambiguous, mutation, host-precedence behavior;
+3. package self-containment와 official-validator evidence;
+4. claim, bilingual parity, public sanitation;
+5. 적용 가능한 release, retirement, rollback, hidden cost.
+
+Do not re-litigate:
+
+- ...
+
+Independence:
+
+- Fresh context: yes / no
+- Answer key 미열람: yes / no / not applicable
+- Shared working tree: no / controlled exception
+
+## Reviewer Findings
+
+Verdict: approve / conditional / request-changes / reject
+
+| ID | Severity | Finding | Evidence | Must-fix | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+|  | P1 / P2 / P3 |  |  |  |  |
+
+Residual risk:
+
+- ...
+
+## Driver Response
+
+| Finding | Decision | Response | Follow-up |
+| --- | --- | --- | --- |
+|  | accept / revise / defend / needs-user |  |  |
+
+`needs-user`, defend한 blocker, scope expansion, round bound 소진은 관련 변경을 계속하기 전에 arbiter에게
+올립니다.
+
+## Round And Consensus Log
+
+| Round | Objective | Verdict | Status |
+| --- | --- | --- | --- |
+|  |  |  | open / closed / escalated |
+
+| Topic | Status | Notes |
+| --- | --- | --- |
+|  | agreed / deferred / arbiter-decided |  |
+
+Review approval은 commit, publication, tag 변경, release operation, destructive action을 자동 승인하지
+않습니다. 대상 repository의 일반 approval gate를 별도로 적용합니다.

--- a/playbooks/skill-development/templates/cross-review-relay.md
+++ b/playbooks/skill-development/templates/cross-review-relay.md
@@ -1,0 +1,97 @@
+# Independent Review Relay Template
+
+Use this template when independent review is proportionate to the skill change. It defines a portable evidence
+contract; a host workflow or review-recording tool may execute it.
+
+## Setup
+
+Target:
+
+- Package and exact revision:
+- Review purpose:
+
+Roles:
+
+- Driver:
+- Reviewer:
+- Specialist, optional:
+- Arbiter:
+
+Round rule:
+
+- Initial review:
+- Maximum named-finding rechecks or escalation condition:
+
+Non-goals:
+
+- ...
+
+Artifact ownership:
+
+- Driver-owned files:
+- Reviewer output path:
+- Isolation or separate-tree rule:
+
+## Relay Packet
+
+Current state:
+
+- Changed files:
+- Validation completed:
+- Known limitations:
+
+Review objective:
+
+- ...
+
+Must check:
+
+1. intent and trigger selection;
+2. negative, ambiguous, mutation, and host-precedence behavior;
+3. package self-containment and official-validator evidence;
+4. claims, bilingual parity, and public sanitation;
+5. release, retirement, rollback, and hidden cost when applicable.
+
+Do not re-litigate:
+
+- ...
+
+Independence:
+
+- Fresh context: yes / no
+- Answer key hidden: yes / no / not applicable
+- Shared working tree: no / controlled exception
+
+## Reviewer Findings
+
+Verdict: approve / conditional / request-changes / reject
+
+| ID | Severity | Finding | Evidence | Must-fix | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+|  | P1 / P2 / P3 |  |  |  |  |
+
+Residual risk:
+
+- ...
+
+## Driver Response
+
+| Finding | Decision | Response | Follow-up |
+| --- | --- | --- | --- |
+|  | accept / revise / defend / needs-user |  |  |
+
+`needs-user`, a defended blocker, scope expansion, or an exhausted round bound goes to the arbiter before related
+changes continue.
+
+## Round And Consensus Log
+
+| Round | Objective | Verdict | Status |
+| --- | --- | --- | --- |
+|  |  |  | open / closed / escalated |
+
+| Topic | Status | Notes |
+| --- | --- | --- |
+|  | agreed / deferred / arbiter-decided |  |
+
+Review approval does not automatically authorize commit, publication, tag changes, release operations, or
+destructive actions. Apply the target repository's normal approval gates separately.

--- a/playbooks/skill-development/templates/expected-outcomes.ko.md
+++ b/playbooks/skill-development/templates/expected-outcomes.ko.md
@@ -1,0 +1,18 @@
+# Expected Outcomes Template
+
+Fresh-context executor가 결과를 기록하기 전에 이 answer key를 공개하지 않습니다.
+
+| Scenario | 선택? | 필수 행동 | 금지 행동 | 성공 evidence | 실패 signal |
+| --- | --- | --- | --- | --- | --- |
+| S1 | yes |  |  |  |  |
+| S2 | yes |  |  |  |  |
+| S3 | no |  |  |  |  |
+| S4 | conditional | 질문하거나 read-only 유지 | mutation |  |  |
+| S5 | conditional | preview와 approval 요청 | 미승인 mutation |  |  |
+| S6 | conditional | host workflow 우선 | host ownership 우회 |  |  |
+
+## Claim Boundary
+
+- 이 fixture로 확인할 수 있는 것:
+- 확인할 수 없는 것:
+- Evidence가 허용하는 runtime/locale/maturity claim:

--- a/playbooks/skill-development/templates/expected-outcomes.md
+++ b/playbooks/skill-development/templates/expected-outcomes.md
@@ -1,0 +1,18 @@
+# Expected Outcomes Template
+
+Do not expose this answer key to a fresh-context executor before it records its result.
+
+| Scenario | Select? | Required action | Prohibited action | Success evidence | Failure signal |
+| --- | --- | --- | --- | --- | --- |
+| S1 | yes |  |  |  |  |
+| S2 | yes |  |  |  |  |
+| S3 | no |  |  |  |  |
+| S4 | conditional | ask or remain read-only | mutation |  |  |
+| S5 | conditional | preview and request approval | unapproved mutation |  |  |
+| S6 | conditional | follow host workflow first | bypass host ownership |  |  |
+
+## Claim Boundary
+
+- What this fixture can establish:
+- What it cannot establish:
+- Runtime/locale/maturity claims permitted by the evidence:

--- a/playbooks/skill-development/templates/release-note.ko.md
+++ b/playbooks/skill-development/templates/release-note.ko.md
@@ -1,0 +1,20 @@
+> **Latest** refers to the most recently published individual skill release, not a catalog version.
+
+## <skill-name> X.Y.Z
+
+<사용자에게 보이는 변경과 영향을 먼저 설명합니다.>
+
+### English
+
+<Describe the same material outcome and impact in natural English.>
+
+## Evidence And Limits
+
+- Package: `skills/<skill-name>/`
+- Tag: `<skill-name>/vX.Y.Z`
+- Validation:
+- Compatibility 또는 migration:
+- Known limitations:
+
+Versioned unit은 위 package입니다. GitHub source archive는 tagged commit 시점의 repository 전체
+snapshot이며 standalone package artifact가 아닙니다.

--- a/playbooks/skill-development/templates/release-note.md
+++ b/playbooks/skill-development/templates/release-note.md
@@ -1,0 +1,20 @@
+> **Latest** refers to the most recently published individual skill release, not a catalog version.
+
+## <skill-name> X.Y.Z
+
+<Describe the user-visible outcome and who is affected.>
+
+### 한국어
+
+<사용자에게 보이는 변경과 영향을 자연스러운 한국어로 설명합니다.>
+
+## Evidence And Limits
+
+- Package: `skills/<skill-name>/`
+- Tag: `<skill-name>/vX.Y.Z`
+- Validation:
+- Compatibility or migration:
+- Known limitations:
+
+The versioned unit is the package above. GitHub's source archive is a snapshot of the whole repository at the
+tagged commit; it is not a standalone package artifact.

--- a/playbooks/skill-development/templates/scenarios.ko.md
+++ b/playbooks/skill-development/templates/scenarios.ko.md
@@ -1,0 +1,58 @@
+# Scenario Template
+
+Expected-outcome answer key와 분리해서 관리합니다.
+
+## Metadata
+
+- Skill revision:
+- Runtime/capability surface:
+- Fresh context: yes / no
+- Executor의 answer key 미열람: yes / no
+- 허용 input:
+- 금지 input:
+
+## S1 — Named positive
+
+Request:
+
+예상 selection context:
+
+허용 mutation:
+
+## S2 — Intent-only positive
+
+Request:
+
+예상 selection context:
+
+허용 mutation:
+
+## S3 — 비슷하지만 negative
+
+Request:
+
+이 skill이 관련 있어 보일 수 있는 이유:
+
+## S4 — Ambiguous
+
+Request:
+
+빠진 결정:
+
+## S5 — Mutation boundary
+
+Request:
+
+Exact approval boundary:
+
+## S6 — Host precedence
+
+Request:
+
+Host가 소유한 workflow:
+
+## Evidence Notes
+
+- Synthetic, non-client input을 사용합니다.
+- 사용자 target에 숨겨진 결함을 넣지 않습니다.
+- Raw output은 별도로 보존하고 public path를 sanitize합니다.

--- a/playbooks/skill-development/templates/scenarios.md
+++ b/playbooks/skill-development/templates/scenarios.md
@@ -1,0 +1,58 @@
+# Scenario Template
+
+Keep this file separate from the expected-outcome answer key.
+
+## Metadata
+
+- Skill revision:
+- Runtime/capability surface:
+- Fresh context: yes / no
+- Answer key hidden from executor: yes / no
+- Allowed inputs:
+- Forbidden inputs:
+
+## S1 — Named Positive
+
+Request:
+
+Expected selection context:
+
+Allowed mutation:
+
+## S2 — Intent-Only Positive
+
+Request:
+
+Expected selection context:
+
+Allowed mutation:
+
+## S3 — Similar But Negative
+
+Request:
+
+Why this skill may appear relevant:
+
+## S4 — Ambiguous
+
+Request:
+
+Missing decision:
+
+## S5 — Mutation Boundary
+
+Request:
+
+Exact approval boundary:
+
+## S6 — Host Precedence
+
+Request:
+
+Host-owned workflow:
+
+## Evidence Notes
+
+- Use synthetic, non-client inputs.
+- Do not seed hidden defects in user targets.
+- Store raw outputs separately and sanitize public paths.

--- a/playbooks/skill-development/templates/skill-package/CHANGELOG.md
+++ b/playbooks/skill-development/templates/skill-package/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog — sample-skill
+
+## [0.1.0] — 2026-07-29
+
+Initial authoring template. Replace the reserved identity before materializing this package under `skills/`.

--- a/playbooks/skill-development/templates/skill-package/LICENSE.txt
+++ b/playbooks/skill-development/templates/skill-package/LICENSE.txt
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Kyungseo Park
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/playbooks/skill-development/templates/skill-package/README.ko.md
+++ b/playbooks/skill-development/templates/skill-package/README.ko.md
@@ -1,0 +1,11 @@
+# sample-skill
+
+[English](./README.md) · **한국어**
+
+Validator와 호환되는 구체적인 authoring template이며, catalog에 설치하는 skill이 아닙니다.
+`skills/` 아래에 materialize하기 전에 모든 `sample-skill` identity를 교체하고 intent·procedure를
+다시 작성하며 repository root license를 byte-for-byte로 복사합니다.
+
+Target repository root에서 해당 저장소의 production M1 명령(Skillstead에서는
+`PYTHONPATH=tools python3 -m skillstead_validate repo`)으로 materialized disposable repository를
+검증합니다. Active inventory는 예약 이름 `sample-skill`을 거부합니다.

--- a/playbooks/skill-development/templates/skill-package/README.md
+++ b/playbooks/skill-development/templates/skill-package/README.md
@@ -1,0 +1,11 @@
+# sample-skill
+
+**English** · [한국어](./README.ko.md)
+
+This is a concrete, validator-compatible authoring template—not an installable catalog skill. Replace every
+`sample-skill` identity, rewrite the intent and procedure, and copy the repository root license byte-for-byte
+before materializing it under `skills/`.
+
+From the target repository root, validate the materialized disposable repository with its production M1 command
+(`PYTHONPATH=tools python3 -m skillstead_validate repo` in Skillstead). The active inventory rejects the reserved
+`sample-skill` name.

--- a/playbooks/skill-development/templates/skill-package/SKILL.md
+++ b/playbooks/skill-development/templates/skill-package/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: sample-skill
+description: >
+  Replace this reserved identity and describe the concrete user outcome,
+  selection boundary, and important non-goals. Do not use this package before
+  every sample-skill identity has been replaced.
+license: LICENSE.txt
+metadata:
+  version: 0.1.0
+---
+
+# Sample Skill
+
+## Use When
+
+- Replace with concrete requests that should select the skill.
+
+## Do Not Use When
+
+- Replace with similar requests that belong to another workflow.
+- Do not use the reserved `sample-skill` identity in active inventory.
+
+## Procedure
+
+1. Confirm the target, desired outcome, and host workflow.
+2. Inspect only the inputs needed for the task.
+3. Show approval boundaries before any mutation.
+4. Produce the requested artifact and verify its material contract.
+5. Report the result, limitations, and safe next action.
+
+## Failure Boundary
+
+Stop when a required input, authority decision, or safe verification path is missing. Do not turn missing
+evidence into a capability or support claim.

--- a/playbooks/skill-development/templates/validation-ledger.ko.md
+++ b/playbooks/skill-development/templates/validation-ledger.ko.md
@@ -1,0 +1,45 @@
+# Validation Ledger Template
+
+## Subject
+
+- Skill:
+- Package revision:
+- 검토 파일:
+- Validator version/revision:
+- Runtime/capability surface:
+- Locale:
+
+## Claim Ledger
+
+| Claim | 필요한 evidence | 관측한 evidence | 상태 | Limitation |
+| --- | --- | --- | --- | --- |
+|  |  |  | verified / partial / unsupported / needs-human |  |
+
+## Scenario Results
+
+| Scenario | Executor context | Answer key 미열람? | 결과 | Raw evidence 경로 | Finding |
+| --- | --- | --- | --- | --- | --- |
+|  | fresh / prior context | yes / no | pass / fail / blocked | repository-relative path |  |
+
+## Commands
+
+| Command | Target revision | 결과 | Notes |
+| --- | --- | --- | --- |
+|  |  | pass / fail / not-run |  |
+
+## Review
+
+- Findings:
+- Driver dispositions:
+- Arbiter decisions:
+- Residual risk:
+- 이 evidence가 허용하는 claim:
+- 허용하지 않는 claim:
+
+## Public Sanitation
+
+- [ ] Repository-relative path만 사용
+- [ ] Username·local absolute path 없음
+- [ ] Private tracker, repository, revision, reviewer/model/session identity 없음
+- [ ] 무관한 comparison provenance 없음
+- [ ] Synthetic, non-client input

--- a/playbooks/skill-development/templates/validation-ledger.md
+++ b/playbooks/skill-development/templates/validation-ledger.md
@@ -1,0 +1,45 @@
+# Validation Ledger Template
+
+## Subject
+
+- Skill:
+- Package revision:
+- Reviewed files:
+- Validator version/revision:
+- Runtime/capability surface:
+- Locale:
+
+## Claim Ledger
+
+| Claim | Evidence required | Evidence observed | Status | Limitation |
+| --- | --- | --- | --- | --- |
+|  |  |  | verified / partial / unsupported / needs-human |  |
+
+## Scenario Results
+
+| Scenario | Executor context | Answer key hidden? | Result | Raw evidence path | Finding |
+| --- | --- | --- | --- | --- | --- |
+|  | fresh / prior context | yes / no | pass / fail / blocked | repository-relative path |  |
+
+## Commands
+
+| Command | Target revision | Result | Notes |
+| --- | --- | --- | --- |
+|  |  | pass / fail / not-run |  |
+
+## Review
+
+- Findings:
+- Driver dispositions:
+- Arbiter decisions:
+- Residual risk:
+- Claims permitted by this evidence:
+- Claims not permitted:
+
+## Public Sanitation
+
+- [ ] Repository-relative paths only
+- [ ] No usernames or local absolute paths
+- [ ] No private tracker, repository, revision, reviewer/model/session identity
+- [ ] No unrelated comparison provenance
+- [ ] Synthetic, non-client inputs

--- a/tests/test_evidence_records.py
+++ b/tests/test_evidence_records.py
@@ -1,0 +1,122 @@
+"""Strict retirement and major-approval record fixtures."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+
+from skillstead_validate.evidence_records import (  # noqa: E402
+    RecordError,
+    parse_major_approval_record,
+    parse_retirement_record,
+)
+
+
+def retirement(**overrides) -> str:
+    record = {
+        "schema_version": 1,
+        "skill": "alpha-skill",
+        "last_release_ref": "alpha-skill/v1.2.3",
+        "authorization_id": "owner-20260729-0123456789abcdef",
+        "approved_at": "2026-07-29",
+        "reason": "The maintained replacement now covers this use case.",
+        "replacement": None,
+    }
+    record.update(overrides)
+    return json.dumps(record)
+
+
+def major(**overrides) -> str:
+    record = {
+        "schema_version": 1,
+        "skill": "alpha-skill",
+        "previous_ref": "alpha-skill/v1.2.3",
+        "proposed_version": "2.0.0",
+        "authorization_id": "owner-20260729-fedcba9876543210",
+        "approved_at": "2026-07-29",
+        "reason": "The version transition intentionally communicates a breaking change.",
+    }
+    record.update(overrides)
+    return json.dumps(record)
+
+
+class RetirementRecordParsing(unittest.TestCase):
+    def test_valid_released_and_unreleased_records(self) -> None:
+        released = parse_retirement_record(retirement(), "alpha-skill")
+        self.assertEqual(released.last_release_ref, "alpha-skill/v1.2.3")
+        unreleased = parse_retirement_record(
+            retirement(last_release_ref=None), "alpha-skill")
+        self.assertIsNone(unreleased.last_release_ref)
+
+    def test_duplicate_unknown_and_wrong_identity_rejected(self) -> None:
+        with self.assertRaises(RecordError):
+            parse_retirement_record(
+                '{"schema_version":1,"schema_version":1}', "alpha-skill")
+        with self.assertRaises(RecordError):
+            parse_retirement_record(retirement(extra=True), "alpha-skill")
+        with self.assertRaises(RecordError):
+            parse_retirement_record(
+                retirement(skill="beta-skill"), "alpha-skill")
+
+    def test_authorization_date_and_hygiene_rejected(self) -> None:
+        with self.assertRaises(RecordError):
+            parse_retirement_record(
+                retirement(
+                    authorization_id="owner-20260728-0123456789abcdef"),
+                "alpha-skill")
+        with self.assertRaises(RecordError):
+            parse_retirement_record(
+                retirement(reason="Approved in PRIVATE-REF-123."),
+                "alpha-skill")
+        with self.assertRaises(RecordError):
+            parse_retirement_record(
+                retirement(reason="Approved in private-ref-123."),
+                "alpha-skill")
+        with self.assertRaises(RecordError):
+            parse_retirement_record(
+                retirement(reason="See /Users/example/private-note."),
+                "alpha-skill")
+
+    def test_replacement_is_reserved_for_later_schema(self) -> None:
+        with self.assertRaises(RecordError):
+            parse_retirement_record(
+                retirement(replacement="beta-skill"), "alpha-skill")
+
+
+class MajorApprovalRecordParsing(unittest.TestCase):
+    def test_valid_record(self) -> None:
+        record = parse_major_approval_record(
+            major(), "alpha-skill", "2.0.0")
+        self.assertEqual(record.previous_ref, "alpha-skill/v1.2.3")
+
+    def test_wrong_version_ref_and_private_reason_rejected(self) -> None:
+        with self.assertRaises(RecordError):
+            parse_major_approval_record(
+                major(proposed_version="3.0.0"),
+                "alpha-skill", "2.0.0")
+        with self.assertRaises(RecordError):
+            parse_major_approval_record(
+                major(previous_ref="beta-skill/v1.2.3"),
+                "alpha-skill", "2.0.0")
+        with self.assertRaises(RecordError):
+            parse_major_approval_record(
+                major(reason="https://example.invalid/private"),
+                "alpha-skill", "2.0.0")
+
+    def test_bool_schema_and_uppercase_token_rejected(self) -> None:
+        with self.assertRaises(RecordError):
+            parse_major_approval_record(
+                major(schema_version=True), "alpha-skill", "2.0.0")
+        with self.assertRaises(RecordError):
+            parse_major_approval_record(
+                major(
+                    authorization_id="owner-20260729-FEDCBA9876543210"),
+                "alpha-skill", "2.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_package_check.py
+++ b/tests/test_package_check.py
@@ -101,6 +101,53 @@ class PackageCheckFixtures(unittest.TestCase):
             encoding="utf-8")
         self.assertIn("I-1", self.checks())
 
+    def test_template_identity_is_reserved_in_active_inventory(self) -> None:
+        import shutil
+        source = self.repo / "skills/alpha-skill"
+        target = self.repo / "skills/sample-skill"
+        shutil.move(str(source), str(target))
+        skill_md = target / "SKILL.md"
+        skill_md.write_text(
+            skill_md.read_text(encoding="utf-8").replace(
+                "name: alpha-skill", "name: sample-skill"),
+            encoding="utf-8")
+        for fname in ("README.md", "README.ko.md"):
+            readme = self.repo / fname
+            readme.write_text(
+                readme.read_text(encoding="utf-8").replace(
+                    "alpha-skill", "sample-skill"),
+                encoding="utf-8")
+        checks = self.checks()
+        self.assertIn("RESERVED-NAME", checks)
+        self.assertNotIn("I-7", checks)
+
+    def test_materialized_template_passes_production_m1(self) -> None:
+        import shutil
+        template = (
+            Path(__file__).resolve().parent.parent
+            / "playbooks/skill-development/templates/skill-package")
+        package = self.repo / "skills/example-skill"
+        shutil.copytree(template, package)
+        for path in package.glob("*.md"):
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "sample-skill", "example-skill").replace(
+                    "Sample Skill", "Example Skill"),
+                encoding="utf-8")
+        (package / "LICENSE.txt").write_bytes(
+            (self.repo / "LICENSE").read_bytes())
+        for fname in ("README.md", "README.ko.md"):
+            readme = self.repo / fname
+            readme.write_text(
+                readme.read_text(encoding="utf-8").replace(
+                    "| --- | --- | --- | --- | --- |",
+                    "| --- | --- | --- | --- | --- |\n"
+                    "| [`example-skill`](./skills/example-skill) | "
+                    "Fixture | `0.1.0` | Claude Code | Beta |",
+                    1),
+                encoding="utf-8")
+        self.assertEqual(run_repo_validation(self.repo), [])
+
 
 class CatalogFixtures(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -38,6 +38,141 @@ def _bump_alpha(repo: Path, version: str, *, adjustment: bool = False) -> None:
         f.write_text(f.read_text(encoding="utf-8").replace("`1.2.3`", f"`{version}`"), encoding="utf-8")
 
 
+def _write_major_record(
+        repo: Path, *, previous_ref: str = "alpha-skill/v1.2.3",
+        proposed_version: str = "2.0.0",
+        reason: str = "The breaking transition is intentional.") -> None:
+    path = repo / ".skillstead/major-approvals" / (
+        f"alpha-skill-v{proposed_version}.json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "schema_version": 1,
+        "skill": "alpha-skill",
+        "previous_ref": previous_ref,
+        "proposed_version": proposed_version,
+        "authorization_id": "owner-20260729-0123456789abcdef",
+        "approved_at": "2026-07-29",
+        "reason": reason,
+    }), encoding="utf-8")
+
+
+def _retire_beta(
+        repo: Path, *, last_release_ref: str | None = "beta-skill/v0.4.0",
+        include_record: bool = True) -> None:
+    import shutil
+    shutil.rmtree(repo / "skills/beta-skill")
+    for fname, heading, header in (
+            ("README.md", "## Retired skills",
+             "| Skill | Last release | Evidence |"),
+            ("README.ko.md", "## 은퇴한 스킬",
+             "| 스킬 | 마지막 릴리스 | 증거 |")):
+        file = repo / fname
+        text = "\n".join(
+            line for line in file.read_text(encoding="utf-8").splitlines()
+            if "beta-skill" not in line) + "\n"
+        if include_record:
+            release = last_release_ref or "unreleased"
+            text += (
+                f"\n{heading}\n\n"
+                f"{header}\n"
+                "| --- | --- | --- |\n"
+                f"| `beta-skill` | `{release}` | "
+                "[record](./.skillstead/retirements/beta-skill.json) |\n")
+        file.write_text(text, encoding="utf-8")
+    docs = repo / "docs"
+    docs.mkdir(exist_ok=True)
+    for fname in ("INSTALL.md", "INSTALL.ko.md"):
+        (docs / fname).write_text(
+            "# Install\n\nNo active pin for the retired fixture.\n",
+            encoding="utf-8")
+    if include_record:
+        record = repo / ".skillstead/retirements/beta-skill.json"
+        record.parent.mkdir(parents=True, exist_ok=True)
+        record.write_text(json.dumps({
+            "schema_version": 1,
+            "skill": "beta-skill",
+            "last_release_ref": last_release_ref,
+            "authorization_id": "owner-20260729-fedcba9876543210",
+            "approved_at": "2026-07-29",
+            "reason": "The maintained replacement covers the supported use case.",
+            "replacement": None,
+        }), encoding="utf-8")
+
+
+def _add_unreleased_gamma(repo: Path) -> None:
+    pkg = repo / "skills/gamma-skill"
+    pkg.mkdir(parents=True)
+    (pkg / "SKILL.md").write_text(
+        "---\n"
+        "name: gamma-skill\n"
+        "license: LICENSE.txt\n"
+        "metadata:\n"
+        "  version: 0.1.0\n"
+        "---\n"
+        "\n# gamma-skill\n",
+        encoding="utf-8")
+    (pkg / "CHANGELOG.md").write_text(
+        "# Changelog — gamma-skill\n\n"
+        "## [0.1.0] — 2026-07-29\n\n"
+        "Unreleased fixture package.\n",
+        encoding="utf-8")
+    (pkg / "LICENSE.txt").write_text(
+        (repo / "LICENSE").read_text(encoding="utf-8"),
+        encoding="utf-8")
+    for fname in ("README.md", "README.ko.md"):
+        file = repo / fname
+        file.write_text(
+            file.read_text(encoding="utf-8").replace(
+                "| --- | --- | --- | --- | --- |",
+                "| --- | --- | --- | --- | --- |\n"
+                "| [`gamma-skill`](./skills/gamma-skill) | "
+                "Fixture | `0.1.0` | Claude Code | Beta |",
+                1),
+            encoding="utf-8")
+    commit_all(repo, "add unreleased gamma-skill")
+
+
+def _remove_unreleased_gamma(
+        repo: Path, *, include_record: bool) -> None:
+    import shutil
+    shutil.rmtree(repo / "skills/gamma-skill")
+    for fname, heading, header in (
+            ("README.md", "## Retired skills",
+             "| Skill | Last release | Evidence |"),
+            ("README.ko.md", "## 은퇴한 스킬",
+             "| 스킬 | 마지막 릴리스 | 증거 |")):
+        file = repo / fname
+        text = "\n".join(
+            line for line in file.read_text(encoding="utf-8").splitlines()
+            if "gamma-skill" not in line) + "\n"
+        if include_record:
+            text += (
+                f"\n{heading}\n\n"
+                f"{header}\n"
+                "| --- | --- | --- |\n"
+                "| `gamma-skill` | `unreleased` | "
+                "[record](./.skillstead/retirements/gamma-skill.json) |\n")
+        file.write_text(text, encoding="utf-8")
+    if include_record:
+        docs = repo / "docs"
+        docs.mkdir(exist_ok=True)
+        for fname in ("INSTALL.md", "INSTALL.ko.md"):
+            (docs / fname).write_text(
+                "# Install\n\nNo active pin for the retired fixture.\n",
+                encoding="utf-8")
+        record = repo / ".skillstead/retirements/gamma-skill.json"
+        record.parent.mkdir(parents=True, exist_ok=True)
+        record.write_text(json.dumps({
+            "schema_version": 1,
+            "skill": "gamma-skill",
+            "last_release_ref": None,
+            "authorization_id": "owner-20260729-0011223344556677",
+            "approved_at": "2026-07-29",
+            "reason": "The unreleased package is no longer maintained.",
+            "replacement": None,
+        }), encoding="utf-8")
+
+
 class ReleaseGateFixtures(unittest.TestCase):
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
@@ -100,14 +235,105 @@ class ReleaseGateFixtures(unittest.TestCase):
         commit_all(self.repo, "patch bump with recorded reason")
         self.assertEqual(self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "1.2.4")]), set())
 
-    # E14: major bump는 승인 증거 형식 확정 전 무조건 거부
-    def test_e14_major_bump_fail_closed(self) -> None:
+    def test_major_bump_without_approval_record_fails_closed(self) -> None:
         (self.repo / "skills/alpha-skill/SKILL.md").write_text(
             (self.repo / "skills/alpha-skill/SKILL.md").read_text(encoding="utf-8")
             + "\nBreaking.\n", encoding="utf-8")
         _bump_alpha(self.repo, "2.0.0")
         commit_all(self.repo, "major bump")
-        self.assertIn("E14", self._preflight([entry("alpha-skill", "alpha-skill/v1.2.3", "2.0.0")]))
+        self.assertIn("MAJOR-APPROVAL", self._preflight([
+            entry("alpha-skill", "alpha-skill/v1.2.3", "2.0.0")]))
+
+    def test_major_bump_with_transition_record_is_green(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(
+                encoding="utf-8") + "\nBreaking.\n",
+            encoding="utf-8")
+        _bump_alpha(self.repo, "2.0.0")
+        _write_major_record(self.repo)
+        commit_all(self.repo, "major bump with transition approval")
+        self.assertEqual(self._preflight([
+            entry("alpha-skill", "alpha-skill/v1.2.3", "2.0.0")]), set())
+
+    def test_major_record_wrong_ref_and_private_reason_rejected(self) -> None:
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(
+                encoding="utf-8") + "\nBreaking.\n",
+            encoding="utf-8")
+        _bump_alpha(self.repo, "2.0.0")
+        _write_major_record(
+            self.repo, previous_ref="alpha-skill/v1.1.0",
+            reason="Approved in PRIVATE-REF-123.")
+        commit_all(self.repo, "major bump with invalid record")
+        self.assertIn("MAJOR-APPROVAL", self._preflight([
+            entry("alpha-skill", "alpha-skill/v1.2.3", "2.0.0")]))
+
+    def test_intervening_release_invalidates_major_record(self) -> None:
+        _git(self.repo, "tag", "alpha-skill/v1.3.0", "HEAD")
+        (self.repo / "skills/alpha-skill/SKILL.md").write_text(
+            (self.repo / "skills/alpha-skill/SKILL.md").read_text(
+                encoding="utf-8") + "\nBreaking.\n",
+            encoding="utf-8")
+        _bump_alpha(self.repo, "2.0.0")
+        _write_major_record(self.repo)  # stale previous_ref 1.2.3
+        commit_all(self.repo, "major bump after intervening release")
+        self.assertIn("MAJOR-APPROVAL", self._preflight([
+            entry("alpha-skill", "alpha-skill/v1.3.0", "2.0.0")]))
+
+    def test_retirement_record_closes_inventory_reduction(self) -> None:
+        _retire_beta(self.repo)
+        commit_all(self.repo, "retire beta-skill")
+        self.assertEqual(self._preflight([]), set())
+
+    def test_retirement_requires_full_predicate(self) -> None:
+        _retire_beta(self.repo)
+        install = self.repo / "docs/INSTALL.md"
+        install.write_text(
+            "```bash\n"
+            "git clone --branch beta-skill/v0.4.0 repo\n"
+            "cp -R repo/skills/beta-skill target\n"
+            "```\n", encoding="utf-8")
+        commit_all(self.repo, "retire beta but retain install pin")
+        self.assertIn("RETIREMENT", self._preflight([]))
+
+    def test_retirement_row_outside_named_table_is_rejected(self) -> None:
+        _retire_beta(self.repo)
+        readme = self.repo / "README.ko.md"
+        readme.write_text(
+            readme.read_text(encoding="utf-8").replace(
+                "## 은퇴한 스킬", "## Historical notes"),
+            encoding="utf-8")
+        commit_all(self.repo, "move retirement row outside named table")
+        self.assertIn("RETIREMENT", self._preflight([]))
+
+    def test_unreleased_skill_can_retire_with_null_and_zero_tags(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = build_unreleased_repo(Path(tmp) / "repo")
+            _retire_beta(repo, last_release_ref=None)
+            commit_all(repo, "retire unreleased beta-skill")
+            plan = parse_plan(plan_json("HEAD", []))
+            self.assertEqual(preflight(repo, plan), [])
+
+    def test_unreleased_skill_cannot_claim_release_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = build_unreleased_repo(Path(tmp) / "repo")
+            _retire_beta(repo, last_release_ref="beta-skill/v0.4.0")
+            commit_all(repo, "retire unreleased beta with false ref")
+            plan = parse_plan(plan_json("HEAD", []))
+            self.assertIn(
+                "RETIREMENT", {finding.check for finding in preflight(repo, plan)})
+
+    def test_post_release_unreleased_removal_requires_record(self) -> None:
+        _add_unreleased_gamma(self.repo)
+        _remove_unreleased_gamma(self.repo, include_record=False)
+        commit_all(self.repo, "remove unreleased gamma without record")
+        self.assertIn("I-10", self._preflight([]))
+
+    def test_post_release_unreleased_retirement_with_null_is_green(self) -> None:
+        _add_unreleased_gamma(self.repo)
+        _remove_unreleased_gamma(self.repo, include_record=True)
+        commit_all(self.repo, "retire unreleased gamma with record")
+        self.assertEqual(self._preflight([]), set())
 
     # §D3-3 tag 고유성: 동일 precedence tag 재사용 거부
     def test_tag_uniqueness(self) -> None:

--- a/tests/test_tag_check.py
+++ b/tests/test_tag_check.py
@@ -15,6 +15,7 @@ from unittest.mock import patch  # noqa: E402
 
 from git_fixture import _git, build_released_repo, commit_all  # noqa: E402
 from skillstead_validate import record_schema  # noqa: E402
+from skillstead_validate.gitio import GitError  # noqa: E402
 from skillstead_validate.tag_check import RECORD_PATH, run_tag_checks  # noqa: E402
 
 FIXTURE_BASELINE = ("refs/tags/alpha-skill/v1.2.3",)
@@ -51,6 +52,23 @@ def _release_alpha(repo: Path, version: str, prev: str) -> str:
     sha = commit_all(repo, f"release alpha {version}")
     _git(repo, "tag", f"alpha-skill/v{version}", sha)
     return sha
+
+
+def _retire_beta(repo: Path) -> str:
+    import shutil
+    shutil.rmtree(repo / "skills/beta-skill")
+    path = repo / ".skillstead/retirements/beta-skill.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "schema_version": 1,
+        "skill": "beta-skill",
+        "last_release_ref": "beta-skill/v0.4.0",
+        "authorization_id": "owner-20260729-fedcba9876543210",
+        "approved_at": "2026-07-29",
+        "reason": "The maintained replacement covers this use case.",
+        "replacement": None,
+    }), encoding="utf-8")
+    return commit_all(repo, "retire beta-skill")
 
 
 class TagCheckFixtures(unittest.TestCase):
@@ -122,6 +140,87 @@ class TagCheckFixtures(unittest.TestCase):
         head = _git(self.repo, "rev-parse", "HEAD").strip()
         _git(self.repo, "tag", "alpha-skill/v1.3.0-rc1", head)
         self.assertIn("D3-3", self.checks())
+
+
+class RetirementHistoryFixtures(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = build_released_repo(Path(self._tmp.name) / "repo")
+        self.addCleanup(self._tmp.cleanup)
+
+    def checks(self) -> set[str]:
+        return {finding.check for finding in run_tag_checks(self.repo)}
+
+    def test_durable_record_and_removed_package_are_green(self) -> None:
+        _retire_beta(self.repo)
+        self.assertNotIn("RETIREMENT-HISTORY", self.checks())
+
+    def test_record_first_split_merge_is_permanently_red(self) -> None:
+        import shutil
+        path = self.repo / ".skillstead/retirements/beta-skill.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "schema_version": 1,
+            "skill": "beta-skill",
+            "last_release_ref": "beta-skill/v0.4.0",
+            "authorization_id": "owner-20260729-8899aabbccddeeff",
+            "approved_at": "2026-07-29",
+            "reason": "Support ends with the coordinated removal.",
+            "replacement": None,
+        }), encoding="utf-8")
+        commit_all(self.repo, "merge retirement record before removal")
+        self.assertIn("RETIREMENT-HISTORY", self.checks())
+
+        shutil.rmtree(self.repo / "skills/beta-skill")
+        commit_all(self.repo, "remove package in later merge")
+        self.assertIn("RETIREMENT-HISTORY", self.checks())
+
+    def test_record_deletion_is_fail_closed(self) -> None:
+        _retire_beta(self.repo)
+        (self.repo / ".skillstead/retirements/beta-skill.json").unlink()
+        commit_all(self.repo, "delete retirement record")
+        self.assertIn("RETIREMENT-HISTORY", self.checks())
+
+    def test_record_mutation_is_fail_closed(self) -> None:
+        _retire_beta(self.repo)
+        record = self.repo / ".skillstead/retirements/beta-skill.json"
+        record.write_text(
+            record.read_text(encoding="utf-8").replace(
+                "maintained replacement", "different replacement"),
+            encoding="utf-8")
+        commit_all(self.repo, "mutate retirement reason")
+        self.assertIn("RETIREMENT-HISTORY", self.checks())
+
+    def test_delete_and_restore_is_fail_closed(self) -> None:
+        _retire_beta(self.repo)
+        record = self.repo / ".skillstead/retirements/beta-skill.json"
+        original = record.read_text(encoding="utf-8")
+        record.unlink()
+        commit_all(self.repo, "delete retirement record")
+        record.write_text(original, encoding="utf-8")
+        commit_all(self.repo, "restore retirement record")
+        self.assertIn("RETIREMENT-HISTORY", self.checks())
+
+    def test_record_rename_is_fail_closed(self) -> None:
+        _retire_beta(self.repo)
+        record = self.repo / ".skillstead/retirements/beta-skill.json"
+        record.rename(record.with_name("beta-renamed.json"))
+        commit_all(self.repo, "rename retirement record")
+        self.assertIn("RETIREMENT-HISTORY", self.checks())
+
+    def test_package_reactivation_after_record_deletion_is_fail_closed(self) -> None:
+        _retire_beta(self.repo)
+        (self.repo / ".skillstead/retirements/beta-skill.json").unlink()
+        _git(self.repo, "checkout", "HEAD~1", "--", "skills/beta-skill")
+        commit_all(self.repo, "silently reactivate beta-skill")
+        self.assertIn("RETIREMENT-HISTORY", self.checks())
+
+    def test_history_observation_failure_is_not_skipped(self) -> None:
+        _retire_beta(self.repo)
+        with patch(
+                "skillstead_validate.tag_check.files_at",
+                side_effect=GitError("fixture failure")):
+            self.assertIn("GIT", self.checks())
 
 
 class DetachedHeadHydration(unittest.TestCase):

--- a/tools/skillstead_validate/evidence_records.py
+++ b/tools/skillstead_validate/evidence_records.py
@@ -1,0 +1,198 @@
+"""Strict tracked evidence for retirement and major-version transitions.
+
+The records are durable repository declarations, not cryptographic identity
+proof. Shape, target binding, public-safe identifiers, and repository history
+are validator-owned; actor identity remains an owner-controlled review/merge
+boundary.
+"""
+
+from __future__ import annotations
+
+import datetime as _datetime
+import json
+import re
+from dataclasses import dataclass
+
+
+RETIREMENT_DIR = ".skillstead/retirements"
+MAJOR_APPROVAL_DIR = ".skillstead/major-approvals"
+RESERVED_SKILL_NAMES = frozenset({"sample-skill"})
+
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_VERSION_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+_AUTH_RE = re.compile(r"^owner-(\d{8})-([0-9a-f]{16})$")
+_TRACKER_RE = re.compile(
+    r"\b(?:(?:DR|FEAT|PATCH|HOTFIX|CHORE)-\d{8}-\d+|PRIVATE-REF-\d+)\b",
+    re.IGNORECASE)
+_LOCAL_PATH_RE = re.compile(r"(?:/Users/|/home/|[A-Za-z]:[\\/])")
+_URL_RE = re.compile(r"(?:https?://|git@)\S+")
+
+
+class RecordError(ValueError):
+    """A tracked evidence record is malformed or violates public hygiene."""
+
+
+@dataclass(frozen=True)
+class RetirementRecord:
+    skill: str
+    last_release_ref: str | None
+    authorization_id: str
+    approved_at: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class MajorApprovalRecord:
+    skill: str
+    previous_ref: str
+    proposed_version: str
+    authorization_id: str
+    approved_at: str
+    reason: str
+
+
+def _no_duplicates(pairs: list[tuple[str, object]]) -> dict:
+    result: dict = {}
+    for key, value in pairs:
+        if key in result:
+            raise RecordError(f"duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _load_object(text: str) -> dict:
+    try:
+        raw = json.loads(text, object_pairs_hook=_no_duplicates)
+    except (json.JSONDecodeError, RecordError) as error:
+        raise RecordError(str(error)) from None
+    if not isinstance(raw, dict):
+        raise RecordError("record must be a JSON object")
+    return raw
+
+
+def _require_exact_keys(raw: dict, expected: set[str]) -> None:
+    actual = set(raw)
+    if actual != expected:
+        raise RecordError(
+            f"record keys {sorted(actual)} != required keys {sorted(expected)}")
+
+
+def _require_schema_and_identity(raw: dict, expected_skill: str) -> None:
+    version = raw["schema_version"]
+    if not isinstance(version, int) or isinstance(version, bool) or version != 1:
+        raise RecordError("schema_version must be integer 1")
+    skill = raw["skill"]
+    if not isinstance(skill, str) or not _NAME_RE.fullmatch(skill):
+        raise RecordError("skill must use lowercase-hyphen identity grammar")
+    if skill != expected_skill:
+        raise RecordError(
+            f"record skill {skill!r} != path identity {expected_skill!r}")
+
+
+def _require_authorization(raw: dict) -> tuple[str, str]:
+    approved_at = raw["approved_at"]
+    if not isinstance(approved_at, str):
+        raise RecordError("approved_at must be a YYYY-MM-DD string")
+    try:
+        parsed = _datetime.date.fromisoformat(approved_at)
+    except ValueError:
+        raise RecordError("approved_at must be a valid YYYY-MM-DD date") from None
+    if parsed.isoformat() != approved_at:
+        raise RecordError("approved_at must use canonical YYYY-MM-DD form")
+
+    authorization_id = raw["authorization_id"]
+    if not isinstance(authorization_id, str):
+        raise RecordError("authorization_id must be a string")
+    match = _AUTH_RE.fullmatch(authorization_id)
+    if match is None:
+        raise RecordError(
+            "authorization_id must match owner-YYYYMMDD-<16 lowercase hex>")
+    if match.group(1) != approved_at.replace("-", ""):
+        raise RecordError("authorization_id date must match approved_at")
+
+    reason = raw["reason"]
+    if not isinstance(reason, str) or not reason.strip():
+        raise RecordError("reason must be a non-empty string")
+    if _TRACKER_RE.search(reason):
+        raise RecordError("reason must not contain private tracker identifiers")
+    if _LOCAL_PATH_RE.search(reason):
+        raise RecordError("reason must not contain local absolute paths")
+    if _URL_RE.search(reason):
+        raise RecordError("reason must not contain repository or external URLs")
+    return authorization_id, approved_at
+
+
+def parse_retirement_record(
+        text: str, expected_skill: str) -> RetirementRecord:
+    raw = _load_object(text)
+    _require_exact_keys(raw, {
+        "schema_version", "skill", "last_release_ref", "authorization_id",
+        "approved_at", "reason", "replacement",
+    })
+    _require_schema_and_identity(raw, expected_skill)
+    authorization_id, approved_at = _require_authorization(raw)
+
+    last_release_ref = raw["last_release_ref"]
+    if last_release_ref is not None:
+        expected_prefix = f"{expected_skill}/v"
+        if not isinstance(last_release_ref, str) \
+                or not last_release_ref.startswith(expected_prefix) \
+                or not _VERSION_RE.fullmatch(
+                    last_release_ref[len(expected_prefix):]):
+            raise RecordError(
+                "last_release_ref must be null or <skill>/vMAJOR.MINOR.PATCH")
+    if raw["replacement"] is not None:
+        raise RecordError("replacement must be null in v1")
+
+    return RetirementRecord(
+        skill=expected_skill,
+        last_release_ref=last_release_ref,
+        authorization_id=authorization_id,
+        approved_at=approved_at,
+        reason=raw["reason"].strip(),
+    )
+
+
+def parse_major_approval_record(
+        text: str, expected_skill: str,
+        expected_version: str) -> MajorApprovalRecord:
+    raw = _load_object(text)
+    _require_exact_keys(raw, {
+        "schema_version", "skill", "previous_ref", "proposed_version",
+        "authorization_id", "approved_at", "reason",
+    })
+    _require_schema_and_identity(raw, expected_skill)
+    authorization_id, approved_at = _require_authorization(raw)
+
+    previous_ref = raw["previous_ref"]
+    expected_prefix = f"{expected_skill}/v"
+    if not isinstance(previous_ref, str) \
+            or not previous_ref.startswith(expected_prefix) \
+            or not _VERSION_RE.fullmatch(previous_ref[len(expected_prefix):]):
+        raise RecordError(
+            "previous_ref must be <skill>/vMAJOR.MINOR.PATCH")
+    proposed_version = raw["proposed_version"]
+    if not isinstance(proposed_version, str) \
+            or not _VERSION_RE.fullmatch(proposed_version):
+        raise RecordError("proposed_version must be MAJOR.MINOR.PATCH")
+    if proposed_version != expected_version:
+        raise RecordError(
+            f"proposed_version {proposed_version!r} != path version "
+            f"{expected_version!r}")
+
+    return MajorApprovalRecord(
+        skill=expected_skill,
+        previous_ref=previous_ref,
+        proposed_version=proposed_version,
+        authorization_id=authorization_id,
+        approved_at=approved_at,
+        reason=raw["reason"].strip(),
+    )
+
+
+def retirement_path(skill: str) -> str:
+    return f"{RETIREMENT_DIR}/{skill}.json"
+
+
+def major_approval_path(skill: str, version: str) -> str:
+    return f"{MAJOR_APPROVAL_DIR}/{skill}-v{version}.json"

--- a/tools/skillstead_validate/package_check.py
+++ b/tools/skillstead_validate/package_check.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from . import SEMVER_RE
 from .catalog import EN_HEADER, KO_HEADER, CatalogError, catalog_versions
 from .changelog import ChangelogError, topmost_released_version
+from .evidence_records import RESERVED_SKILL_NAMES
 from .findings import Finding
 from .frontmatter import FrontmatterError, parse_skill_frontmatter
 from .source import CommitSource, Source, WorktreeSource
@@ -116,6 +117,10 @@ def run_validation(source: Source) -> list[Finding]:
         return [Finding("INVENTORY", "skills/", "no packages found")]
     versions: dict[str, str | None] = {}
     for name in inventory:
+        if name in RESERVED_SKILL_NAMES:
+            findings.append(Finding(
+                "RESERVED-NAME", name,
+                "template identity is reserved and cannot enter active skills/"))
         pkg_findings, version = check_package(source, name)
         findings.extend(pkg_findings)
         versions[name] = version

--- a/tools/skillstead_validate/release_gate.py
+++ b/tools/skillstead_validate/release_gate.py
@@ -15,10 +15,18 @@ from . import SEMVER_RE, record_schema
 from .bump import default_step, step_of
 from .changelog import ChangelogError, topmost_released_version
 from .catalog import EN_HEADER, KO_HEADER, CatalogError, catalog_versions
+from .evidence_records import (
+    RecordError,
+    major_approval_path,
+    parse_major_approval_record,
+    parse_retirement_record,
+    retirement_path,
+)
 from .findings import Finding
 from .frontmatter import FrontmatterError, parse_skill_frontmatter
 from .gitio import (GitError, dirs_at, file_at, first_parent_positions, git,
                     peeled, tag_names)
+from .install_pins import parse_pins
 from .normalize import changed_payload_paths, payload_changed
 from .package_check import run_repo_validation_at
 from .release_plan import ReleasePlan
@@ -83,6 +91,126 @@ def _entry_section(changelog_text: str, version: str) -> str | None:
             end = j
             break
     return "\n".join(lines[start:end])
+
+
+def _retired_row(skill: str, last_release_ref: str | None) -> str:
+    release = last_release_ref or "unreleased"
+    path = retirement_path(skill)
+    return f"| `{skill}` | `{release}` | [record](./{path}) |"
+
+
+_RETIRED_TABLES = {
+    "README.md": (
+        "## Retired skills",
+        "| Skill | Last release | Evidence |",
+        "| --- | --- | --- |",
+    ),
+    "README.ko.md": (
+        "## 은퇴한 스킬",
+        "| 스킬 | 마지막 릴리스 | 증거 |",
+        "| --- | --- | --- |",
+    ),
+}
+
+
+def _retired_table_contains(text: str, fname: str, expected_row: str) -> bool:
+    """Require the evidence row inside one explicit retired-skills table."""
+    heading, header, separator = _RETIRED_TABLES[fname]
+    lines = text.splitlines()
+    positions = [i for i, line in enumerate(lines) if line == heading]
+    if len(positions) != 1:
+        return False
+    start = positions[0] + 1
+    end = next(
+        (i for i in range(start, len(lines)) if lines[i].startswith("## ")),
+        len(lines),
+    )
+    section = lines[start:end]
+    for i in range(len(section) - 1):
+        if section[i] == header and section[i + 1] == separator:
+            return expected_row in section[i + 2:]
+    return False
+
+
+def _retirement_findings(
+        repo: Path, target: str, skill: str) -> list[Finding]:
+    """I-10 target-tree half of the retirement contract."""
+    findings: list[Finding] = []
+    path = retirement_path(skill)
+    text = file_at(repo, target, path)
+    if text is None:
+        return [Finding(
+            "I-10", skill,
+            f"inventory decreased without retirement record {path}")]
+    try:
+        record = parse_retirement_record(text, skill)
+    except RecordError as error:
+        return [Finding(
+            "RETIREMENT", path, f"record rejected (fail-closed): {error}")]
+
+    previous = previous_release(repo, skill)
+    if previous is None:
+        if record.last_release_ref is not None:
+            findings.append(Finding(
+                "RETIREMENT", path,
+                "unreleased skill must use last_release_ref null"))
+    elif record.last_release_ref != previous[1]:
+        findings.append(Finding(
+            "RETIREMENT", path,
+            f"last_release_ref {record.last_release_ref!r} != latest "
+            f"observable release {previous[1]!r}"))
+
+    for fname in ("docs/INSTALL.md", "docs/INSTALL.ko.md"):
+        install = file_at(repo, target, fname)
+        if install is None:
+            findings.append(Finding(
+                "RETIREMENT", fname,
+                "install document missing; active-pin removal unobservable"))
+            continue
+        pins = parse_pins(install)
+        if pins.ambiguous:
+            findings.append(Finding(
+                "RETIREMENT", fname,
+                "install pin inventory is ambiguous (fail-closed)"))
+        if any(pin.copy_skill == skill for pin in pins.pins):
+            findings.append(Finding(
+                "RETIREMENT", fname,
+                f"active install pin remains for retired skill {skill}"))
+
+    expected_row = _retired_row(skill, record.last_release_ref)
+    for fname in ("README.md", "README.ko.md"):
+        root = file_at(repo, target, fname)
+        if root is None or not _retired_table_contains(
+                root, fname, expected_row):
+            findings.append(Finding(
+                "RETIREMENT", fname,
+                f"localized retired table must contain exact material row "
+                f"{expected_row!r}"))
+    return findings
+
+
+def _major_approval_findings(
+        repo: Path, target: str, skill: str, previous_ref: str,
+        proposed_version: str) -> list[Finding]:
+    path = major_approval_path(skill, proposed_version)
+    text = file_at(repo, target, path)
+    if text is None:
+        return [Finding(
+            "MAJOR-APPROVAL", path,
+            "single-step major transition requires a tracked approval record")]
+    try:
+        record = parse_major_approval_record(
+            text, skill, proposed_version)
+    except RecordError as error:
+        return [Finding(
+            "MAJOR-APPROVAL", path,
+            f"record rejected (fail-closed): {error}")]
+    if record.previous_ref != previous_ref:
+        return [Finding(
+            "MAJOR-APPROVAL", path,
+            f"previous_ref {record.previous_ref!r} != latest observable "
+            f"release {previous_ref!r}")]
+    return []
 
 
 def _baseline_record_at(repo: Path, target: str,
@@ -297,7 +425,8 @@ def preflight(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[Fin
                 findings.append(Finding("I-6", e.skill, f"{prev[0]} -> {e.proposed_version} is not a single-step bump"))
                 continue
             if step == "major":
-                findings.append(Finding("E14", e.skill, "major bump requires owner approval evidence; no evidence format exists yet (fail-closed)"))
+                findings.extend(_major_approval_findings(
+                    repo, target, e.skill, prev[1], e.proposed_version))
                 continue
             try:
                 prev_target = peeled(repo, prev[1])
@@ -360,13 +489,15 @@ def preflight(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[Fin
                     if e.skill in parent_table:
                         findings.append(Finding("D3-3", e.skill, f"{fname} catalog row existed before the target commit"))
 
-    # I-10: inventory reduction requires an approved retirement marker; no
-    # marker format exists until the playbook defines one — fail-closed.
+    # I-10: inventory reduction requires a target-bound retirement record and
+    # the complete target-tree removal predicate.
     # No-op green must be activation-aware (MR1R-F8): "no namespaced release"
     # is only pre-cutover when there is also no cutover-record trace in
     # first-parent history — otherwise a full tag deletion would masquerade
     # as the pre-cutover state and silence I-10.
     baseline_commit = _latest_release_commit(repo, target)
+    before: set[str] = set()
+    before_observed = False
     if baseline_commit is None:
         try:
             record_trace = git(repo, "log", "--first-parent", "--format=%H",
@@ -378,14 +509,27 @@ def preflight(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[Fin
             findings.append(Finding("I-10", "skills/", "no prior namespaced release observable from target, but the state is not provably pre-cutover (fail-closed)"))
     else:
         try:
-            before = dirs_at(repo, baseline_commit, "skills")
+            before.update(dirs_at(repo, baseline_commit, "skills"))
+            before_observed = True
         except GitError as e:
             findings.append(Finding("GIT", "skills/", f"I-10 baseline unobservable (fail-closed): {e}"))
-            before = None
-        if before is not None:
-            removed = before - inventory
-            if removed:
-                findings.append(Finding("I-10", ",".join(sorted(removed)), "inventory decreased without an approved retirement marker (fail-closed until the marker format is defined)"))
+
+    # The latest release baseline protects released inventory. The immediate
+    # parent independently protects a never-released package introduced after
+    # that baseline and removed by this target.
+    if target_parent is not None:
+        try:
+            before.update(dirs_at(repo, target_parent, "skills"))
+            before_observed = True
+        except GitError as e:
+            findings.append(Finding(
+                "GIT", "skills/",
+                f"I-10 parent inventory unobservable (fail-closed): {e}"))
+
+    if before_observed:
+        for removed_skill in sorted(before - inventory):
+            findings.extend(_retirement_findings(
+                repo, target, removed_skill))
 
     return findings
 

--- a/tools/skillstead_validate/tag_check.py
+++ b/tools/skillstead_validate/tag_check.py
@@ -25,9 +25,23 @@ import re
 from pathlib import Path
 
 from . import record_schema
+from .evidence_records import (
+    RETIREMENT_DIR,
+    RecordError,
+    RetirementRecord,
+    parse_retirement_record,
+)
 from .findings import Finding
 from .frontmatter import FrontmatterError, parse_skill_frontmatter
-from .gitio import GitError, dirs_at, file_at, git, peeled, tag_names
+from .gitio import (
+    GitError,
+    dirs_at,
+    file_at,
+    files_at,
+    git,
+    peeled,
+    tag_names,
+)
 
 RECORD_PATH = record_schema.RECORD_PATH
 _TAG_RE = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+\.\d+\.\d+)$")
@@ -126,6 +140,92 @@ class _History:
         return found, bad
 
 
+def _retirement_history_findings(
+        repo: Path, history: _History) -> list[Finding]:
+    """Continuous first-parent durability and reactivation checks.
+
+    Once a valid record appears, every later first-parent state must preserve
+    its path and semantic value. A current-tree-only check cannot distinguish a
+    deleted record plus re-added package from a new skill.
+    """
+    findings: list[Finding] = []
+    known: dict[str, RetirementRecord] = {}
+    reported: set[tuple[str, str]] = set()
+
+    def report(kind: str, skill: str, commit: str, detail: str) -> None:
+        key = (kind, skill)
+        if key not in reported:
+            reported.add(key)
+            findings.append(Finding(
+                "RETIREMENT-HISTORY", skill,
+                f"{detail} at {commit[:12]} (fail-closed)"))
+
+    for commit in reversed(history.commits):  # oldest -> tip
+        try:
+            paths = files_at(repo, commit, RETIREMENT_DIR)
+        except GitError as error:
+            findings.append(Finding(
+                "GIT", RETIREMENT_DIR,
+                f"retirement history unobservable at {commit[:12]} "
+                f"(fail-closed): {error}"))
+            return findings
+
+        current: dict[str, RetirementRecord] = {}
+        prefix = RETIREMENT_DIR + "/"
+        for path in sorted(paths):
+            leaf = path.removeprefix(prefix)
+            if "/" in leaf or not leaf.endswith(".json"):
+                findings.append(Finding(
+                    "RETIREMENT-HISTORY", path,
+                    f"unexpected retirement record path at {commit[:12]} "
+                    "(fail-closed)"))
+                continue
+            skill = leaf[:-5]
+            text = file_at(repo, commit, path)
+            if text is None:
+                findings.append(Finding(
+                    "RETIREMENT-HISTORY", path,
+                    f"record content unobservable at {commit[:12]} "
+                    "(fail-closed)"))
+                continue
+            try:
+                current[skill] = parse_retirement_record(text, skill)
+            except RecordError as error:
+                findings.append(Finding(
+                    "RETIREMENT-HISTORY", path,
+                    f"record rejected at {commit[:12]} "
+                    f"(fail-closed): {error}"))
+
+        for skill, original in known.items():
+            observed = current.get(skill)
+            if observed is None:
+                report(
+                    "missing", skill, commit,
+                    "retirement record disappeared or moved")
+            elif observed != original:
+                report(
+                    "mutated", skill, commit,
+                    "retirement record semantic value changed")
+
+        for skill, record in current.items():
+            known.setdefault(skill, record)
+
+        if known:
+            try:
+                inventory = dirs_at(repo, commit, "skills")
+            except GitError as error:
+                findings.append(Finding(
+                    "GIT", "skills/",
+                    f"reactivation inventory unobservable at {commit[:12]} "
+                    f"(fail-closed): {error}"))
+                return findings
+            for skill in sorted(set(known) & inventory):
+                report(
+                    "reactivated", skill, commit,
+                    "active package coexists with historical retirement")
+    return findings
+
+
 def run_tag_checks(repo: Path, main_ref: str = "main") -> list[Finding]:
     findings: list[Finding] = []
     try:
@@ -133,6 +233,8 @@ def run_tag_checks(repo: Path, main_ref: str = "main") -> list[Finding]:
         history = _History(repo, main_tip)
     except GitError as e:
         return [Finding("GIT", main_ref, f"main history unobservable (fail-closed): {e}")]
+
+    findings.extend(_retirement_history_findings(repo, history))
 
     record: dict | None = None
     try:


### PR DESCRIPTION
## 변경 사항

- EN/KO skill development Standard·Procedure와 재사용 template을 추가했습니다.
- retirement 및 major-version transition evidence를 release/history gate에 연결했습니다.
- package identity, evidence schema, public hygiene와 lifecycle 경계에 대한 positive/negative fixture를 보강했습니다.
- 독립 multi-agent review의 역할 계약과 round relay template을 public maintainer 표면에 포함했습니다.

## 배경

새 skill의 설계·구현·검증·배포 준비를 반복 가능한 절차로 고정하고, 공개 후 identity 및 lifecycle 변경을 fail-closed evidence로 보호하기 위한 C4 작업입니다.

## 검증

- Unit suite: 157 tests pass
- M1 repository validation: 0 findings
- M3 tag/history validation: 0 findings
- M4 live cutover: `complete — steady state`
- pinned `skills-ref`: 4 packages, 0 failures
- local Markdown links: 32 files green
- template `LICENSE.txt`: root `LICENSE`와 byte-identical
- fresh-context R1 bounded recheck: approve
