### PR TITLE
test: reads better 요구를 집행하는 negative fixture를 추가한다

### DIFF
--- a/examples/writing-quality-editor/fixtures/expected-outcomes.md
+++ b/examples/writing-quality-editor/fixtures/expected-outcomes.md
@@ -92,6 +92,58 @@ and what conditions or risks remain. Compare those answers against the required 
 cannot answer means the writing did not improve, and an answer missing a required proposition means something was
 lost.
 
+## Enforcing "Reads Better" (F27)
+
+F22 to F26 test that an intended change happened. F27 tests the other direction: it supplies three frozen
+candidates that all keep the meaning, and asks whether the procedure still fails the ones that are worse to
+read. Judge them, do not rewrite them.
+
+### Expected verdicts
+
+| Candidate | Verdict | Why |
+| --- | --- | --- |
+| 1 | fail | Ritual framing repeated on nearly every sentence flattens instruction and background into the same weight |
+| 2 | fail | Nominalised frames absorb the clause structure, so the one instruction becomes a definition rather than a command |
+| 3 | pass | Condition, action, and reason arrive in the order the reader needs them, and no sentence is empty |
+
+Ranking, once each candidate has its own verdict: 3, then 1, then 2.
+
+### How to judge
+
+Judge each candidate **on its own** first. Only after every candidate has an independent pass or fail may
+you rank them. All three can pass; all three can fail.
+
+1. **Quote the places that force a re-read**, and say what each one costs the reader. "Hard to follow" with
+   no quotation is not a finding.
+2. **Name the kind of document it reads as.** A migration note that reads as meeting minutes or as an
+   internal architecture memo has failed its profile even when every fact survives.
+3. **Record a pass or a fail per candidate**, with the evidence above, before any comparison.
+
+### Diagnostics, not gates
+
+Two more observations help explain a verdict but never decide one.
+
+- **How many empty frames there are.** Counting is useful for showing a reader what went wrong. It is not a
+  threshold: two judges counted the same candidate at 12 and at 16 and still reached the same verdict and
+  the same ranking. Do not set a passing number, and do not rank by count.
+- **Whether a frame can be lifted off.** A repeated prefix can be deleted and leave a working sentence
+  behind; a nominalised frame that owns the predicate has to be rewritten. This explains why candidate 2
+  ranks below candidate 1 even though both fail, and why the count alone would order them the other way.
+
+### What is out of scope here
+
+Candidate 2 implies a layered structure the source does not support, which could lead a reader to mistake it
+for the product's real architecture. That is a profile failure, not a meaning failure: no candidate states a
+component, interface, or behaviour the source does not state, and the concrete sentences that follow still
+describe the same resampler behaviour.
+
+### Locale boundary
+
+Repetition counts, English nominalisation, and detachable prefixes are surface signals of **this English
+fixture**. In another locale, do not look for the same expressions. Judge empty framing and unnecessary
+abstraction that blur the requested document profile, and their effect on the reader, against the grammar
+and conventions of that language. Counts and thresholds are never shared across locales.
+
 ## Coverage
 
 | Dimension | Fixtures |
@@ -123,3 +175,4 @@ lost.
 | Error message | F06 |
 | Gallery copy | F11 |
 | Brief/technical comparison | F19, F20 |
+| Reads-better enforcement (frozen candidates) | F27 |

