### PR TITLE
fix: 발행 직후 stale 관측을 재관측하되 진짜 red는 유지한다

### DIFF
--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -35,6 +35,33 @@ action별 request boolean 제약(request는 의도한 최종 상태와 같아야
 `--verify-tag`). `gh release …` 직접 호출은 **지원되지 않는 경로**입니다 — 저장소 ruleset에는
 admin bypass가 있으므로 이 경계는 hard guarantee가 아니라 discipline입니다.
 
+**발행 직후 재관측 (M5).** 발행 직후에 보낸 읽기는 아직 따라잡지 못한 replica에서 응답할 수 있어,
+방금 만든 release가 빠진 목록이 돌아오기도 합니다. wrapper는 **그 경우만** 재시도하며, 판별 기준은
+스스로 모순되는 관측입니다 — `Latest`가 요청한 tag를 가리키는데 정작 그 tag가 release 목록에 없는
+상태입니다. 목록이 `Latest`가 가리키는 release를 빠뜨릴 수는 없으므로, 목록이 아직 보이지 않는
+것뿐입니다.
+
+그 밖의 경우는 red를 그대로 유지합니다. **실제 Latest 오배치**는 모양이 다릅니다 — `Latest`가 목록에
+존재하되 가장 최신이 아닙니다. Release 누락, 정규화할 수 없는 release 객체(`CV-DOMAIN` — 발행된
+release의 `published_at`이 null이거나 빈 문자열인 경우 포함), transport 실패도 마찬가지입니다.
+
+재시도는 세 가지로 제한됩니다: 최대 **3회** 재관측, **1초 / 2초 / 4초** backoff, 첫 stale 읽기부터
+측정하는 **10초** wall-clock 상한. 이 상한은 deadline으로 transport까지 전달되어 페이지 단위 release
+호출의 **매 페이지 직전에 다시 검사**되므로, 이미 시작된 요청 하나도 상한을 넘길 수 없습니다 —
+요청당 timeout만으로는 한 페이지만 제한할 뿐 루프 전체를 제한하지 못합니다. wrapper는 재관측이 어떻게
+끝났는지를 최초 stale verdict와 함께 보고하며, `resolved`가 아닌 경우 그 최초 verdict를 그대로
+반환합니다.
+
+| 종료 이유 | 의미 |
+| --- | --- |
+| `resolved` | 재관측이 더 이상 스스로 모순되지 않아 verdict를 다시 계산했습니다 |
+| `retry-exhausted` | 세 번의 재관측이 모두 여전히 stale이었습니다 |
+| `total-cap` | wall-clock 상한에 도달했거나, deadline이 지나 transport가 요청을 시작하지 않았습니다 |
+| `observation-failed` | deadline과 무관한 이유로 재관측이 실패했습니다(예: CLI 자체 오류) |
+
+마지막 두 값을 나눈 것은 의도적입니다. transport 오류를 timeout으로 보고하면 실행이 관측하지 않은
+사실을 말하게 됩니다.
+
 ## CI workflow
 
 | 파일 | trigger | 목적 |

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -40,6 +40,37 @@ wrapper never creates tags (`--verify-tag` on every create). Calling `gh
 release …` directly is an **unsupported path** — repository rulesets carry
 admin bypasses, so this boundary is discipline, not a hard guarantee.
 
+**Post-publish re-read (M5).** A read issued immediately after a publish can
+come back from a replica that has not caught up, listing releases without the
+one just created. The wrapper retries **only** that case, identified by an
+observation that contradicts itself: `Latest` names the requested tag, yet
+that tag is absent from the release list. A list cannot omit the release
+`Latest` points at, so the list is simply not visible yet.
+
+Everything else keeps its red. A *real* misplacement looks different — `Latest`
+is present in the list but is not the newest — and so do a missing Release, an
+unnormalizable release object (`CV-DOMAIN`, including a published release whose
+`published_at` is null or empty), and any transport failure.
+
+The retry is bounded three ways: at most **3** re-reads, backing off
+**1s / 2s / 4s**, inside a **10s** wall-clock cap measured from the first stale
+read. The cap is handed to the transport as a deadline and re-checked before
+every page of the paged releases call, so a single in-flight request cannot
+outlive it either — a per-request timeout alone would bound one page, not the
+loop. The wrapper reports how the re-read ended, together with the first stale
+verdict, and anything other than `resolved` returns that original verdict
+unchanged.
+
+| End reason | Meaning |
+| --- | --- |
+| `resolved` | a re-read no longer contradicted itself; the verdict was recomputed |
+| `retry-exhausted` | all three re-reads still showed the stale observation |
+| `total-cap` | the wall-clock cap was reached, or the transport refused a request because the deadline had passed |
+| `observation-failed` | a re-read failed for a reason unrelated to the deadline (for example the CLI itself erred) |
+
+The last two are separate on purpose: reporting a transport error as a timeout
+would state something the run did not observe.
+
 ## CI workflows
 
 | File | Triggers | Purpose |

