### PR TITLE
docs: bilingual 문서 drift를 정리하고 두 skill을 patch bump한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Granular, per-change entries begin at the first public release. Earlier developm
 - **Lifecycle evidence and validation.** Added strict retirement and major-version approval records, fail-closed
   current-tree and first-parent history checks, reserved-identity protection, and positive and negative fixtures
   for lifecycle boundary failures.
+- **Bilingual documentation currentness.** Aligned the `VALIDATION` language switcher with the `VERSIONING` and
+  `INSTALL` form, corrected the `svg-infographic` package tree to match the folder an install actually copies,
+  and pointed the Korean skill READMEs at the Korean install guide.
+
+### Skills
+
+- `svg-infographic` `0.8.2` — package tree correction and Korean install link.
+- `writing-quality-editor` `0.9.1` — Korean install link.
 
 ## 2026-07-28
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -33,10 +33,10 @@
 
 | 스킬 | 이런 작업에 적합 | 버전 | 지원 실행 환경 | 성숙도 |
 | --- | --- | --- | --- | --- |
-| [`svg-infographic`](./skills/svg-infographic) | 아키텍처 설명, 작업 흐름, 비교 자료를 수정 가능한 SVG와 검증된 2× PNG로 제작 | `0.8.1` | Supported: Claude Code + Codex | Stable |
+| [`svg-infographic`](./skills/svg-infographic) | 아키텍처 설명, 작업 흐름, 비교 자료를 수정 가능한 SVG와 검증된 2× PNG로 제작 | `0.8.2` | Supported: Claude Code + Codex | Stable |
 | [`docs-claim-check`](./skills/docs-claim-check) | 공개 문서의 주장이 제공된 근거로 뒷받침되는지 확인 | `0.9.0` | Claude Code | Beta |
 | [`github-release-guide`](./skills/github-release-guide) | 비공개 GitHub 저장소의 첫 공개 전환 또는 공개 후 매 버전 릴리스를 점검하고 단계별로 안내 | `0.8.1` | Supported: Claude Code + Codex | Stable |
-| [`writing-quality-editor`](./skills/writing-quality-editor) | 사용자 문서를 처음부터 작성하거나 자연스럽게 다듬고, 사실·의도·목소리·운영 제약을 보존하면서 영어↔한국어 내용을 재구성 | `0.9.0` | Supported: Claude Code + Codex | Beta |
+| [`writing-quality-editor`](./skills/writing-quality-editor) | 사용자 문서를 처음부터 작성하거나 자연스럽게 다듬고, 사실·의도·목소리·운영 제약을 보존하면서 영어↔한국어 내용을 재구성 | `0.9.1` | Supported: Claude Code + Codex | Beta |
 
 각 스킬은 필요한 파일을 모두 갖춘 독립 패키지입니다. 전체 목록을 설치할 필요 없이, 사용할 스킬의
 폴더만 통째로 복사하면 됩니다. 개인용·프로젝트용 설치 경로, 고정 버전 설치, 깨끗한 업데이트 방법,

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ required pipeline: start with the skill you need, skip the others, and recheck a
 
 | Skill | Best for | Version | Runtime support | Maturity |
 | --- | --- | --- | --- | --- |
-| [`svg-infographic`](./skills/svg-infographic) | Turning architecture notes, process flows, comparisons, and technical concepts into editable SVG + verified 2× PNG | `0.8.1` | Supported: Claude Code + Codex | Stable |
+| [`svg-infographic`](./skills/svg-infographic) | Turning architecture notes, process flows, comparisons, and technical concepts into editable SVG + verified 2× PNG | `0.8.2` | Supported: Claude Code + Codex | Stable |
 | [`docs-claim-check`](./skills/docs-claim-check) | Checking whether public documentation claims are supported by supplied evidence | `0.9.0` | Claude Code | Beta |
 | [`github-release-guide`](./skills/github-release-guide) | Guiding a private repository's first public transition and every later version release, with separate approval before each change | `0.8.1` | Supported: Claude Code + Codex | Stable |
-| [`writing-quality-editor`](./skills/writing-quality-editor) | Composing and revising user-facing text, plus natural English↔Korean adaptation, without inventing or changing facts, intent, voice, or operational constraints | `0.9.0` | Supported: Claude Code + Codex | Beta |
+| [`writing-quality-editor`](./skills/writing-quality-editor) | Composing and revising user-facing text, plus natural English↔Korean adaptation, without inventing or changing facts, intent, voice, or operational constraints | `0.9.1` | Supported: Claude Code + Codex | Beta |
 
 Each skill is self-contained and can be installed independently. You do not need to install the entire
 catalog—copy only the complete folder for the skill you want to use. See

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -1,6 +1,6 @@
 # 검증·릴리스 도구 체계
 
