### PR TITLE
docs: 시나리오 수 표기를 현재 fixture와 맞춘다

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -118,7 +118,7 @@ V1은 두 시점에 사용할 수 있습니다. 비공개 github.com 저장소�
 숨기지는 않습니다. AI 탐지기 회피와 작성 주체·출처 은폐는 명시적으로 하지 않습니다.
 
 - 자세한 안내: [`writing-quality-editor` 한국어 README](./skills/writing-quality-editor/README.ko.md)
-- 검증 자료: [검증 시나리오 21개와 별도 정답표](./examples/writing-quality-editor/README.ko.md)
+- 검증 자료: [검증 시나리오 27개와 별도 정답표](./examples/writing-quality-editor/README.ko.md)
 - 스킬 이름을 쓰는 예시: `writing-quality-editor를 사용해 아래 문서를 자연스럽게 다듬어 줘. 원문의 핵심 사실, 조건과 요구 사항은 그대로 유지해 줘.`
 - 줄임말을 쓰는 예시: `WQE로 이 온보딩 안내서를 검토해 줘. 문제를 찾되 아직 문장은 수정하지 마.`
 - 자연스럽게 요청하는 예시: `이 README를 검토해 줘. 아직 문장은 수정하지 마.` · `아래 자료에서 확인할 수 있는 내용만 바탕으로 새 README를 작성해 줘.` · `이 영어 릴리스 노트를 한국어 독자가 자연스럽게 읽을 수 있도록 다시 써 줘. 의미와 조건은 바꾸지 마.`

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ sentence structure. It may change information order, sentence rhythm, idioms, an
 does not invent claims or hide ambiguity. AI-detector gaming and provenance concealment are explicit non-goals.
 
 - Friendly guide: [`writing-quality-editor` README](./skills/writing-quality-editor/README.md)
-- Validation material: [21 scenarios and a separate answer key](./examples/writing-quality-editor)
+- Validation material: [27 scenarios and a separate answer key](./examples/writing-quality-editor)
 - Name the skill: `Use writing-quality-editor to make the document below read naturally. Preserve its core facts, conditions, and requirements.`
 - Use the shorthand: `Use WQE to review this onboarding guide. Identify problems, but do not revise it yet.`
 - Or ask naturally: `Review this README. Do not revise the prose yet.` · `Write a new README using only information supported by the material below.` · `Rewrite this English release note so it reads naturally to Korean readers. Preserve its meaning and conditions.`

--- a/examples/writing-quality-editor/README.ko.md
+++ b/examples/writing-quality-editor/README.ko.md
@@ -7,7 +7,7 @@
 
 | 경로 | 용도 |
 | --- | --- |
-| `fixtures/scenarios.md` | Compose, Assess, Revise, Adapt를 다루는 요청과 원문 자료 21개 |
+| `fixtures/scenarios.md` | Compose, Assess, Revise, Adapt를 다루는 요청과 원문 자료 27개 |
 | `fixtures/expected-outcomes.md` | 정답표와 의미 보존 점검표. 평가 대상 에이전트에게는 제공하지 않음 |
 | `fixtures/validation-evidence.md` | 정적 검사, 새 대화에서의 실행 기록, 중단 기준과 공개 문구의 근거 범위 |
 | `release-claim-audit-v0.7.0-prepublish-20260718.md` | 릴리스 필수 공개 문구 13건의 사전 평가와, 공개 후까지 남는 고정 태그 검증 항목 |

--- a/examples/writing-quality-editor/README.md
+++ b/examples/writing-quality-editor/README.md
@@ -8,7 +8,7 @@ is invented for this fixture set.
 
 | Path | Purpose |
 | --- | --- |