--- a/playbooks/skill-development/skill-development-procedure.ko.md
+++ b/playbooks/skill-development/skill-development-procedure.ko.md
@@ -92,6 +92,11 @@ GitHub source archive는 repository snapshot이며 standalone package artifact�
 Merge-to-tag 구간의 임시 red를 숨기지 않습니다. 실제 merge target과 remote ref를 관측한 뒤 문서에
 정한 bounded path만 다시 실행합니다. 예상하지 못한 code나 partial ref는 Owner가 결정합니다.
 
+Publish 단계 자체에는 그런 판단이 필요하지 않습니다. Release wrapper는 발행 직후의 관측이 스스로
+모순될 때에 **한해서만** 정해진 예산 안에서 재관측하고 그 결과를 보고합니다. 따라서 wrapper가 돌려준
+red는 이미 그 재시도를 견딘 결과이므로, 타이밍 문제가 아니라 실제 finding으로 읽고 red를 없애려고
+publish를 다시 실행하지 않습니다.
+
 ## 9. 지원 종료 시 retirement
 
 Retirement는 active skill에 적용하며 disposable pre-publication material에는 적용하지 않습니다.

--- a/playbooks/skill-development/skill-development-procedure.md
+++ b/playbooks/skill-development/skill-development-procedure.md
@@ -91,6 +91,11 @@ During the merge-to-tag window, do not suppress a temporary red result. Re-run o
 after the actual merge target and remote refs are observable. Unexpected codes or partial refs require an owner
 decision.
 
+The publish step itself needs no such judgement. The release wrapper already retries its own post-publish read
+when — and only when — that observation contradicts itself, within a bounded budget it reports. A red the
+wrapper returns has therefore already survived that retry, so read it as a real finding rather than a timing
+artefact, and never repeat a publish to make one disappear.
+
 ## 9. Retire When Support Ends
 
 Retirement applies to an active skill, not disposable pre-publication material.

--- a/tests/test_cutover.py
+++ b/tests/test_cutover.py
@@ -550,6 +550,35 @@ class TransportSeam(unittest.TestCase):
             raise TransportError("HTTP 404: Not Found")
         self.assertIsNone(fetch_latest("o/r", runner))
 