-[English](./VALIDATION.md)
+*[English (canonical)](./VALIDATION.md) · 한국어*
 
 이 문서는 `tools/skillstead_validate/`의 검증 도구 체계와 그것이 지키는 릴리스 경로를 설명합니다.
 버전 규칙 자체는 [`VERSIONING.ko.md`](./VERSIONING.ko.md)에 있고, 이 문서는 그 규칙을 어떻게 검사하고

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,6 +1,6 @@
 # Validation And Release Toolchain
 
-[한국어](./VALIDATION.ko.md)
+*English (canonical) · [한국어](./VALIDATION.ko.md)*
 
 This document describes the repository's validation toolchain under
 `tools/skillstead_validate/` and the release path it guards. The versioning

--- a/skills/svg-infographic/CHANGELOG.md
+++ b/skills/svg-infographic/CHANGELOG.md
@@ -11,6 +11,12 @@ automated checks read the topmost released heading to confirm it matches `metada
 `SKILL.md`. The full grammar is documented at
 [`docs/VERSIONING.md`](https://github.com/kyungseo/skillstead/blob/main/docs/VERSIONING.md).
 
+## [0.8.2] — 2026-07-29
+
+- Corrected the package tree in `README.md` and `README.ko.md` to list every file the complete-folder
+  install copies, including `README.md`, `README.ko.md`, `CHANGELOG.md`, and `LICENSE.txt`.
+- Pointed the Korean README at the Korean install guide (`docs/INSTALL.ko.md`) instead of the English one.
+
 ## [0.8.1] — 2026-07-28
 
 - Added canonical-name and intent-only prompt examples while preserving output-path confirmation and render

--- a/skills/svg-infographic/README.ko.md
+++ b/skills/svg-infographic/README.ko.md
@@ -235,6 +235,10 @@ Claude Code 또는 Codex의 skills 디렉터리에 패키지를 복사합니다.
 ```text
 <skills-dir>/svg-infographic/
 ├── SKILL.md                  # 핵심 작업 절차(진입점)
+├── README.md                 # 영어 안내 문서
+├── README.ko.md              # 이 문서
+├── CHANGELOG.md              # 이 스킬의 릴리스 이력
+├── LICENSE.txt               # Apache-2.0 전문(패키지와 함께 이동)
 ├── references/
 │   ├── archetypes.md         # 다이어그램 유형별 골격, 시각 표현 지침, 점검 항목
 │   ├── authoring.md          # 상세 규칙, 아이콘 모음, 수동 렌더링 대안
@@ -249,7 +253,7 @@ Claude Code 또는 Codex의 skills 디렉터리에 패키지를 복사합니다.
 ```
 
 macOS, Linux와 Windows에서 전역 또는 프로젝트 경로에 설치하는 명령은
-[`docs/INSTALL.md`](https://github.com/kyungseo/skillstead/blob/main/docs/INSTALL.md)를 참고하세요.
+[`docs/INSTALL.ko.md`](https://github.com/kyungseo/skillstead/blob/main/docs/INSTALL.ko.md)를 참고하세요.
 
 ## 예제
 

--- a/skills/svg-infographic/README.md
+++ b/skills/svg-infographic/README.md
@@ -220,6 +220,10 @@ project. The skill is a multi-file package, so copy the whole folder:
 ```text
 <skills-dir>/svg-infographic/
 ├── SKILL.md                  # core workflow (entry point)
+├── README.md                 # this guide
+├── README.ko.md              # Korean guide
+├── CHANGELOG.md              # per-skill release history
+├── LICENSE.txt               # Apache-2.0 full text (travels with the package)
 ├── references/
 │   ├── archetypes.md         # archetype catalog: skeletons, premium recipe, checks
 │   ├── authoring.md          # detailed rules, icon set, manual render fallback

--- a/skills/svg-infographic/SKILL.md
+++ b/skills/svg-infographic/SKILL.md
@@ -3,7 +3,7 @@ name: svg-infographic
 description: Author technical/structured SVG infographics and diagrams, then render them to crisp PNG with a headless browser. Best for architecture diagrams, topology maps, flows, before/after comparisons, nested/onion layer models, roadmaps, decision matrices, and social-ready technical one-pagers. Prefers clean line icons in soft tinted circles. First-class Korean/CJK text. Includes an opt-in "tidy hand-drawn" sketch preset (paper background, Korean handwriting font, rough strokes, highlighter). Not for photo-heavy or illustration-heavy graphics, statistical charts, or mascot/character illustration.
 license: LICENSE.txt
 metadata:
-  version: 0.8.1
+  version: 0.8.2
 ---
 
 # svg-infographic

