### PR TITLE
fix: 첫 통상 release의 stale read도 재관측하고 plan ref를 앞단에서 검증한다

### DIFF
--- a/docs/INSTALL.ko.md
+++ b/docs/INSTALL.ko.md
@@ -37,9 +37,9 @@ cp -R /tmp/skillstead/skills/github-release-guide .claude/skills/
 
 아래에서 runtime·scope·운영체제별 전체 명령을 확인할 수 있습니다.
 
-git 대신 파일을 내려받고 싶을 수 있지만 skill별 zip 파일은 아직 제공하지 않습니다. 현재 release
-검사는 zip 파일의 identity와 checksum을 검증하지 않으므로, 검토된 pinned tag를 clone하는 방법을
-재현 가능한 설치 경로로 유지합니다.
+파일을 내려받아 설치하는 방식은 아직 지원하지 않습니다. skill별 zip 파일을 제공하지 않기 때문입니다.
+현재 release 검사는 zip 파일이 해당 skill과 tag에 맞는 파일인지, 또 checksum이 맞는지 확인하지
+못하므로, 지금은 검증된 tag를 지정해 `git clone`하는 방법으로 설치해 주세요.
 
 `svg-infographic`을 복사하거나 discovery해도 Node.js가 설치되지 않으며, 필요하지도 않습니다. Node.js 18+는
 자동화된 source lint와 bundled render workflow에만 필요합니다. Node.js가 없으면 skill이 감지한 package

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -41,8 +41,13 @@ admin bypass가 있으므로 이 경계는 hard guarantee가 아니라 disciplin
 상태입니다. 목록이 `Latest`가 가리키는 release를 빠뜨릴 수는 없으므로, 목록이 아직 보이지 않는
 것뿐입니다.
 
+이 판정은 promotion verdict 두 가지를 모두 덮습니다. stale 목록이 둘 중 무엇을 내는지는 successor
+release가 하나라도 보이는지에만 달려 있으므로, cutover 이후 **첫** 통상 release는 같은 staleness를
+`CV-LATEST-STEADY`가 아니라 `CV-LATEST-INITIAL`로 보고합니다. baseline Release가 아직 덜 보이는
+목록은 두 검사에 닿기 전에 판정되므로, cutover 진행 중에는 이 재시도가 적용되지 않습니다.
+
 그 밖의 경우는 red를 그대로 유지합니다. **실제 Latest 오배치**는 모양이 다릅니다 — `Latest`가 목록에