+    # A deadline that already passed must stop the call, not shorten it.
+    def test_expired_deadline_never_starts_a_request(self) -> None:
+        calls = []
+
+        def runner(args, timeout=None):
+            calls.append(args)
+            return json.dumps([])
+        with self.assertRaises(TransportError):
+            fetch_releases("o/r", runner, deadline=5.0, monotonic=lambda: 5.0)
+        self.assertEqual(calls, [])
+
+    # Per-request timeouts alone would not bound a paging loop, so the
+    # deadline is re-checked before every page.
+    def test_deadline_stops_paging_midway(self) -> None:
+        clock = {"t": 0.0}
+        timeouts = []
+
+        def runner(args, timeout=None):
+            timeouts.append(timeout)
+            clock["t"] += 4.0
+            return json.dumps([{"id": i} for i in range(100)])
+        with self.assertRaises(TransportError):
+            fetch_releases("o/r", runner, deadline=10.0,
+                           monotonic=lambda: clock["t"])
+        # Every page is given exactly the time still left, so no single request
+        # can outlive the deadline; once nothing is left the next page is never
+        # requested at all.
+        self.assertEqual(timeouts, [10.0, 6.0, 2.0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -17,10 +17,30 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from git_fixture import _git, build_unreleased_repo, commit_all  # noqa: E402
 from skillstead_validate import install_pins, record_schema  # noqa: E402
 from skillstead_validate.cutover import P3_MARKER  # noqa: E402
+from skillstead_validate.transport import TransportError  # noqa: E402
 from skillstead_validate.wrapper import (RequestError, parse_request,  # noqa: E402
                                          run_wrapper)
 from test_cutover import (FIX_PIN, FIX_TAGS, SKILLS, make_install,  # noqa: E402
                            make_release, write_install_pair)
+from test_release_gate import _bump_alpha  # noqa: E402
+
+
+def _bump_beta(repo: Path, version: str) -> None:
+    """beta-skill counterpart of _bump_alpha: version + CHANGELOG + catalog."""
+    skill_md = repo / "skills/beta-skill/SKILL.md"
+    skill_md.write_text(
+        skill_md.read_text(encoding="utf-8").replace("  version: 0.4.0", f"  version: {version}"),
+        encoding="utf-8")
+    changelog = repo / "skills/beta-skill/CHANGELOG.md"
+    changelog.write_text(
+        changelog.read_text(encoding="utf-8").replace(
+            "## [0.4.0]", f"## [{version}] — 2026-07-28\n\nFixture entry.\n\n## [0.4.0]", 1)
+        .replace(f"## [{version}] — 2026-07-28 — 2026-07-24", f"## [{version}] — 2026-07-28"),
+        encoding="utf-8")
+    for fname in ("README.md", "README.ko.md"):
+        f = repo / fname
+        f.write_text(f.read_text(encoding="utf-8").replace("`0.4.0`", f"`{version}`"),
+                     encoding="utf-8")
 
 
 def request_json(**overrides) -> str:
@@ -60,7 +80,7 @@ class RequestContract(unittest.TestCase):
             parse_request(request_json(action="edit-metadata"))
 
 
-class WrapperFixture(unittest.TestCase):
+class WrapperBase(unittest.TestCase):
     """tags-ok state fixture (record + baseline tags), constants patched."""
 
     def setUp(self) -> None:
@@ -90,7 +110,7 @@ class WrapperFixture(unittest.TestCase):
         self.latest: str | None = None
         self.commands: list[list[str]] = []
 
-    def fetch(self):
+    def fetch(self, deadline=None):
         return list(self.store), self.latest
 
     def execute_and_apply(self, cmd: list[str]) -> None:
@@ -121,6 +141,8 @@ class WrapperFixture(unittest.TestCase):
                            now=int(_git(self.repo, "log", "-1", "--format=%ct").strip()) + 10,
                            execute=self.execute_and_apply, **kwargs)
 
+
+class WrapperFixture(WrapperBase):
     # -- W2 allowed matrix ----------------------------------------------
     def test_publish_missing_baseline_release_in_tags_ok(self) -> None:
         result = self.invoke(request_json())
@@ -274,6 +296,210 @@ class WrapperFixture(unittest.TestCase):
         self.assertFalse(result.executed)
         self.assertIsNone(result.error)
         self.assertEqual(self.commands, [])
+
+
+class WrapperPostRead(WrapperBase):
+    """W5b — bounded re-read of a self-contradictory post-mutation read.
+
+    A read issued right after a publish can come back without the release that
+    was just created. That single case is retried; everything else keeps the
+    original red, because a wrong observation is not a slow one.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Promoted steady state needs both baselines released AND at least one
+        # earlier successor, so Step 6B compares published_at (CV-LATEST-STEADY)
+        # instead of taking the initial-promotion branch.
+        for i, ref in enumerate(FIX_TAGS):
+            self.store.append(make_release(ref.removeprefix("refs/tags/"),
+                                           f"2026-07-28T00:0{i}:00Z"))
+        _bump_beta(self.repo, "0.5.0")
+        prior_sha = commit_all(self.repo, "release beta-skill 0.5.0")
+        _git(self.repo, "tag", "beta-skill/v0.5.0", prior_sha)
+        self.store.append(make_release("beta-skill/v0.5.0", "2026-07-28T02:00:00Z"))
+        self.latest = "beta-skill/v0.5.0"
+
+        self.succ = "alpha-skill/v1.3.0"
+        _bump_alpha(self.repo, "1.3.0")
+        succ_sha = commit_all(self.repo, "release alpha-skill 1.3.0")
+        _git(self.repo, "tag", self.succ, succ_sha)
+
+        self.slept: list[float] = []
+        self.clock = 0.0
+        self.post_reads = 0
+        self.last_deadline = None
+
+    def _stale_store(self) -> list[dict]:
+        """What the API returns while the new release is not visible yet."""
+        return [r for r in self.store if r["tag_name"] != self.succ]
+
+    def _sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.clock += seconds
+
+    def _monotonic(self) -> float:
+        return self.clock
+
+    def _succ_release(self, published: str = "2026-07-28T04:00:00Z") -> dict:
+        return make_release(self.succ, published)
+
+    def _invoke_succ(self, fetch, **kwargs):
+        """Publish the successor tag; `fetch` drives the post-mutation reads."""
+        return run_wrapper(
+            self.repo, parse_request(request_json(tag=self.succ,
+                                                  title="alpha-skill 1.3.0")),
+            fetch,
+            now=int(_git(self.repo, "log", "-1", "--format=%ct").strip()) + 10,
+            execute=self.execute_and_apply, sleep=self._sleep,
+            monotonic=self._monotonic, **kwargs)
+
+    def _reader(self, post):
+        """Wrap a post-mutation reader; pre-mutation reads stay truthful.
+
+        `post(n)` receives the 1-based post-read index and returns
+        (releases, latest); the pre-mutation read always sees the real store.
+        """
+        def fetch(deadline=None):
+            if self.latest != self.succ:      # still before the publish
+                return list(self.store), self.latest
+            self.post_reads += 1
+            self.last_deadline = deadline
+            return post(self.post_reads)
+        return fetch
+
+    # 1 — a fresh first read never enters the re-read path.
+    def test_fresh_read_does_not_retry(self) -> None:
+        result = self._invoke_succ(
+            self._reader(lambda n: (list(self.store), self.latest)))
+        self.assertIsNone(result.error, result.error)
+        self.assertEqual(result.post_verdict.verdict, "complete")
+        self.assertEqual(self.slept, [])
+        self.assertEqual(result.post_read_notes, [])
+
+    # 2 — stale first read, then the release appears: green, reason resolved.
+    def test_stale_then_visible_resolves(self) -> None:
+        seen = {}
+
+        def post(n):
+            if n == 1:
+                stale = self._stale_store()
+                seen["tag_absent"] = self.succ not in [r["tag_name"] for r in stale]
+                seen["latest"] = self.latest
+                return stale, self.latest
+            return list(self.store), self.latest
+
+        result = self._invoke_succ(self._reader(post))
+        # The first observation really did contradict itself.
+        self.assertTrue(seen["tag_absent"])
+        self.assertEqual(seen["latest"], self.succ)
+        self.assertIsNone(result.error, result.error)
+        self.assertEqual(result.post_verdict.verdict, "complete")
+        notes = " ".join(result.post_read_notes)
+        self.assertIn("stale observation", notes)
+        self.assertIn("re-read 1/3", notes)
+        self.assertIn("-> resolved", notes)
+        self.assertEqual(self.slept, [1.0])
+
+    # 3 — a real misplacement is in the list and must never be retried.
+    def test_real_latest_misplacement_stays_red(self) -> None:
+        def post(n):
+            # Everything visible, but Latest names an older, present release.
+            return list(self.store), FIX_TAGS[0].removeprefix("refs/tags/")
+
+        result = self._invoke_succ(self._reader(post))
+        self.assertIn("postcondition failed", result.error)
+        self.assertEqual(self.slept, [])
+        self.assertEqual(result.post_read_notes, [])
+
+    # 4 — Latest never becomes the requested tag: postcondition, no retry.
+    def test_release_missing_stays_red(self) -> None:
+        def post(n):
+            return self._stale_store(), "beta-skill/v0.5.0"
+
+        result = self._invoke_succ(self._reader(post))
+        self.assertIn("postcondition failed", result.error)
+        self.assertEqual(self.slept, [])
+
+    # 5 — an observation failure is not staleness, and it is not a timeout
+    #     either: it keeps the first red under its own end reason.
+    def test_observation_failure_stays_red(self) -> None:
+        def post(n):
+            if n == 1:
+                return self._stale_store(), self.latest
+            raise TransportError("gh exploded")
+
+        result = self._invoke_succ(self._reader(post))
+        self.assertIn("post-mutation verdict is red", result.error)
+        self.assertEqual(result.post_verdict.code, "CV-LATEST-STEADY")
+        notes = " ".join(result.post_read_notes)
+        self.assertIn("gh exploded", notes)
+        self.assertIn("-> observation-failed", notes)
+        self.assertNotIn("total-cap", notes)
+
+    # 6 — still stale after every retry: original red, reason retry-exhausted.
+    def test_retry_exhausted_keeps_first_verdict(self) -> None:
+        def post(n):
+            return self._stale_store(), self.latest
+
+        result = self._invoke_succ(self._reader(post))
+        self.assertIn("post-mutation verdict is red", result.error)
+        self.assertEqual(result.post_verdict.code, "CV-LATEST-STEADY")
+        notes = " ".join(result.post_read_notes)
+        self.assertIn("re-read 3/3", notes)
+        self.assertIn("-> retry-exhausted", notes)
+        self.assertEqual(self.slept, [1.0, 2.0, 4.0])
+
+    # 7a/7b — the tag IS listed but its published_at is unusable: CV-DOMAIN,
+    # and the predicate must not read that as "not visible yet".
+    def _published_at_case(self, value) -> None:
+        def post(n):
+            bad = self._succ_release()
+            bad["published_at"] = value
+            return self._stale_store() + [bad], self.succ
+
+        result = self._invoke_succ(self._reader(post))
+        self.assertIn("post-mutation verdict is red", result.error)
+        self.assertEqual(result.post_verdict.code, "CV-DOMAIN")
+        self.assertEqual(self.slept, [])
+        self.assertEqual(result.post_read_notes, [])
+
+    def test_published_at_null_stays_red_without_retry(self) -> None:
+        self._published_at_case(None)
+
+    def test_published_at_empty_stays_red_without_retry(self) -> None:
+        self._published_at_case("")
+
+    # 8 — the wall clock runs out before the retry budget does.
+    def test_total_cap_stops_before_retries_exhaust(self) -> None:
+        def post(n):
+            if n > 1:
+                self.clock += 5.0     # each re-read costs real time
+            return self._stale_store(), self.latest
+
+        result = self._invoke_succ(self._reader(post))
+        self.assertIn("post-mutation verdict is red", result.error)
+        self.assertEqual(result.post_verdict.code, "CV-LATEST-STEADY")
+        notes = " ".join(result.post_read_notes)
+        self.assertIn("re-read 2/3", notes)
+        self.assertIn("-> total-cap", notes)
+        # Two backoffs fit; the third would cross the cap, so it never happens.
+        self.assertEqual(self.slept, [1.0, 2.0])
+
+    # 9 — the deadline reaches the transport, and a fetch that trips it ends
+    #     the loop instead of being retried.
+    def test_fetch_deadline_exceeded_ends_with_total_cap(self) -> None:
+        def post(n):
+            if n == 1:
+                return self._stale_store(), self.latest
+            raise TransportError("deadline exceeded before request")
+
+        result = self._invoke_succ(self._reader(post))
+        self.assertIn("post-mutation verdict is red", result.error)
+        self.assertEqual(result.post_verdict.code, "CV-LATEST-STEADY")
+        self.assertIn("-> total-cap", " ".join(result.post_read_notes))
+        # The transport was actually handed a deadline to enforce.
+        self.assertIsNotNone(self.last_deadline)
 
 
 if __name__ == "__main__":

--- a/tools/skillstead_validate/__main__.py
+++ b/tools/skillstead_validate/__main__.py
@@ -64,8 +64,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"request rejected (fail-closed): {e}", file=sys.stderr)
             return 1
 
-        def fetch():
-            return fetch_releases(args.repo_slug), fetch_latest(args.repo_slug)
+        def fetch(deadline=None):
+            return (fetch_releases(args.repo_slug, deadline=deadline),
+                    fetch_latest(args.repo_slug, deadline=deadline))
         try:
             result = run_wrapper(args.repo_root.resolve(), request, fetch,
                                  main_ref=args.main_ref, repo_slug=args.repo_slug,

--- a/tools/skillstead_validate/transport.py
+++ b/tools/skillstead_validate/transport.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import time
 
 PER_PAGE = 100
 
@@ -18,23 +19,48 @@ class TransportError(RuntimeError):
     pass
 
 
-def _default_runner(args: list[str]) -> str:
+def _call(runner, args: list[str], deadline: float | None, monotonic) -> str:
+    """Run one request, bounded by whatever is left of ``deadline``.
+
+    A deadline that has already passed is not "almost out of time" — it is out
+    of time, so the request is never started (fail-closed). When no deadline is
+    set the runner keeps its original one-argument shape.
+    """
+    if deadline is None:
+        return runner(args)
+    left = deadline - monotonic()
+    if left <= 0:
+        raise TransportError("deadline exceeded before request")
+    return runner(args, timeout=left)
+
+
+def _default_runner(args: list[str], timeout: float | None = None) -> str:
     try:
-        proc = subprocess.run(args, capture_output=True, text=True, check=True)
+        proc = subprocess.run(args, capture_output=True, text=True, check=True,
+                              timeout=timeout)
     except FileNotFoundError as e:
         raise TransportError("gh executable not found") from e
+    except subprocess.TimeoutExpired as e:
+        raise TransportError(f"{' '.join(args)}: timed out after {timeout}s") from e
     except subprocess.CalledProcessError as e:
         raise TransportError(f"{' '.join(args)}: {e.stderr.strip()}") from e
     return proc.stdout
 
 
-def fetch_releases(repo_slug: str, runner=_default_runner) -> list[dict]:
-    """All release objects, every page walked to exhaustion."""
+def fetch_releases(repo_slug: str, runner=_default_runner,
+                   deadline: float | None = None, monotonic=time.monotonic) -> list[dict]:
+    """All release objects, every page walked to exhaustion.
+
+    ``deadline`` is a ``monotonic()`` instant. It is re-checked before *every*
+    page: a per-request timeout alone would not bound this loop, because the
+    total cost is one timeout per page rather than one per call.
+    """
     releases: list[dict] = []
     page = 1
     while True:
-        out = runner(["gh", "api",
-                      f"repos/{repo_slug}/releases?per_page={PER_PAGE}&page={page}"])
+        out = _call(runner, ["gh", "api",
+                             f"repos/{repo_slug}/releases?per_page={PER_PAGE}&page={page}"],
+                    deadline, monotonic)
         try:
             batch = json.loads(out)
         except json.JSONDecodeError as e:
@@ -47,11 +73,13 @@ def fetch_releases(repo_slug: str, runner=_default_runner) -> list[dict]:
         page += 1
 
 
-def fetch_latest(repo_slug: str, runner=_default_runner) -> str | None:
+def fetch_latest(repo_slug: str, runner=_default_runner,
+                 deadline: float | None = None, monotonic=time.monotonic) -> str | None:
     """``tag_name`` of the repository Latest release, or None when there is
     no release at all (GitHub answers 404)."""
     try:
-        out = runner(["gh", "api", f"repos/{repo_slug}/releases/latest"])
+        out = _call(runner, ["gh", "api", f"repos/{repo_slug}/releases/latest"],
+                    deadline, monotonic)
     except TransportError as e:
         if "404" in str(e) or "Not Found" in str(e):
             return None

--- a/tools/skillstead_validate/wrapper.py
+++ b/tools/skillstead_validate/wrapper.py
@@ -21,16 +21,25 @@ import json
 import os
 import re
 import subprocess
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from . import record_schema
 from .cutover import P3_MARKER, Verdict, _release_p123, run_cutover
 from .gitio import GitError, git
 from .tag_check import run_tag_checks
+from .transport import TransportError
 
 ACTIONS = ("create-draft", "publish", "edit-metadata")
 RECOVERY_MODES = ("none", "premature-accept-forward", "metadata-correction")
+
+# W5b bounded re-read. GitHub can answer a read issued right after a publish
+# from a replica that has not caught up yet; these bound how long the wrapper
+# is willing to wait for that to settle before it reports the original red.
+POST_READ_MAX_RETRIES = 3
+POST_READ_BACKOFF_SECONDS = (1.0, 2.0, 4.0)
+POST_READ_TOTAL_CAP_SECONDS = 10.0
 _NAMESPACED_TAG = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+)\.(\d+)\.(\d+)$")
 
 
@@ -95,10 +104,89 @@ class WrapperResult:
     commands: list[list[str]]
     post_verdict: Verdict | None = None
     error: str | None = None
+    post_read_notes: list[str] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
         return self.error is None and self.executed
+
+
+def _stale_observation(req: ReleaseOperationRequest, releases_raw, latest_tag,
+                       verdict: Verdict) -> bool:
+    """True only for an observation that contradicts itself.
+
+    ``Latest`` names the tag we just published, yet that tag is absent from the
+    release list — a list cannot omit the release Latest points at, so the list
+    is simply not visible yet. A *real* misplacement looks different: Latest is
+    present in the list but is not the newest, and that must stay red.
+
+    The scan reads raw, pre-normalization data, so anything unreadable makes
+    this predicate False (no re-read) rather than optimistic.
+    """
+    if req.action != "publish" or latest_tag != req.tag:
+        return False
+    if verdict.verdict != "red" or verdict.code != "CV-LATEST-STEADY":
+        return False
+    if not isinstance(releases_raw, list):
+        return False
+    for r in releases_raw:
+        if not isinstance(r, dict) or not isinstance(r.get("tag_name"), str):
+            return False
+        if r["tag_name"] == req.tag:
+            return False
+    return True
+
+
+def _reread(result: WrapperResult, req: ReleaseOperationRequest, repo: Path,
+            main_ref: str, fetch, now, sleep, monotonic):
+    """Re-observe a stale post-mutation read, bounded three ways.
+
+    Retries stop at POST_READ_MAX_RETRIES, at POST_READ_TOTAL_CAP_SECONDS of
+    wall clock (the deadline is handed to the transport so a single in-flight
+    request cannot outlive it either), or as soon as the observation stops
+    contradicting itself. Any other red never reaches here.
+    """
+    first = result.post_verdict
+    started = monotonic()
+    deadline = started + POST_READ_TOTAL_CAP_SECONDS
+    releases_raw, latest_tag = None, None
+    attempt = 0
+    reason = "retry-exhausted"
+
+    result.post_read_notes.append(
+        "stale observation (Latest == requested tag, tag absent from release list)")
+
+    for attempt in range(1, POST_READ_MAX_RETRIES + 1):
+        backoff = POST_READ_BACKOFF_SECONDS[attempt - 1]
+        if monotonic() + backoff >= deadline:
+            attempt -= 1
+            reason = "total-cap"
+            break
+        sleep(backoff)
+        if monotonic() >= deadline:
+            attempt -= 1
+            reason = "total-cap"
+            break
+        try:
+            releases_raw, latest_tag = fetch(deadline=deadline)
+        except TransportError as e:
+            reason = "total-cap" if "deadline" in str(e) or "timed out" in str(e) else "observation-failed"
+            result.post_read_notes.append(f"re-read {attempt} failed: {e}")
+            break
+        verdict = run_cutover(repo, main_ref, releases_raw, latest_tag, now=now)
+        if not _stale_observation(req, releases_raw, latest_tag, verdict):
+            result.post_verdict = verdict
+            reason = "resolved"
+            break
+
+    elapsed = monotonic() - started
+    result.post_read_notes.append(
+        f"re-read {attempt}/{POST_READ_MAX_RETRIES}, elapsed {elapsed:.1f}s -> {reason}")
+    if reason == "resolved":
+        result.post_read_notes.append(f"first observation: {first}")
+        return releases_raw, latest_tag
+    result.post_verdict = first
+    return (releases_raw, latest_tag) if latest_tag is not None else (None, req.tag)
 
 
 def _missing_baseline_tags(releases_raw: list[dict]) -> set[str]:
@@ -214,6 +302,8 @@ def _default_execute(args: list[str]) -> None:
 
 def _emit_summary(result: WrapperResult) -> None:
     lines = [f"wrapper pre-verdict: {result.pre_verdict}"]
+    for note in result.post_read_notes:
+        lines.append(f"wrapper post-read: {note}")
     if result.post_verdict is not None:
         lines.append(f"wrapper post-verdict: {result.post_verdict}")
     if result.error:
@@ -229,11 +319,14 @@ def _emit_summary(result: WrapperResult) -> None:
 def run_wrapper(repo: Path, req: ReleaseOperationRequest, fetch,
                 main_ref: str = "main", now: int | None = None,
                 execute=_default_execute, repo_slug: str | None = None,
-                dry_run: bool = False) -> WrapperResult:
+                dry_run: bool = False, sleep=time.sleep,
+                monotonic=time.monotonic) -> WrapperResult:
     """``fetch() -> (releases_raw, latest_tag)`` supplies the Release
     observation before and after the mutation (transport in live use,
     injected in tests). ``execute(argv)`` performs the permitted gh call.
-    ``dry_run`` stops after the allowed-matrix and pre-publish checks."""
+    ``dry_run`` stops after the allowed-matrix and pre-publish checks.
+    ``sleep``/``monotonic`` are injected so the bounded re-read below is
+    exercised without real waiting."""
     releases_raw, latest_tag = fetch()
     pre = run_cutover(repo, main_ref, releases_raw, latest_tag, now=now)
     result = WrapperResult(pre_verdict=pre, executed=False, commands=[])
@@ -299,6 +392,12 @@ def run_wrapper(repo: Path, req: ReleaseOperationRequest, fetch,
     # W5 — post-mutation evaluator + exact postcondition on publish.
     post_releases, post_latest = fetch()
     result.post_verdict = run_cutover(repo, main_ref, post_releases, post_latest, now=now)
+
+    # W5b — bounded re-read for a self-contradictory observation only.
+    if _stale_observation(req, post_releases, post_latest, result.post_verdict):
+        post_releases, post_latest = _reread(
+            result, req, repo, main_ref, fetch, now, sleep, monotonic)
+
     if req.action == "publish" and post_latest != req.tag:
         result.error = f"postcondition failed: Latest is {post_latest!r}, expected {req.tag!r}"
     elif result.post_verdict.verdict == "red":


### PR DESCRIPTION
## 배경

M5 release wrapper가 **성공한 발행을 실패로 보고**했다. 발행 직후 release 목록을 한 번 읽어 `argmax(published_at)`을 계산하는데, 방금 만든 release가 아직 그 목록에 없으면 `CV-LATEST-STEADY` red가 난다. 실제 발행 두 건에서 모두 재현됐고, tag·Release·`Latest`의 실제 상태는 정상이었다.

이 red는 드문 예외가 아니라 성공 경로의 기본 동작이었다. 발행할 때마다 사람이 실제 상태를 확인해 green임을 판정해야 했다.

## 무엇을 고쳤나

재시도 대상을 **스스로 모순되는 관측 하나**로 좁혔다.

> `Latest`가 요청한 tag를 가리키는데, 그 tag가 release 목록에 없다

목록이 `Latest`가 가리키는 release를 빠뜨릴 수는 없으므로, 이건 목록이 아직 보이지 않는 것뿐이다. **진짜 오배치는 모양이 다르다** — `Latest`가 목록에 존재하되 가장 최신이 아니다. 그래서 이 술어에 걸리지 않는다.

red를 그대로 유지하는 경우:

| 상황 | 이유 |
| --- | --- |
| 실제 `Latest` 오배치 | 목록에 존재하되 argmax가 아님 — 관측이 틀린 것이지 안 보이는 게 아니다 |
| Release 누락 | postcondition 단계에서 이미 실패 |
| `CV-DOMAIN` (`published_at`이 null·빈 문자열) | 정규화할 수 없는 관측은 "아직 안 보인다"가 아니라 "불완전하다" |
| transport 실패 | fail-closed |

## 재시도 경계

3회, `1s / 2s / 4s` backoff, **10초 wall-clock 상한**. 이 상한은 deadline으로 transport까지 전달되어 **페이지 단위 release 호출의 매 페이지 직전에 다시 검사**된다. 요청당 timeout만으로는 페이지 하나만 제한할 뿐 paging 루프 전체를 제한하지 못하기 때문이다.

종료 이유를 네 값으로 보고한다: `resolved` · `retry-exhausted` · `total-cap` · `observation-failed`. 마지막 둘을 나눈 것은 의도적이다 — transport 오류를 timeout으로 보고하면 실행이 관측하지 않은 사실을 말하게 된다.

`resolved`가 아닌 모든 경로는 최초 red를 그대로 반환한다.

## 검증

- `python3 -m unittest discover -s tests` — **169 tests, OK** (기존 157 + 신규 12)
- `PYTHONPATH=tools python3 -m skillstead_validate repo` — **0 findings**
- `PYTHONPATH=tools python3 -m skillstead_validate tags` — **0 findings**
- `python3 tools/run_skills_ref.py` — **4 packages, 0 failures**
- `git diff --check` clean

신규 fixture 12종은 정상 발행(재시도 0회), stale→해소, 실제 오배치·Release 누락·`CV-DOMAIN`(`null`/`""` 각각)·transport 실패의 red 유지, 재시도 소진, cap 중단(`[1.0, 2.0]` 정확 고정), deadline이 paging을 중단시키는 transport 경로를 각각 고정한다. 각 fixture는 재관측 횟수와 종료 이유를 함께 검증한다.

실제 release 데이터(22건, 실제 `Latest`)로 원래 red를 재현한 뒤 1회 재관측에 `complete — steady state`가 되는 것도 확인했다. mutation 없이 판정 경로만 구동했다.

## 범위 밖

cutover 직후 **첫** 통상 release에서는 successor가 없어 같은 stale 관측이 `CV-LATEST-INITIAL`로 나타난다. 이 확장은 의도적으로 포함하지 않았고 별도로 추적한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)