--- a/examples/writing-quality-editor/fixtures/scenarios.md
+++ b/examples/writing-quality-editor/fixtures/scenarios.md
@@ -388,3 +388,106 @@ Confirm the new key id appears in `keyring.json` and that the build pipeline pic
 ceremony with the release owner. Take a backup of `keyring.json` before running it. On a host where the release
 owner has not enrolled, the command fails partway and leaves `keyring.json` in a mixed state.
 ```
+
+## F27 — Reads-Better Enforcement (Frozen Candidates)
+
+Unlike F01 to F26, this fixture does not ask for a revision. It supplies three **frozen candidate
+revisions** of one source and tests whether the judging procedure enforces the `reads better` requirement in
+`expected-outcomes.md`.
+
+All three candidates preserve the source's meaning. The question is whether the procedure still fails the
+ones that are worse to read.
+
+- Mode: `Revise` (judging only — do not produce a fourth revision)
+- Profile: Release/migration note
+- Audience: users of an image-processing library upgrading from 2.4 or earlier to 2.5
+- Request that produced the candidates: `tighten this and make it easier to follow`
+
+### Source
+
+```text
+Through version 2.4 we stripped the embedded colour profile whenever an image was resized, and the reason
+was that the resampler worked in a fixed sRGB space, so a profile that no longer described the pixels ended
+up generating more support tickets than it ever solved, which was a reasonable trade for photographs but a
+poor one for scanned artwork, where the profile is often the only surviving record of what the scanner
+actually saw, and losing it silently turned a colour-managed file into a guess.
+
+From version 2.5 the resampler converts into the working space instead of assuming it, which means the
+profile can survive the round trip, and so resizing preserves the profile by default now. If you were
+relying on the old behaviour to normalise mixed uploads, the thing to do is set `strip_profile=True` on the
+resize call rather than post-processing the output afterwards, because a second conversion introduces
+rounding that the first conversion has already paid for.
+
+There is still one case where the profile gets dropped, which is images whose profile fails validation —
+those are converted to sRGB and flagged instead of being passed through unvalidated, because the maintainers
+decided that a wrong profile is worse than no profile at all.
+```
+
+### Candidate 1
+
+```text
+This note documents our handling of embedded colour profiles. Through version 2.4 we stripped the embedded
+colour profile whenever an image was resized. It is relevant to note that the resampler worked in a fixed
+sRGB space, and that a profile which no longer described the pixels generated more support tickets than it
+ever solved; this was the reason for the behaviour. It is also relevant to note that this was a reasonable
+trade for photographs and a poor one for scanned artwork, where the profile is often the only surviving
+record of what the scanner actually saw, and where losing it silently turned a colour-managed file into a
+guess.
+
+This note further documents the change introduced at version 2.5. It is relevant to note that from version
+2.5 the resampler converts into the working space instead of assuming it, and that this means the profile
+can survive the round trip. It is also relevant to note that resizing preserves the profile by default now.
+If you were relying on the old behaviour to normalise mixed uploads, it is relevant to note that you should
+set `strip_profile=True` on the resize call rather than post-processing the output afterwards, since a
+second conversion introduces rounding that the first conversion has already paid for.
+
+This note additionally documents a remaining exception. It is relevant to note that there is still one case
+where the profile gets dropped, which is images whose profile fails validation. It is also relevant to note
+that those are converted to sRGB and flagged instead of being passed through unvalidated, because the
+maintainers decided that a wrong profile is worse than no profile at all.
+```
+
+### Candidate 2
+
+```text
+Through version 2.4 our colour-management posture involved a removal step: we stripped the embedded colour
+profile whenever an image was resized. The rationale for that posture was a property of the processing
+layer — the resampler worked in a fixed sRGB space — with the downstream consequence that a profile which no
+longer described the pixels generated more support tickets than it ever solved. From a content-category
+perspective this represented a reasonable trade for photographs and a poor one for scanned artwork, a
+category in which the profile is often the only surviving record of what the scanner actually saw, such that
+losing it silently turned a colour-managed file into a guess.
+
+From version 2.5 the processing layer adopts a different approach: the resampler converts into the working
+space instead of assuming it. The implication at the pipeline level is that the profile can survive the
+round trip, and the resulting position is that resizing preserves the profile by default now. In terms of
+the migration path, if you were relying on the old behaviour to normalise mixed uploads, the appropriate
+configuration action is to set `strip_profile=True` on the resize call rather than post-processing the
+output afterwards, the underlying consideration being that a second conversion introduces rounding that the
+first conversion has already paid for.
+
+At the exception level there is still one case where the profile gets dropped, namely images whose profile
+fails validation. The handling applied in that scenario is that those are converted to sRGB and flagged
+instead of being passed through unvalidated, reflecting a decision on the part of the maintainers that a
+wrong profile is worse than no profile at all.
+```
+
+### Candidate 3
+
+```text
+Through version 2.4 we stripped the embedded colour profile whenever an image was resized. The resampler
+worked in a fixed sRGB space, and a profile that no longer described the pixels generated more support
+tickets than it ever solved — that was the reason. For photographs it was a reasonable trade. For scanned
+artwork it was a poor one: there the profile is often the only surviving record of what the scanner actually
+saw, and losing it silently turned a colour-managed file into a guess.
+
+From version 2.5 the resampler converts into the working space instead of assuming it, which means the
+profile can survive the round trip. So resizing preserves the profile by default now. If you were relying on
+the old behaviour to normalise mixed uploads, set `strip_profile=True` on the resize call rather than
+post-processing the output afterwards — a second conversion introduces rounding that the first conversion
+has already paid for.
+
+There is still one case where the profile gets dropped: images whose profile fails validation. Those are
+converted to sRGB and flagged instead of being passed through unvalidated, because the maintainers decided
+that a wrong profile is worse than no profile at all.
+```


### PR DESCRIPTION
## 배경

`expected-outcomes.md`의 `reads better` 요구는 **문장으로만 있고 그것을 실패시키는 고정 사례가 없었다.** F22~F26은 의도한 변화가 일어났는지 보지만, **의미를 다 지키고도 읽기 나빠진 결과**를 실패시키는 판정은 없었다.

## 변경

`F27 — Reads-Better Enforcement (Frozen Candidates)`를 추가한다. F01~F26과 달리 수정을 요청하지 않고, 한 원문의 **고정 후보 3건을 주고 판정만** 시킨다.

셋 다 의미를 보존하며, 그중 둘은 각각 **반복 구조**와 **불필요한 추상화**로 저하됐다.

| 후보 | 기대 판정 |
| --- | --- |
| 1 | fail — 거의 모든 문장에 반복되는 의례적 framing이 지시와 배경을 같은 무게로 평탄화 |
| 2 | fail — 명사화 frame이 절 구조를 흡수해 유일한 지시가 명령이 아닌 정의문이 됨 |
| 3 | pass — 조건·행동·근거가 독자가 필요한 순서로 오고 빈 문장이 없음 |

## 판정 축과 진단 자료의 분리

**판정 축 3종** — 재독 지점 인용 + reader cost 설명 / 문서 종류 판별 / 상대 비교 전 절대 판정.

**진단 자료 2종(게이트 아님)** — 빈 뼈대 개수, 뼈대의 분리 가능성.

개수를 게이트에서 뺀 근거는 실측이다. **두 평가자가 같은 후보를 12개와 16개로 세고도 판정과 순위가 같았다.** 개수에 합격선을 두거나 개수로 순위를 매기지 않는다.

## locale 경계

반복 횟수·영어식 명사화·분리 가능한 접두사는 **이 영어 fixture의 표면 신호**다. 다른 locale에서 같은 표현을 찾지 않으며, **횟수나 임계값을 locale 간에 공유하지 않는다.**

## 검증

- `skillstead_validate repo` — 0 finding
- `unittest discover -s tests` — Ran 175 tests, OK
- `run_skills_ref.py` — 4 package, 0 failure
- `git diff --check` — clean

## Release 영향

**`skills/**` 변경 0건**이므로 `docs/VERSIONING.md`에 따라 **version bump와 release가 없다.** `writing-quality-editor 0.10.0`은 무변경이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)