--- a/skills/writing-quality-editor/CHANGELOG.md
+++ b/skills/writing-quality-editor/CHANGELOG.md
@@ -11,6 +11,10 @@ automated checks read the topmost released heading to confirm it matches `metada
 `SKILL.md`. The full grammar is documented at
 [`docs/VERSIONING.md`](https://github.com/kyungseo/skillstead/blob/main/docs/VERSIONING.md).
 
+## [0.9.1] — 2026-07-29
+
+- Pointed the Korean README at the Korean install guide (`docs/INSTALL.ko.md`) instead of the English one.
+
 ## [0.9.0] — 2026-07-28
 
 - Added `WQE` as a natural-language discovery alias in the common description and user examples. The canonical

--- a/skills/writing-quality-editor/README.ko.md
+++ b/skills/writing-quality-editor/README.ko.md
@@ -122,4 +122,4 @@ repository 전용
 사용하는 가상 검증 자료와 정답표는
 [`examples/writing-quality-editor`](https://github.com/kyungseo/skillstead/tree/main/examples/writing-quality-editor)에 있습니다.
 
-전체 스킬 설치 방법은 [`docs/INSTALL.md`](https://github.com/kyungseo/skillstead/blob/main/docs/INSTALL.md)에서 확인할 수 있습니다.
+전체 스킬 설치 방법은 [`docs/INSTALL.ko.md`](https://github.com/kyungseo/skillstead/blob/main/docs/INSTALL.ko.md)에서 확인할 수 있습니다.

--- a/skills/writing-quality-editor/SKILL.md
+++ b/skills/writing-quality-editor/SKILL.md
@@ -3,7 +3,7 @@ name: writing-quality-editor
 description: Writing Quality Editor (WQE) composes, assesses, revises, and adapts user-facing writing so it reads naturally while preserving meaning, claims, intent, voice, conditions, numbers, identifiers, exceptions, and risks. Use when a user asks to write, review, polish, fix, improve, supplement, clarify, translate, localize, or make a document sound natural; no skill or mode name is required. Covers README, onboarding, release notes, manuals, UI, errors, gallery copy, research-backed briefs, technical comparisons, and natural English↔Korean adaptation. If a host repository workflow owns document classification, path, indexing, lifecycle, or approval, keep it primary and use this skill only as an optional authoring layer. Locale-neutral design; EN↔KO (`ko-KR`) is the initial profile under validation. Do not game detectors, conceal provenance, invent claims, replace evidence review, or bypass host workflows.
 license: LICENSE.txt
 metadata:
-  version: 0.9.0
+  version: 0.9.1
 ---
 
 # Writing Quality Editor


### PR DESCRIPTION
## 배경

C5 per-skill versioning cutover와 skill-development playbook 작업이 끝난 뒤 남아 있던 bilingual 문서 drift를 정리한다. 네 건 모두 사용자가 실제로 따라가는 경로의 결함이다.

## 변경 내용

**문서 정정**

- `docs/VALIDATION.md`·`.ko.md` — 상단 언어 전환을 `VERSIONING`·`INSTALL`과 같은 canonical 형식(`*English (canonical) · [한국어](…)*` / `*[English (canonical)](…) · 한국어*`)으로 정렬했다.
- `skills/svg-infographic/README.md`·`README.ko.md` — package tree가 실제 설치본에 있는 `README.md`·`README.ko.md`·`CHANGELOG.md`·`LICENSE.txt` 네 건을 빠뜨리고 있었다. complete-folder 설치를 안내하는 문서가 정작 복사되는 파일을 다 보여주지 않았다.
- `skills/svg-infographic/README.ko.md`·`skills/writing-quality-editor/README.ko.md` — 한국어 문서가 영어 설치 가이드(`docs/INSTALL.md`)를 가리키고 있었다. `docs/INSTALL.ko.md`로 전환했다.

**Patch bump**

`README*.md` 변경이므로 `docs/VERSIONING.md`의 경로 기본값에 따라 patch다.

| Package | 변경 | 버전 |
| --- | --- | --- |
| `svg-infographic` | `README.md`·`README.ko.md` | `0.8.1` → `0.8.2` |
| `writing-quality-editor` | `README.ko.md` | `0.9.0` → `0.9.1` |

`docs/VALIDATION*`는 package 밖 shared docs라 bump 대상이 아니다. `metadata.version`과 per-skill `CHANGELOG.md`는 non-trigger bookkeeping으로 위 payload 변경과 함께 실린다.

## 검증

- `python3 -m unittest discover -s tests` — **157 tests, OK**
- `PYTHONPATH=tools python3 -m skillstead_validate repo` — **0 findings**
- `PYTHONPATH=tools python3 -m skillstead_validate tags` — **0 findings**
- `python3 tools/run_skills_ref.py` — **4 packages, 0 failures**
- `git diff --check` clean
- 언어 전환 형식 6종(VALIDATION·VERSIONING·INSTALL EN/KO) 동일 형식 확인
- 한국어 skill README의 stale `docs/INSTALL.md` 참조 **0건**
- package tree top-level ↔ 실제 folder **완전 일치**(EN·KO)

## 릴리스

merge 후 M2 preflight → atomic tag → M3 검증 → 승인 후 canonical Release 순서로 두 건을 발행한다. INSTALL pin은 다른 skill의 tag를 사용하므로 이번 bump가 pin rotation을 유발하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)