-존재하되 가장 최신이 아닙니다. Release 누락, 정규화할 수 없는 release 객체(`CV-DOMAIN` — 발행된
+존재하되 기대한 tag가 아닙니다. Release 누락, 정규화할 수 없는 release 객체(`CV-DOMAIN` — 발행된
 release의 `published_at`이 null이거나 빈 문자열인 경우 포함), transport 실패도 마찬가지입니다.
 
 재시도는 세 가지로 제한됩니다: 최대 **3회** 재관측, **1초 / 2초 / 4초** backoff, 첫 stale 읽기부터

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -47,10 +47,17 @@ observation that contradicts itself: `Latest` names the requested tag, yet
 that tag is absent from the release list. A list cannot omit the release
 `Latest` points at, so the list is simply not visible yet.
 
+This covers both promotion verdicts. Which one a stale list produces depends
+only on whether any successor release is visible, so the very first ordinary
+release after the cutover reports the same staleness as `CV-LATEST-INITIAL`
+rather than `CV-LATEST-STEADY`. A list that is still missing baseline Releases
+never reaches either check — it is judged earlier — so the retry does not apply
+during a cutover.
+
 Everything else keeps its red. A *real* misplacement looks different — `Latest`
-is present in the list but is not the newest — and so do a missing Release, an
-unnormalizable release object (`CV-DOMAIN`, including a published release whose
-`published_at` is null or empty), and any transport failure.
+is present in the list but is not the expected one — and so do a missing
+Release, an unnormalizable release object (`CV-DOMAIN`, including a published
+release whose `published_at` is null or empty), and any transport failure.
 
 The retry is bounded three ways: at most **3** re-reads, backing off
 **1s / 2s / 4s**, inside a **10s** wall-clock cap measured from the first stale

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -761,6 +761,31 @@ class PlanParsingFailClosed(unittest.TestCase):
         with self.assertRaises(PlanError):
             parse_plan(plan_json("HEAD", entries))
 
+    # proposed_ref is checked here rather than left to the gate, so a plan that
+    # names the tag loosely is refused with the expected form in the message.
+    def _reject_ref(self, ref: str) -> str:
+        bad = entry("alpha-skill", None, "0.1.0")
+        bad["proposed_ref"] = ref
+        with self.assertRaises(PlanError) as caught:
+            parse_plan(plan_json("HEAD", [bad]))
+        return str(caught.exception)
+
+    def test_short_tag_name_rejected(self) -> None:
+        message = self._reject_ref("alpha-skill/v0.1.0")
+        self.assertIn("refs/tags/alpha-skill/v0.1.0", message)
+        self.assertIn("refs/tags/<skill>/v<proposed_version>", message)
+
+    def test_ref_naming_another_skill_rejected(self) -> None:
+        self._reject_ref("refs/tags/beta-skill/v0.1.0")
+
+    def test_ref_disagreeing_with_version_rejected(self) -> None:
+        self._reject_ref("refs/tags/alpha-skill/v0.2.0")
+
+    def test_well_formed_ref_accepted(self) -> None:
+        plan = parse_plan(plan_json("HEAD", [entry("alpha-skill", None, "0.1.0")]))
+        self.assertEqual(plan.releases[0].proposed_ref,
+                         "refs/tags/alpha-skill/v0.1.0")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -502,5 +502,96 @@ class WrapperPostRead(WrapperBase):
         self.assertIsNotNone(self.last_deadline)
 
 
+class WrapperPostReadInitial(WrapperBase):
+    """W5b in the initial-promotion branch.
+
+    Before any successor release exists, Step 6B judges promotion instead of
+    comparing timestamps, so the same stale list reports CV-LATEST-INITIAL.
+    The recovery predicate is unchanged; only the verdict code differs.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.slept: list[float] = []
+        self.clock = 0.0
+        self.post_reads = 0
+
+    def _sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.clock += seconds
+
+    def _monotonic(self) -> float:
+        return self.clock
+
+    def _invoke(self, tag: str, title: str, fetch):
+        return run_wrapper(
+            self.repo, parse_request(request_json(tag=tag, title=title)), fetch,
+            now=int(_git(self.repo, "log", "-1", "--format=%ct").strip()) + 10,
+            execute=self.execute_and_apply, sleep=self._sleep,
+            monotonic=self._monotonic)
+
+    def _reader(self, post):
+        def fetch(deadline=None):
+            if self.latest != self.pending:
+                return list(self.store), self.latest
+            self.post_reads += 1
+            return post(self.post_reads)
+        return fetch
+
+    # B1 — the first ordinary release after the cutover, read too early.
+    def test_first_successor_stale_read_resolves(self) -> None:
+        for i, ref in enumerate(FIX_TAGS):          # every baseline published
+            self.store.append(make_release(ref.removeprefix("refs/tags/"),
+                                           f"2026-07-28T00:0{i}:00Z"))
+        self.latest = FIX_TAGS[-1].removeprefix("refs/tags/")   # == LATEST_REF
+        succ = "alpha-skill/v1.3.0"
+        _bump_alpha(self.repo, "1.3.0")
+        _git(self.repo, "tag", succ, commit_all(self.repo, "release alpha 1.3.0"))
+        self.pending = succ
+        seen = {}
+
+        def post(n):
+            if n == 1:
+                stale = [r for r in self.store if r["tag_name"] != succ]
+                seen["code_input"] = [r["tag_name"] for r in stale]
+                return stale, self.latest
+            return list(self.store), self.latest
+
+        result = self._invoke(succ, "alpha-skill 1.3.0", self._reader(post))
+        # The stale list held no successor at all, which is why the first
+        # verdict took the initial-promotion branch.
+        self.assertNotIn(succ, seen["code_input"])
+        notes = " ".join(result.post_read_notes)
+        self.assertIn("CV-LATEST-INITIAL", notes)      # first observation
+        self.assertIn("-> resolved", notes)
+        self.assertIsNone(result.error, result.error)
+        self.assertEqual(result.post_verdict.verdict, "complete")
+        self.assertEqual(self.slept, [1.0])
+
+    # B2 — a genuine misplacement in the same branch: Latest lands on a
+    #      baseline tag that is not the declared Latest ref. The tag IS listed,
+    #      so the predicate declines and the red stands.
+    def test_initial_promotion_misplacement_stays_red(self) -> None:
+        wrong = FIX_TAGS[0].removeprefix("refs/tags/")   # not LATEST_REF
+        self.store.append(make_release(FIX_TAGS[-1].removeprefix("refs/tags/"),
+                                       "2026-07-28T00:00:00Z"))
+        self.latest = FIX_TAGS[-1].removeprefix("refs/tags/")
+        self.pending = wrong
+        listed = {}
+
+        def post(n):
+            listed["tags"] = [r["tag_name"] for r in self.store]
+            return list(self.store), self.latest
+
+        result = self._invoke(wrong, "alpha-skill 1.2.3", self._reader(post))
+        # Publishing the last missing baseline left Latest on the wrong tag.
+        self.assertEqual(result.post_verdict.code, "CV-LATEST-INITIAL")
+        self.assertEqual(self.latest, wrong)
+        self.assertIn(wrong, listed["tags"])            # present, so not stale
+        self.assertIn("post-mutation verdict is red", result.error)
+        self.assertEqual(self.slept, [])                # never retried
+        self.assertEqual(result.post_read_notes, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/skillstead_validate/release_plan.py
+++ b/tools/skillstead_validate/release_plan.py
@@ -73,6 +73,12 @@ def parse_plan(text: str) -> ReleasePlan:
         for key in ("proposed_version", "proposed_ref"):
             if not isinstance(item[key], str) or not item[key]:
                 raise PlanError(f"{key} must be a non-empty string")
+        expected_ref = f"refs/tags/{item['skill']}/v{item['proposed_version']}"
+        if item["proposed_ref"] != expected_ref:
+            raise PlanError(
+                f"proposed_ref must be the fully-qualified tag ref {expected_ref!r}, "
+                f"got {item['proposed_ref']!r} — write the ref exactly as "
+                f"refs/tags/<skill>/v<proposed_version>")
         if item["skill"] in seen:
             raise PlanError(f"duplicate release entry for skill {item['skill']!r}")
         seen.add(item["skill"])

--- a/tools/skillstead_validate/wrapper.py
+++ b/tools/skillstead_validate/wrapper.py
@@ -40,6 +40,9 @@ RECOVERY_MODES = ("none", "premature-accept-forward", "metadata-correction")
 POST_READ_MAX_RETRIES = 3
 POST_READ_BACKOFF_SECONDS = (1.0, 2.0, 4.0)
 POST_READ_TOTAL_CAP_SECONDS = 10.0
+# Promotion verdicts a stale list can produce. Which one appears depends only
+# on whether any successor release is visible, so both are in scope.
+_STALE_CODES = ("CV-LATEST-STEADY", "CV-LATEST-INITIAL")
 _NAMESPACED_TAG = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+)\.(\d+)\.(\d+)$")
 
 
@@ -118,14 +121,19 @@ def _stale_observation(req: ReleaseOperationRequest, releases_raw, latest_tag,
     ``Latest`` names the tag we just published, yet that tag is absent from the
     release list — a list cannot omit the release Latest points at, so the list
     is simply not visible yet. A *real* misplacement looks different: Latest is
-    present in the list but is not the newest, and that must stay red.
+    present in the list but is not the expected one, and that must stay red.
+
+    Both promotion codes are covered. Once the release just published drops out
+    of a stale list, the successor set can look empty, so the very first
+    ordinary release after the cutover reports the same staleness as
+    ``CV-LATEST-INITIAL`` rather than ``CV-LATEST-STEADY``.
 
     The scan reads raw, pre-normalization data, so anything unreadable makes
     this predicate False (no re-read) rather than optimistic.
     """
     if req.action != "publish" or latest_tag != req.tag:
         return False
-    if verdict.verdict != "red" or verdict.code != "CV-LATEST-STEADY":
+    if verdict.verdict != "red" or verdict.code not in _STALE_CODES:
         return False
     if not isinstance(releases_raw, list):
         return False


### PR DESCRIPTION
## 배경

발행 직후 재관측이 `CV-LATEST-STEADY`만 회복 대상으로 삼고 있었다. 그런데 **stale 목록에서는 방금 만든 release가 빠져 successor가 하나도 없어 보이므로**, cutover 이후 **첫** 통상 release는 같은 staleness를 `CV-LATEST-INITIAL`로 보고한다. 어느 code가 나오는지는 successor가 보이는지에만 달려 있다.

이 저장소는 이미 steady state라 노출이 없지만, 이 검증 도구를 새로 적용하는 저장소는 첫 release에서 바로 이 경로를 만난다.

## 변경 내용

**재관측 범위** — 두 promotion code를 모두 회복 대상에 넣었다. **술어의 내부 불일치 조건은 그대로다** (`Latest`가 요청 tag를 가리키는데 그 tag가 목록에 없음).

red를 유지하는 경계도 그대로다.

| 상황 | 결과 |
| --- | --- |
| 실제 오배치 (`Latest`가 목록에 존재하되 기대값 아님) | **red 유지**, 재시도 0회 |
| baseline Release가 덜 보이는 목록 (cutover 진행 중) | 두 검사 이전에 `tags-ok`·`CV-PREMATURE`로 판정 — 확장 미적용 |
| `CV-DOMAIN` · Release 누락 · transport 실패 | **red 유지** |

**plan parser** — `proposed_ref`가 `refs/tags/<skill>/v<version>`인지 parse 단계에서 확인한다. 지금까지는 gate가 두 값을 비교해 보여줄 뿐이라 무엇을 어떻게 고쳐야 하는지 드러나지 않았다. 오류 메시지에 기대 ref와 작성 형식을 함께 담았다.

**설치 문서(한국어)** — zip 안내가 기술 설명부터 시작해 읽기 어려웠다. 결론("아직 지원하지 않습니다")이 먼저 오도록 순서를 바꾸고, 영어 문서의 identity 결속 주장("해당 skill과 tag에 맞는 파일인지")을 함께 보존했다.

## 검증

- `python3 -m unittest discover -s tests` — **175 tests, OK** (기존 169 + 신규 6)
- `PYTHONPATH=tools python3 -m skillstead_validate repo` / `tags` — 각 **0 findings**
- `python3 tools/run_skills_ref.py` — **4 packages, 0 failures**
- `git diff --check` clean

신규 fixture는 초기 승격 분기에서 두 경우를 갈라 고정한다 — 첫 successor의 stale read는 재관측으로 해소되고, **마지막 missing baseline을 발행한 뒤 `Latest`가 선언된 ref가 아닌 다른(목록에 존재하는) baseline tag를 가리키는** 실제 오배치는 재시도 없이 red로 남는다. parser는 짧은 tag 이름·다른 skill·version 불일치를 각각 거부한다.

## 범위 밖

per-skill Release zip asset은 이번에 도입하지 않는다. 별도 판정에서 defer로 결론냈다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)