-| `fixtures/scenarios.md` | Twenty-one prompts and source materials covering Compose, Assess, Revise, and Adapt |
+| `fixtures/scenarios.md` | Twenty-seven prompts and source materials covering Compose, Assess, Revise, and Adapt |
 | `fixtures/expected-outcomes.md` | Answer key and invariant checklist; keep away from agents under evaluation |
 | `fixtures/validation-evidence.md` | Static gate, fresh-context execution ledger, stop rule, and claim boundary |
 | `release-claim-audit-v0.7.0-prepublish-20260718.md` | Pre-release assessment of thirteen release-critical public claims and the one pinned-tag item that remains open until publication |

--- a/examples/writing-quality-editor/fixtures/validation-evidence.md
+++ b/examples/writing-quality-editor/fixtures/validation-evidence.md
@@ -9,7 +9,7 @@ post-release claim closeout passed.
 | Check | Result |
 | --- | --- |
 | Official skill validator | Pass: `Skill is valid!` |
-| Scenario and answer-key parity | Pass: 21 scenarios / 21 answer-key rows |
+| Scenario and answer-key parity | Pass: 27 scenarios / 27 answer-key rows |
 | Intent-inference coverage | Pass: F01 unnamed ambiguous review, F02 named skill without mode, F12 unnamed revision |
 | KO→EN coverage | Pass: F04, F13, F14 |
 | Premature `validated` claim and stale 12-count scan | Pass: 0 matches |


### PR DESCRIPTION
## 배경

fixture가 `F01`~`F27`로 늘었는데, **현재 내용을 서술하는** 다섯 곳이 `21`에 머물러 있었다.

## 변경 — 5파일 5줄

| 위치 | before → after |
| --- | --- |
| `README.md` | `21 scenarios` → `27` |
| `README.ko.md` | `검증 시나리오 21개` → `27개` |
| `examples/writing-quality-editor/README.md` | `Twenty-one prompts` → `Twenty-seven` |
| `examples/writing-quality-editor/README.ko.md` | `원문 자료 21개` → `27개` |
| `.../fixtures/validation-evidence.md` | `21 scenarios / 21 answer-key rows` → `27 / 27` |

마지막 항목은 `Static Contract Gate`의 **현재 결과**다(같은 파일이 이 gate를 `package consistency` 검사로 규정). 기계 대조를 재현해 갱신했다.

```bash
grep -oE '^## F[0-9]+ —' examples/writing-quality-editor/fixtures/scenarios.md \
  | grep -oE 'F[0-9]+' | sort -u | wc -l          # 27
grep -oE '\| F[0-9]+ \|' examples/writing-quality-editor/fixtures/expected-outcomes.md \
  | grep -oE 'F[0-9]+' | sort -u | wc -l          # 27
# 차집합 0건 — 누락·초과 없음
```

## 의도적으로 손대지 않은 곳

`docs/INSTALL.md`·`INSTALL.ko.md`의 `21-scenario ... pinned v0.7.0 ... passed`, `CHANGELOG.md`, release audit 2건.

**이것들은 현재 개수가 아니라 `v0.7.0`에서 무엇이 통과했는지의 기록이다.** 원문이 `within that recorded evidence scope`로 범위를 명시하므로 거짓이 아니며, `27`로 바꾸면 **수행한 적 없는 검증을 주장하게 된다.**

markdown 전체의 literal `21`을 전수 재검색한 결과 나머지는 scenario ID(`F21`)·이미지 치수·SVG viewBox였다.

## 검증

- `skillstead_validate repo` — 0 finding
- `unittest discover -s tests` — Ran 175 tests, OK
- `run_skills_ref.py` — 4 package, 0 failure
- `git diff --check` — clean

## Release 영향

**`skills/**` 변경 0건**이므로 `docs/VERSIONING.md`에 따라 **version bump와 release가 없다.**

## 후속

`Supported` 증거가 legacy tag 시점(`v0.5.0`·`v0.7.0`)에 머물러 현재 per-skill 버전까지 이어지는지는 이 PR이 다루지 않는다. 별도 항목이 소유한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)