### PR TITLE
docs: C4 repository 변경을 changelog에 기록한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Notable changes to this repository. Format based on [Keep a Changelog](https://k
 
 Granular, per-change entries begin at the first public release. Earlier development history is in the git log.
 
+## 2026-07-29
+
+### Repository
+
+- **Reusable skill-development playbook.** Added bilingual package standards, a maintainer procedure, validation
+  examples, and reusable templates for scenarios, expected outcomes, evidence ledgers, release notes, and
+  role-based cross-review relay.
+- **Lifecycle evidence and validation.** Added strict retirement and major-version approval records, fail-closed
+  current-tree and first-parent history checks, reserved-identity protection, and positive and negative fixtures
+  for lifecycle boundary failures.
+
 ## 2026-07-28
 
 ### Repository


### PR DESCRIPTION
## 변경 사항

- Root `CHANGELOG.md`에 2026-07-29 repository 항목을 추가했습니다.
- PR #31에서 도입한 reusable skill-development playbook과 lifecycle validation 변경을 기록했습니다.

## 누락 원인

PR #31의 candidate surface와 completion criteria에 root changelog cascade가 포함되지 않았고, 현재 validator는 per-skill changelog contract만 검사하므로 repository-level 기록 누락을 잡지 못했습니다.

## 검증

- M1 repository validation: 0 findings
- M3 tag/history validation: 0 findings
- `git diff --check`: pass
