### PR TITLE
feat(svg-infographic): add layout geometry guards

### DIFF
--- a/skills/svg-infographic/CHANGELOG.md
+++ b/skills/svg-infographic/CHANGELOG.md
@@ -11,6 +11,13 @@ automated checks read the topmost released heading to confirm it matches `metada
 `SKILL.md`. The full grammar is documented at
 [`docs/VERSIONING.md`](https://github.com/kyungseo/skillstead/blob/main/docs/VERSIONING.md).
 
+## [Unreleased]
+
+- Added opt-in source layout contracts for panel title/subtitle/divider budgets and icon-text card center alignment,
+  with deterministic error/warning fixtures for provable and unsupported geometry.
+- Added a one-line/two-line page-title contract that derives the left accent rail from the eyebrow and final title
+  line, rejecting copied fixed heights and subtitle-clearance intrusion before rendering.
+
 ## [0.8.3] — 2026-07-30
 
 - Added a first-use path with an example request, adjustable defaults, and a direct link to the catalog-wide

--- a/skills/svg-infographic/SKILL.md
+++ b/skills/svg-infographic/SKILL.md
@@ -83,14 +83,14 @@ Pick from the content signal, then **read that archetype's section in `reference
 **This step is the main defense against render-fix loops. Do the arithmetic first; never place a box at an eyeballed coordinate.** Produce a short numeric plan (a scratch table of coordinates is enough), then author the SVG from those numbers.
 
 1. **Canvas.** Pick a preset: **compact doc** 680w · **wide architecture** 1400×900 · **16:9 slide** 1600×900 · **social portrait** 1080×1350 (4:5). Height is flexible for the doc width. Fix outer margins (≥ 40px wide canvases, ≥ 24px at 680w).
-2. **Regions.** Split the canvas top→bottom: header (title + subtitle), one band per section, optional footer row. Assign each region a `y` range and keep 32–48px between bands.
+2. **Regions.** Split the canvas top→bottom: header (title + subtitle), one band per section, optional footer row. Assign each region a `y` range and keep 32–48px between bands. For a page title with a left accent rail, compute `eyebrowTop`, the final `titleBottom`, then `railY = eyebrowTop − railTopPad` and `railH = titleBottom + railBottomPad − railY`; a two-line title must therefore produce a taller rail than a one-line title. Keep the subtitle below `railBottom + subtitleGap`. For every panel header, compute `headerH = top padding + title line box + title/subtitle gap + subtitle line box + bottom padding`; place the divider only after that budget. Do not squeeze the title area until the copy happens to fit.
 3. **Grid arithmetic.** For each row of n cards inside a region: choose `cardW` and `gap` (gutter 24–32px), then **verify the last edge before drawing**: `start + (n−1)·(cardW+gap) + cardW ≤ region_right − padding`. Same check vertically for columns/stacks. If it doesn't fit: shrink `cardW`/`gap`, wrap to a second row, or widen the canvas — decide *now*, not after a render.
 4. **Text budget.** For each box, set lines × chars/line from the box width: ~28–36 Latin chars per line at body size, **Korean ≈ 60% of that**; 2–3 lines max per box. **Edit the copy to fit the budget before writing SVG** — abbreviate long tokens now. SVG has no auto-wrap; every line you plan here becomes one `<tspan>`.
 5. **Type scale — unified across the diagram** (never vary per box):
    - 1080-wide social: H1 46 / section 24 / card title 25 / body 19 / caption 16
    - 1400–1600 wide: H1 40–44 / section 22 / card title 20–22 / body 16–17 / caption 13–14
    - 680-wide docs: title 22 / box label 14 / caption 11
-6. **Icons.** Derive every icon-circle center from card geometry (e.g. `cy = card_y + card_h/2`), never a hand-tuned per-language offset. EN and KO variants must share the **same formulas**.
+6. **Icons and copy clusters.** Derive every icon-circle center from card geometry (e.g. `cy = card_y + card_h/2`). Compute the text cluster's visual bounds from its planned line boxes and center that cluster on the **same** `card_y + card_h/2`; never hand-tune either side per language. EN and KO variants must share the same formulas.
 7. **Connector corridors.** Budget connectors like cards: `corridor = target_visual_left − source_visual_right`, and subtract the marker's real footprint (`markerUnits="strokeWidth"` multiplies it by the stroke width — formulas in `authoring.md` §3). If no readable shaft survives, choose a compact arrow, a transition glyph, or a reflow *now*, not after a render.
 
 ## 3. Author the SVG — core rules
@@ -114,7 +114,8 @@ Read `references/authoring.md` for the detailed rules and the reusable icon set.
 
 - **Boxes:** rounded rect `rx="8"` (wide bands `rx="12–22"`), hairline border `stroke-width:1`. Each box = tinted fill + same-family border + same-family text (one semantic color family per box).
 - **Vertical centering:** center text with `dominant-baseline="central"` and `y` at the box's vertical center. Two lines straddle the center: title at `center−11`, sub at `center+10`, both `central`. Never rely on the default alphabetic baseline for box labels — it sits high.
-- **Wrapping:** one planned line = one `<tspan x=.. dy=..>`; keep to the §2 text budget.
+- **Layout contracts for repeated structures:** annotate page-title headers, panel headers, and icon-text cards with the opt-in `data-layout-role` contract from `authoring.md` §1/§4/§7. The page-title contract derives the rail from the eyebrow and final title line; a card contract names its actual background rect `card-frame`, so frame, icon, and complete text cluster derive from one center. The source lint then rejects short/floating title rails, divider collisions, and mismatched centers before rendering. Keep unsupported transforms or unusual typography outside this annotation and verify them manually.
+- **Wrapping:** one planned line = one `<tspan x=.. dy=..>`; keep to the §2 text budget. Inside an opt-in layout contract, use plain numeric `y`/`dy` and non-nested `<tspan>` lines so the lint can accumulate the complete vertical line box.
 - **Arrows:** define one `<marker>` arrowhead, use `marker-end`. Solid = sync/request, dashed (`stroke-dasharray="5 4"`) = async/batch/private. The default head is an **open-V stroked marker sized by visible geometry: `visible ≈ markerWidth × 8/12`, aim visible ≈3× the shaft → `markerWidth ≈ 4.5 × shaft`** (sizing table in `authoring.md` §3) — filled triangles only as a deliberate choice with the same visible-extent arithmetic. `markerUnits="userSpaceOnUse"` is **mandatory** on every referenced marker and the lint gate enforces it — the default `markerUnits="strokeWidth"` multiplies the head by the stroke width. Set `refX` so the tip lands on the path endpoint; leave an 8–12px gap between tip and target box **and** keep a visible shaft behind the head; pick each connector's form (standard / compact / curved / transition glyph / reflow) from the corridor budget, and prefer the gentle single-bend curve recipe when boxes sit at different heights (`authoring.md` §3).
 - **On-accent text is light:** any label on a saturated fill uses `class="on-accent"` (white/near-white) — never dark text on a mid/dark accent, and never rely on a blanket `text{fill}` rule to sort it out.
 - **Emphasis toolkit:** stroke + soft shadow + a number/status badge + a corner label + a filled icon badge. **No top accent bar on cards** (corner-smear and badge-collision failure modes — details and narrow exception in `authoring.md`).
@@ -123,7 +124,7 @@ Read `references/authoring.md` for the detailed rules and the reusable icon set.
 ## 4. Pre-render checklist (source-level — run before every render)
 
 **Run the lint gate first for a verified handoff** — it machine-checks the deterministic subset of this list
-(ids/references, root viewBox, marker units and footprint, high-confidence Latin/CJK text overflow) with file/line,
+(ids/references, root viewBox, marker units and footprint, opt-in header/card layout geometry, high-confidence Latin/CJK text overflow) with file/line,
 measured values, and a suggested fix per finding. If Node 18+ is unavailable, follow the §0 approval/fallback
 branch; the manual fallback does not count as a machine-linted handoff.
 

--- a/skills/svg-infographic/references/archetypes.md
+++ b/skills/svg-infographic/references/archetypes.md
@@ -8,7 +8,7 @@ Every archetype uses the same section schema: **Choose when** (content signal) �
 
 This is the default visual language — the gallery look. Apply it unless the user asks for something plainer:
 
-- **Page header:** short vertical accent bar (4–6px wide, primary color) at the left of the H1; conclusion-style title; one-line muted subtitle. Header region ≈ 120–150px tall on wide canvases.
+- **Page header:** vertical accent rail (4–6px wide, primary color) at the left of the eyebrow + H1 stack; conclusion-style title; one-line muted subtitle. Compute the rail from the actual one-line/two-line title stack rather than reusing a fixed height (`authoring.md` §1). Header region ≈ 120–150px tall on wide canvases and grows when the title wraps.
 - **Band containers:** each major section sits in a light-tinted rounded panel (`rx 14–22`, very light fill such as `#F4F8FC`, hairline border). Bands stack top→bottom with 32–48px gaps.
 - **Pill section headers:** each band opens with a filled pill (rounded rect, saturated section color, `class="on-accent"` label, optional ①②③ numbering) at the band's top-left, overlapping or just inside the band's top edge.
 - **White cards:** content cards are white (`#FFFFFF`) on the tinted band, hairline border in the card's semantic color, subtle shadow (`<filter>` soft drop shadow, low opacity). Icon circle left, title + 1–2 body lines right — or icon-top for narrow cards.
@@ -167,7 +167,7 @@ Two **equal-height, equal-width** panels with a 32–48px gutter; optional cente
 
 **Recipe:** icon-first white cards; a number badge only if the cards form a sequence; KPI numerals in the card's family ink at ~2× card-title size; keep one card emphasized at most.
 
-**Checks:** grid arithmetic both directions (last-edge formula for columns *and* rows); all cards identical size; text budget per card respected (headline ≤ 2 lines, body ≤ 2 lines); icons vertically centered by formula, not nudged.
+**Checks:** grid arithmetic both directions (last-edge formula for columns *and* rows); all cards identical size; text budget per card respected (headline ≤ 2 lines, body ≤ 2 lines); icon and full text cluster share one computed vertical center, not separate nudges; repeated cards use the opt-in `icon-text-card` source contract from `authoring.md` §7.
 
 ## Decision / risk matrix
 

--- a/skills/svg-infographic/references/authoring.md
+++ b/skills/svg-infographic/references/authoring.md
@@ -5,6 +5,25 @@ Detailed geometry, connector, panel, emphasis, color, and icon rules, plus the m
 ## 1. Geometry & containment
 
 - **Containment is arithmetic, not eyeballing.** Every child (card, icon, arrow, badge, label) sits inside its container/panel bounds **plus inner padding**, unless it is a deliberate outside-the-frame callout. For a row of repeated cards, compute the last card's far edge as `start + (n−1)·(cardW+gap) + cardW` and confirm it is `≤ container_edge − padding`; same for a column's bottom edge. If a row won't fit, shrink `cardW`/`gap`, wrap to a second row, or widen the canvas.
+- **Page-title accent rail follows the title stack.** Never copy a fixed rail height from a one-line title into a two-line title. With centered-baseline text, compute `eyebrowTop = eyebrowY − eyebrowFontSize/2`, `titleBottom = max(titleLineY + titleFontSize/2)`, `railY = eyebrowTop − railTopPad`, and `railH = titleBottom + railBottomPad − railY`. Keep `subtitleTop − railBottom ≥ subtitleGap`. For the premium one-line/two-line header, opt into the source check:
+
+```xml
+<g data-layout-role="page-title-header" data-layout-rail-padding-top="16"
+   data-layout-rail-padding-bottom="0" data-layout-subtitle-gap="12"
+   data-layout-tolerance="2">
+  <rect data-layout-role="title-rail" x="60" y="58" width="6" height="143" rx="3"/>
+  <text data-layout-role="title-eyebrow" x="88" y="82" font-size="16"
+    dominant-baseline="middle">SKILL · EXAMPLE</text>
+  <text data-layout-role="title-line" x="88" y="127" font-size="46"
+    dominant-baseline="middle">첫 번째 제목 줄</text>
+  <text data-layout-role="title-line" x="88" y="178" font-size="46"
+    dominant-baseline="middle">두 번째 제목 줄</text>
+  <text data-layout-role="title-subtitle" x="88" y="230" font-size="18"
+    dominant-baseline="middle">한 줄 설명</text>
+</g>
+```
+
+The contract accepts one or two **measurable visual title lines**, counted across `title-line` elements and their non-nested `<tspan>` lines. It requires plain numeric rail padding/gap, a positive-width rect rail, centered-baseline measurable text, and translate-only transforms. Optional `data-layout-tolerance` defaults to 2px and accepts 0–8px; an unsupported, negative, or larger value emits `W-LAYOUT` and falls back to 2px for the actual comparison. Unsupported units or typography become `W-LAYOUT`; a rail whose top/bottom does not match the stack or that enters the subtitle clearance becomes `E-LAYOUT`. The same source-coordinate limitation described in §4 applies, so verify the final rail and rendered glyphs in the 2× PNG.
 - **Containment is judged on visual bounds, not the fill rect.** A child's visual edge = its rect/path edge **plus** half its stroke width, the drop-shadow spread (conservative margin: `abs(offset) + ~3 × stdDeviation`), and anything drawn outside the base rect (badge, corner label, marker/arrowhead). Pass condition on every side: `child_visual_edge ≤ parent_edge − inner_padding`. In a padded panel, a child that merely *touches* the parent edge is a containment failure even though the coordinates read "inside" — and a generous shadow *filter region* says nothing about containment. Keep left/right inner padding balanced, and fix an overflow by recomputing card width, gutters, or position inside the current region before reaching for a wider canvas.
 - **Paired / side-by-side boxes:** always leave a **visible gutter of 24–32px**; never let two boxes touch. Balance the left/right outer margins.
 - **Generous margins; align to a grid; consistent gutters.** Pick the margin and gutter values once in the layout pass and reuse them everywhere.
@@ -52,6 +71,20 @@ Detailed geometry, connector, panel, emphasis, color, and icon rules, plus the m
 ## 4. Panels & header bands
 
 - **Header band on a rounded panel:** use a **top-only rounded** header — a `<path>` with rounded top corners and a square bottom edge (`M x+r,y H x+w-r A r r 0 0 1 x+w,y+r V y+h H x V y+r A r r 0 0 1 x+r,y Z`), or a header rect clipped to the panel. **Never stack a fully-rounded rect plus a square "cover" rect** — it smears the lower corners in the PNG.
+- **Budget title, subtitle, and divider as one vertical unit.** Compute `headerH = padTop + titleH + gap + subtitleH + padBottom`; the divider begins after `subtitleBottom + padBottom`, never through the subtitle's line box. For repeated panel headers, opt into the source check with plain numeric values and centered-baseline text:
+
+```xml
+<g data-layout-role="panel-header" data-layout-top="0" data-layout-bottom="132"
+   data-layout-gap="16" data-layout-padding-top="20" data-layout-padding-bottom="24">
+  <text data-layout-role="header-title" y="38" font-size="32" dominant-baseline="middle">…</text>
+  <text data-layout-role="header-subtitle" y="82" font-size="20" dominant-baseline="middle">…</text>
+  <line data-layout-role="header-divider" x1="0" y1="120" x2="936" y2="120"/>
+</g>
+```
+
+The contract accepts `translate()` but not rotate/scale/skew. It accumulates non-nested `<tspan>` lines with plain numeric `y`/`dy`; nested spans, relative units, and unsupported baselines become `W-LAYOUT`, not a silent pass. Divider bounds include half its stroke width. Keep `data-layout-bottom` close to the divider—more than the documented small slack produces a warning so downstream bands do not inherit accidental empty space. A reviewed exception may use `data-lint-allow="layout-geometry"`; record why the PNG check is sufficient.
+
+The line box is a **source-coordinate model**, not rendered ink measurement. `middle` and `central`, font fallback, and mixed CJK/Latin glyphs can look optically different even when their source boxes align. Final typography alignment remains part of the 2× PNG pass.
 - **Band containers** (premium base): light tinted fill, hairline border, `rx 14–22`; white content cards on top with a subtle `<filter>` drop shadow at low opacity. Keep shadows soft — a heavy shadow reads as clutter at 2×.
 
 ## 5. Emphasis & corner decorations
@@ -75,7 +108,21 @@ Detailed geometry, connector, panel, emphasis, color, and icon rules, plus the m
 Icon-first is the default: a simple **line icon inside a soft tinted circle** per card or node.
 
 - **Icon vs number:** a **number badge only when sequence or cross-reference matters** (numbered steps). When the icon alone identifies the item, use the icon only — never icon + redundant number.
-- **Placement:** icon circle `r≈34–38` with a light tint fill (`#E3EEF8`), the icon centered inside at ~40px via `<use>`. Derive the circle center from card geometry (`cy = card_y + card_h/2`) — never a hand-tuned per-language offset; EN and KO variants share the same formula.
+- **Placement:** icon circle `r≈34–38` with a light tint fill (`#E3EEF8`), the icon centered inside at ~40px via `<use>`. Derive both the circle center and the complete text cluster from card geometry (`centerY = card_y + card_h/2`) — never a hand-tuned per-language offset; EN and KO variants share the same formula. For repeated icon-text cards, annotate the card group with `data-layout-role="icon-text-card" data-layout-center-y="118"`; mark its actual background rect `card-frame`, the circle `icon-center`, and centered-baseline text lines `card-title` / `card-body`. The lint checks frame, icon, and the accumulated text cluster against the same target. The card-specific `data-layout-center-tolerance` defaults to 2px; keep explicit values in the reviewed 0–8px range. For backward compatibility, a larger value emits `W-LAYOUT` but remains the supplied comparison tolerance, unlike the page-title contract's 2px fallback. Treat that warning as unverified geometry requiring correction or explicit 2× PNG disposition, never as alignment proof.
+
+```xml
+<g data-layout-role="icon-text-card" data-layout-center-y="118">
+  <rect data-layout-role="card-frame" width="444" height="236" rx="24"/>
+  <circle data-layout-role="icon-center" cx="72" cy="118" r="28"/>
+  <text data-layout-role="card-title" y="94" font-size="24" dominant-baseline="middle">…</text>
+  <text data-layout-role="card-body" y="122" font-size="16" dominant-baseline="middle">
+    <tspan x="124" dy="0">…</tspan><tspan x="124" dy="24">…</tspan>
+  </text>
+</g>
+```
+
+The source-coordinate model limitation described in §4 also applies to card-center checks; confirm rendered ink and optical centering in the final 2× PNG.
+
 - **Recolor:** author each symbol with `stroke="currentColor"`; set the color per instance with `style="color:#…"` on the `<use>`.
 - **Style options to offer:** default = soft circular background + thin line icon. Alternatives: no background (line icon only), filled/solid icon, or mono. Stroke width ~1.7–1.9.
 

--- a/skills/svg-infographic/scripts/check-svg.mjs
+++ b/skills/svg-infographic/scripts/check-svg.mjs
@@ -10,6 +10,7 @@
 //   E-BOUNDS    shape obviously outside the root viewBox
 //   E-MARKER    referenced <marker> without explicit markerUnits="userSpaceOnUse"
 //   E-HEADSIZE  effective arrowhead footprint far beyond the connector contract
+//   E-LAYOUT    opt-in page-title, panel-header, and icon/text-cluster geometry violations
 //   E-TEXT      high-confidence Latin/CJK text overflow past its containing box
 //   W-*         ambiguous cases (transforms, unresolved styles, near-threshold
 //               overflow, large-but-plausible heads) — reported, never fatal
@@ -28,7 +29,8 @@
 //
 // Opt-outs for deliberate design exceptions (use sparingly, with a reason in
 // the surrounding commit/PR): data-lint-allow="text-overflow" on the text or
-// its container, data-lint-allow="marker-footprint" on the marker.
+// its container, data-lint-allow="marker-footprint" on the marker, or
+// data-lint-allow="layout-geometry" on an explicitly annotated layout group.
 
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
@@ -181,6 +183,27 @@ function declsFor(el, rules) {
   }
   Object.assign(merged, parseInlineStyle(el.attrs.style));
   return merged;
+}
+
+// Resolve non-inherited geometry on the element itself. Unlike declsFor(),
+// this must not merge root `svg` rules into descendants: width/y/height do not
+// inherit. Presentation attributes are the fallback; local CSS wins.
+function localGeometryProp(el, name, rules) {
+  const merged = Object.create(null);
+  const classes = (el.attrs.class ?? "").split(/\s+/).filter(Boolean);
+  for (const r of rules) if (r.selector === el.tag) Object.assign(merged, r.decls);
+  for (const r of rules) {
+    const m = r.selector.match(/^([A-Za-z]*)\.([\w-]+)$/);
+    if (m && classes.includes(m[2]) && (m[1] === "" || m[1] === el.tag)) Object.assign(merged, r.decls);
+  }
+  if (el.attrs.id) {
+    for (const r of rules) {
+      const m = r.selector.match(/^([A-Za-z]*)#([\w:.-]+)$/);
+      if (m && m[2] === el.attrs.id && (m[1] === "" || m[1] === el.tag)) Object.assign(merged, r.decls);
+    }
+  }
+  Object.assign(merged, parseInlineStyle(el.attrs.style));
+  return merged[name] ?? el.attrs[name];
 }
 
 function px(value) {
@@ -532,6 +555,245 @@ export function lintSvg(source, filename = "input.svg") {
       if (r.uncertain) continue;
       if (r.x < vb.x - SLACK || r.y < vb.y - SLACK || r.x + r.w > vb.x + vb.w + SLACK || r.y + r.h > vb.y + vb.h + SLACK) {
         add(errors, r.el.line, "E-BOUNDS", `rect (${round1(r.x)},${round1(r.y)} ${round1(r.w)}×${round1(r.h)}) extends outside the ${vb.w}×${vb.h} viewBox`, "recompute the layout so every element sits inside the canvas margins (SKILL.md §2)");
+      }
+    }
+  }
+
+  // --- opt-in layout geometry contracts ---------------------------------
+  // Generic SVG is too varied for a reliable universal overlap detector.
+  // Authors opt in only the repeated structures that the skill can prove:
+  // page-title headers, panel headers, and icon/text cards. Text in these groups must use a centered
+  // baseline so its source-coordinate line box can be derived from y, dy, and
+  // font-size. Rendered ink and optical centering still belong to PNG QA.
+  const roleOf = (el) => el.attrs["data-layout-role"];
+  const descendantsWithRole = (group, roles) => [...walk(group)].filter((el) => roles.includes(roleOf(el)));
+  const lineBox = (el) => {
+    if (el.tag !== "text") return { proven: false, reason: `role is on <${el.tag}>, not <text>` };
+    const lineAt = (lineEl, y) => {
+      const fs = px(inheritedProp(lineEl, "font-size", rules));
+      const baseline = String(inheritedProp(lineEl, "dominant-baseline", rules) ?? "").trim().toLowerCase();
+      const t = resolveTransform(lineEl);
+      if (t.uncertain) return { proven: false, reason: "non-translate transform present" };
+      if (y === undefined || fs === undefined) return { proven: false, reason: "plain y/dy and font-size are required" };
+      if (!["middle", "central"].includes(baseline)) {
+        return { proven: false, reason: 'dominant-baseline must be "middle" or "central"' };
+      }
+      const center = y + t.dy;
+      return { proven: true, top: center - fs / 2, bottom: center + fs / 2 };
+    };
+
+    let currentY = px(el.attrs.y);
+    const boxes = [];
+    const ownText = decodeEntities(el.text.trim());
+    if (ownText) boxes.push(lineAt(el, currentY));
+    const tspans = el.children.filter((child) => child.tag === "tspan");
+    if (el.children.some((child) => child.tag === "tspan" && child.children.some((nested) => nested.tag === "tspan"))) {
+      return { proven: false, reason: "nested tspan text is outside the provable subset" };
+    }
+    for (const ts of tspans) {
+      const absoluteY = px(ts.attrs.y);
+      const dy = px(ts.attrs.dy);
+      if (ts.attrs.y !== undefined && absoluteY === undefined) return { proven: false, reason: "tspan y must be a plain number" };
+      if (ts.attrs.dy !== undefined && dy === undefined) return { proven: false, reason: "tspan dy must be a plain number" };
+      if (absoluteY !== undefined) currentY = absoluteY;
+      if (dy !== undefined && currentY === undefined) return { proven: false, reason: "tspan dy needs a resolvable parent y or absolute y" };
+      if (dy !== undefined) currentY += dy;
+      if (currentY === undefined) return { proven: false, reason: "tspan needs a resolvable parent y, y, or dy" };
+      if (decodeEntities(ts.text.trim())) boxes.push(lineAt(ts, currentY));
+    }
+    if (!boxes.length) return { proven: false, reason: "layout text has no measurable line" };
+    const unproven = boxes.find((box) => !box.proven);
+    if (unproven) return unproven;
+    return {
+      proven: true,
+      top: Math.min(...boxes.map((box) => box.top)),
+      bottom: Math.max(...boxes.map((box) => box.bottom)),
+      lineCount: boxes.length,
+    };
+  };
+  const clusterBox = (elements) => {
+    const boxes = elements.map((el) => ({ el, box: lineBox(el) }));
+    const unproven = boxes.find(({ box }) => !box.proven);
+    if (unproven) return { proven: false, el: unproven.el, reason: unproven.box.reason };
+    return {
+      proven: true,
+      top: Math.min(...boxes.map(({ box }) => box.top)),
+      bottom: Math.max(...boxes.map(({ box }) => box.bottom)),
+      lineCount: boxes.reduce((sum, { box }) => sum + box.lineCount, 0),
+    };
+  };
+
+  for (const group of walk(svgRoot)) {
+    const definitionTags = ["defs", "symbol", "marker", "clipPath", "mask", "pattern"];
+    if (definitionTags.includes(group.tag) || hasAncestor(group, definitionTags)) continue;
+    if (ancestorAllows(group, "layout-geometry")) continue;
+    const role = roleOf(group);
+    if (role === "page-title-header") {
+      const topPadding = px(group.attrs["data-layout-rail-padding-top"]);
+      const bottomPadding = px(group.attrs["data-layout-rail-padding-bottom"]);
+      const subtitleGap = px(group.attrs["data-layout-subtitle-gap"]);
+      const toleranceRaw = group.attrs["data-layout-tolerance"];
+      const parsedTolerance = px(toleranceRaw);
+      const tolerance = toleranceRaw === undefined || parsedTolerance === undefined || parsedTolerance < 0 || parsedTolerance > 8 ? 2 : parsedTolerance;
+      const gt = resolveTransform(group);
+      const rails = descendantsWithRole(group, ["title-rail"]);
+      const eyebrows = descendantsWithRole(group, ["title-eyebrow"]);
+      const titles = descendantsWithRole(group, ["title-line"]);
+      const subtitles = descendantsWithRole(group, ["title-subtitle"]);
+      if ([topPadding, bottomPadding, subtitleGap].some((n) => n === undefined || n < 0) || rails.length !== 1 || rails[0].tag !== "rect" || eyebrows.length !== 1 || titles.length < 1 || titles.length > 2 || subtitles.length !== 1) {
+        add(errors, group.line, "E-LAYOUT", "page-title-header contract requires non-negative numeric rail padding/subtitle gap, one title-rail rect, one title-eyebrow text, one or two title-line texts, and one title-subtitle text", "complete the page-title-header roles and numeric budget or remove the annotation (authoring.md §1)");
+        continue;
+      }
+      if (gt.uncertain) {
+        add(warnings, group.line, "W-LAYOUT", "page-title-header geometry is unverified because a non-translate transform is present", "use translate() only or verify the title rail manually in the 2× PNG (authoring.md §1)");
+        continue;
+      }
+      if (toleranceRaw !== undefined && (parsedTolerance === undefined || parsedTolerance < 0)) {
+        add(warnings, group.line, "W-LAYOUT", `page-title-header tolerance "${toleranceRaw}" is unsupported; the 2px default was used`, 'use a plain 0–8px tolerance or data-lint-allow="layout-geometry" with a reviewed reason (authoring.md §1)');
+      } else if (parsedTolerance !== undefined && parsedTolerance > 8) {
+        add(warnings, group.line, "W-LAYOUT", `page-title-header tolerance ${parsedTolerance}px exceeds the 8px review threshold; the 2px default was used`, 'use 0–8px or data-lint-allow="layout-geometry" with a reviewed reason (authoring.md §1)');
+      }
+      const eyebrow = lineBox(eyebrows[0]);
+      const titleBox = clusterBox(titles);
+      const subtitle = lineBox(subtitles[0]);
+      if ([eyebrow, titleBox, subtitle].some((box) => !box.proven && box.reason === "layout text has no measurable line")) {
+        add(errors, group.line, "E-LAYOUT", "page-title-header contract requires every eyebrow/title/subtitle role to contain measurable text", "add visible text content or remove the empty layout role (authoring.md §1)");
+        continue;
+      }
+      const railYRaw = localGeometryProp(rails[0], "y", rules);
+      const railY = railYRaw === undefined ? 0 : px(railYRaw);
+      const railH = px(localGeometryProp(rails[0], "height", rules));
+      const railWidthRaw = localGeometryProp(rails[0], "width", rules);
+      const railW = px(railWidthRaw);
+      const rt = resolveTransform(rails[0]);
+      if (railH !== undefined && railH <= 0) {
+        add(errors, group.line, "E-LAYOUT", "page-title-header title-rail height must be greater than zero", "compute a positive rail height from the eyebrow and final title line (authoring.md §1)");
+        continue;
+      }
+      if (railW !== undefined && railW <= 0) {
+        add(errors, group.line, "E-LAYOUT", "page-title-header title-rail width must be greater than zero", "use a visible positive rail width (authoring.md §1)");
+        continue;
+      }
+      if (!eyebrow.proven || !titleBox.proven || !subtitle.proven || railY === undefined || railH === undefined || railW === undefined || rt.uncertain) {
+        const reason = !eyebrow.proven ? eyebrow.reason : !titleBox.proven ? titleBox.reason : !subtitle.proven ? subtitle.reason : railW === undefined ? "title rail needs a plain positive width" : "title rail needs plain y/height and a translate-only transform";
+        add(warnings, group.line, "W-LAYOUT", `page-title-header geometry is unverified: ${reason}`, "use plain centered-baseline text and rect geometry so the pre-render rail check can prove the stack (authoring.md §1)");
+        continue;
+      }
+      if (titleBox.lineCount < 1 || titleBox.lineCount > 2) {
+        add(errors, group.line, "E-LAYOUT", `page-title-header supports one or two measurable title lines; found ${titleBox.lineCount}`, "split the title into one or two measurable lines or remove the premium page-title contract (authoring.md §1)");
+        continue;
+      }
+      const expectedTop = eyebrow.top - topPadding;
+      const expectedBottom = titleBox.bottom + bottomPadding;
+      const railTop = railY + rt.dy;
+      const railBottom = railTop + railH;
+      const violations = [];
+      if (Math.abs(railTop - expectedTop) > tolerance) violations.push(`rail top differs from eyebrow budget by ${round1(Math.abs(railTop - expectedTop))}px`);
+      if (Math.abs(railBottom - expectedBottom) > tolerance) violations.push(`rail bottom differs from final title line by ${round1(Math.abs(railBottom - expectedBottom))}px`);
+      if (subtitle.top < titleBox.bottom + subtitleGap - 0.01) violations.push(`title/subtitle gap is ${round1(subtitle.top - titleBox.bottom)}px; needs ${subtitleGap}px`);
+      if (railBottom > subtitle.top - subtitleGap + 0.01) violations.push(`rail bottom leaves ${round1(subtitle.top - railBottom)}px before the subtitle; needs ${subtitleGap}px`);
+      if (violations.length) {
+        add(errors, group.line, "E-LAYOUT", `page-title-header rail budget failed: ${violations.join("; ")}`, "derive rail y/height from the eyebrow and final title line before rendering (SKILL.md §2, authoring.md §1)");
+      }
+    } else if (role === "panel-header") {
+      const top = px(group.attrs["data-layout-top"]);
+      const bottom = px(group.attrs["data-layout-bottom"]);
+      const gap = px(group.attrs["data-layout-gap"]);
+      const padTop = px(group.attrs["data-layout-padding-top"]);
+      const padBottom = px(group.attrs["data-layout-padding-bottom"]);
+      const gt = resolveTransform(group);
+      if ([top, bottom, gap, padTop, padBottom].some((n) => n === undefined) || gt.uncertain) {
+        add(warnings, group.line, "W-LAYOUT", "panel-header geometry is unverified because its numeric budget or transform is unsupported", 'use plain data-layout-top/bottom/gap/padding-top/padding-bottom values and translate() only (authoring.md §4)');
+        continue;
+      }
+      const titles = descendantsWithRole(group, ["header-title"]);
+      const subtitles = descendantsWithRole(group, ["header-subtitle"]);
+      const dividers = descendantsWithRole(group, ["header-divider"]);
+      if (titles.length !== 1 || subtitles.length !== 1 || dividers.length !== 1 || dividers[0].tag !== "line") {
+        add(errors, group.line, "E-LAYOUT", "panel-header contract requires exactly one header-title text, one header-subtitle text, and one header-divider line", "add the three data-layout-role children or remove the panel-header annotation (authoring.md §4)");
+        continue;
+      }
+      const title = lineBox(titles[0]);
+      const subtitle = lineBox(subtitles[0]);
+      const divider = dividers[0];
+      const dt = resolveTransform(divider);
+      const y1 = px(divider.attrs.y1);
+      const y2 = px(divider.attrs.y2);
+      const strokeRaw = inheritedProp(divider, "stroke-width", rules);
+      const strokeWidth = strokeRaw === undefined ? 1 : px(strokeRaw);
+      if (!title.proven || !subtitle.proven || dt.uncertain || y1 === undefined || y2 === undefined || Math.abs(y1 - y2) > 0.01 || strokeWidth === undefined) {
+        const reason = !title.proven ? title.reason : !subtitle.proven ? subtitle.reason : strokeWidth === undefined ? "divider stroke-width must be a plain number" : "divider must be a horizontal line with plain y1/y2";
+        add(warnings, group.line, "W-LAYOUT", `panel-header geometry is unverified: ${reason}`, 'use centered-baseline text with plain y/font-size and a horizontal <line> divider (authoring.md §4)');
+        continue;
+      }
+      const frameTop = top + gt.dy;
+      const frameBottom = bottom + gt.dy;
+      const dividerY = y1 + dt.dy;
+      const dividerTop = dividerY - strokeWidth / 2;
+      const dividerBottom = dividerY + strokeWidth / 2;
+      const violations = [];
+      if (title.top < frameTop + padTop - 0.01) violations.push(`title starts ${round1(frameTop + padTop - title.top)}px inside the top padding`);
+      if (subtitle.top < title.bottom + gap - 0.01) violations.push(`title/subtitle gap is ${round1(subtitle.top - title.bottom)}px; needs ${gap}px`);
+      if (dividerTop < subtitle.bottom + padBottom - 0.01) violations.push(`subtitle/divider visual gap is ${round1(dividerTop - subtitle.bottom)}px; needs ${padBottom}px`);
+      if (dividerBottom > frameBottom + 0.01) violations.push(`divider visual edge is ${round1(dividerBottom - frameBottom)}px below the header budget`);
+      if (violations.length) {
+        add(errors, group.line, "E-LAYOUT", `panel-header vertical budget failed: ${violations.join("; ")}`, "recompute header height and y positions before rendering (SKILL.md §2, authoring.md §4)");
+      } else {
+        const unused = frameBottom - dividerBottom;
+        const slackLimit = Math.max(16, gap);
+        if (unused > slackLimit) {
+          add(warnings, group.line, "W-LAYOUT", `panel-header declares ${round1(unused)}px below its divider; more than the ${slackLimit}px slack allowance`, "tighten data-layout-bottom so downstream regions do not inherit accidental empty space (authoring.md §4)");
+        }
+      }
+    } else if (role === "icon-text-card") {
+      const targetRaw = group.attrs["data-layout-center-y"];
+      const target = px(targetRaw);
+      const toleranceRaw = group.attrs["data-layout-center-tolerance"];
+      const parsedTolerance = px(toleranceRaw);
+      const tolerance = toleranceRaw === undefined || parsedTolerance === undefined || parsedTolerance < 0 ? 2 : parsedTolerance;
+      const gt = resolveTransform(group);
+      const frames = descendantsWithRole(group, ["card-frame"]);
+      const icons = descendantsWithRole(group, ["icon-center"]);
+      const texts = descendantsWithRole(group, ["card-title", "card-body"]);
+      if (targetRaw === undefined || target === undefined || frames.length !== 1 || frames[0].tag !== "rect" || icons.length !== 1 || icons[0].tag !== "circle" || texts.length === 0) {
+        add(errors, group.line, "E-LAYOUT", "icon-text-card contract requires a plain data-layout-center-y, exactly one card-frame rect, exactly one icon-center circle, and at least one card-title/card-body text", "complete the declared card contract or remove the icon-text-card annotation (authoring.md §7)");
+        continue;
+      }
+      if (gt.uncertain) {
+        add(warnings, group.line, "W-LAYOUT", "icon-text-card geometry is unverified because a non-translate transform is present", "use translate() only or verify the card manually in the 2× PNG (authoring.md §7)");
+        continue;
+      }
+      if (toleranceRaw !== undefined && (parsedTolerance === undefined || parsedTolerance < 0)) {
+        add(warnings, group.line, "W-LAYOUT", `icon-text-card tolerance "${toleranceRaw}" is unsupported; the 2px default was used`, 'use a plain 0–8px tolerance or data-lint-allow="layout-geometry" with a reviewed reason (authoring.md §7)');
+      } else if (tolerance > 8) {
+        add(warnings, group.line, "W-LAYOUT", `icon-text-card tolerance ${tolerance}px exceeds the 8px review threshold and can conceal visible drift`, 'use 0–8px or data-lint-allow="layout-geometry" with a reviewed reason (authoring.md §7)');
+      }
+      const frameYRaw = frames[0].attrs.y;
+      const frameY = frameYRaw === undefined ? 0 : px(frameYRaw);
+      const frameH = px(frames[0].attrs.height);
+      const ft = resolveTransform(frames[0]);
+      const iconCy = px(icons[0].attrs.cy);
+      const it = resolveTransform(icons[0]);
+      const textBox = clusterBox(texts);
+      if (!textBox.proven && textBox.reason === "layout text has no measurable line") {
+        add(errors, group.line, "E-LAYOUT", "icon-text-card contract requires every card-title/card-body text to contain at least one measurable line", "add visible text content or remove the empty layout role (authoring.md §7)");
+        continue;
+      }
+      if (frameY === undefined || frameH === undefined || ft.uncertain || iconCy === undefined || it.uncertain || !textBox.proven) {
+        const reason = !textBox.proven ? textBox.reason : frameY === undefined || frameH === undefined || ft.uncertain ? "card frame needs plain y/height and a translate-only transform" : "icon circle needs a plain cy and translate-only transform";
+        add(warnings, group.line, "W-LAYOUT", `icon-text-card geometry is unverified: ${reason}`, "use plain card-frame, circle, and centered-baseline text geometry so the pre-render center check can prove the cluster (authoring.md §7)");
+        continue;
+      }
+      const targetY = target + gt.dy;
+      const frameCenterY = frameY + frameH / 2 + ft.dy;
+      const actualIconY = iconCy + it.dy;
+      const textCenterY = (textBox.top + textBox.bottom) / 2;
+      const violations = [];
+      if (Math.abs(frameCenterY - targetY) > tolerance) violations.push(`card-frame center differs from target by ${round1(Math.abs(frameCenterY - targetY))}px`);
+      if (Math.abs(actualIconY - targetY) > tolerance) violations.push(`icon center differs from target by ${round1(Math.abs(actualIconY - targetY))}px`);
+      if (Math.abs(textCenterY - targetY) > tolerance) violations.push(`text-cluster center differs from target by ${round1(Math.abs(textCenterY - targetY))}px`);
+      if (violations.length) {
+        add(errors, group.line, "E-LAYOUT", `icon-text-card center alignment failed: ${violations.join("; ")} (tolerance ${tolerance}px)`, "derive the frame, icon, and text-cluster centers from the same card center before rendering (SKILL.md §2, authoring.md §7)");
       }
     }
   }

--- a/skills/svg-infographic/scripts/check-svg.test.mjs
+++ b/skills/svg-infographic/scripts/check-svg.test.mjs
@@ -279,6 +279,135 @@ test("non-translate transform degrades to a warning, never an error", () => {
   assert.ok(rulesOf(warnings).includes("W-TEXT"));
 });
 
+test("explicit layout budgets accept two headers and four centered icon-text cards", () => {
+  const { errors, warnings } = lint("layout-budget-valid.svg");
+  assert.deepEqual(errors, []);
+  assert.deepEqual(warnings, []);
+});
+
+test("page-title rail contract accepts one-line and two-line title stacks", () => {
+  const { errors, warnings } = lint("title-rail-valid.svg");
+  assert.deepEqual(errors, []);
+  assert.deepEqual(warnings, []);
+});
+
+test("page-title rail contract rejects a copied fixed height and subtitle intrusion", () => {
+  const { errors } = lint("title-rail-invalid.svg");
+  const layout = errors.filter((f) => f.rule === "E-LAYOUT");
+  assert.equal(layout.length, 2);
+  assert.ok(layout.every((f) => f.message.includes("page-title-header rail budget failed")));
+  assert.ok(layout.some((f) => f.message.includes("final title line")));
+  assert.ok(layout.some((f) => f.message.includes("before the subtitle")));
+});
+
+test("page-title rail contract warns when source geometry cannot be proved", () => {
+  const { errors, warnings } = lint("title-rail-unverified.svg");
+  assert.deepEqual(errors.filter((f) => f.rule === "E-LAYOUT"), []);
+  const layout = warnings.filter((f) => f.rule === "W-LAYOUT");
+  assert.equal(layout.length, 1);
+  assert.match(layout[0].message, /title rail needs plain y\/height/);
+});
+
+test("page-title rail contract rejects negative budget values and a non-positive rail", () => {
+  const source = fixture("title-rail-valid.svg")
+    .replace('data-layout-rail-padding-top="12"', 'data-layout-rail-padding-top="-1"')
+    .replace('height="145"', 'height="0"');
+  const { errors } = lintSvg(source, "title-rail-invalid-contract.svg");
+  const layout = errors.filter((f) => f.rule === "E-LAYOUT");
+  assert.equal(layout.length, 2);
+  assert.ok(layout.some((f) => f.message.includes("non-negative numeric")));
+  assert.ok(layout.some((f) => f.message.includes("height must be greater than zero")));
+});
+
+test("page-title rail contract rejects zero width and warns on unsupported width", () => {
+  const zeroWidth = fixture("title-rail-valid.svg").replace('width="6"', 'width="0"');
+  const { errors: zeroErrors } = lintSvg(zeroWidth, "title-rail-zero-width.svg");
+  assert.ok(zeroErrors.some((f) => f.rule === "E-LAYOUT" && f.message.includes("width must be greater than zero")));
+
+  const percentageWidth = fixture("title-rail-valid.svg").replace('width="6"', 'width="0%"');
+  const { errors, warnings } = lintSvg(percentageWidth, "title-rail-percentage-width.svg");
+  assert.deepEqual(errors.filter((f) => f.rule === "E-LAYOUT"), []);
+  assert.ok(warnings.some((f) => f.rule === "W-LAYOUT" && f.message.includes("plain positive width")));
+
+  const styleWidth = fixture("title-rail-valid.svg").replace('width="6"', 'width="6" style="width:0"');
+  const { errors: styleErrors } = lintSvg(styleWidth, "title-rail-style-width.svg");
+  assert.ok(styleErrors.some((f) => f.rule === "E-LAYOUT" && f.message.includes("width must be greater than zero")));
+});
+
+test("page-title rail geometry uses the same local CSS precedence on every axis", () => {
+  const inlineHeight = fixture("title-rail-valid.svg").replace('height="93" rx="3"', 'height="93" style="height:0" rx="3"');
+  const { errors: inlineErrors } = lintSvg(inlineHeight, "title-rail-inline-height.svg");
+  assert.ok(inlineErrors.some((f) => f.rule === "E-LAYOUT" && f.message.includes("height must be greater than zero")));
+
+  const classHeight = fixture("title-rail-valid.svg")
+    .replace("  <title>", "  <style>.collapsed-rail { height: 0; }</style>\n  <title>")
+    .replace('data-layout-role="title-rail" x="40" y="40"', 'data-layout-role="title-rail" class="collapsed-rail" x="40" y="40"');
+  const { errors: classErrors } = lintSvg(classHeight, "title-rail-class-height.svg");
+  assert.ok(classErrors.some((f) => f.rule === "E-LAYOUT" && f.message.includes("height must be greater than zero")));
+
+  const movedRail = fixture("title-rail-valid.svg")
+    .replace("  <title>", "  <style>.moved-rail { y: 400; }</style>\n  <title>")
+    .replace('data-layout-role="title-rail" x="40" y="40"', 'data-layout-role="title-rail" class="moved-rail" x="40" y="40"');
+  const { errors: movedErrors } = lintSvg(movedRail, "title-rail-class-y.svg");
+  assert.ok(movedErrors.some((f) => f.rule === "E-LAYOUT" && f.message.includes("rail top differs")));
+});
+
+test("root svg geometry rules do not leak into a descendant title rail", () => {
+  const source = fixture("title-rail-valid.svg").replace("  <title>", "  <style>svg { width: 100%; height: 100%; }</style>\n  <title>");
+  const { errors, warnings } = lintSvg(source, "title-rail-root-svg-geometry.svg");
+  assert.deepEqual(errors, []);
+  assert.deepEqual(warnings, []);
+});
+
+test("page-title rail contract counts visual tspan lines, not only title elements", () => {
+  const source = fixture("title-rail-valid.svg").replace(
+    '<text data-layout-role="title-line" x="68" y="110" font-size="46" dominant-baseline="middle">한 줄 제목</text>',
+    '<text data-layout-role="title-line" x="68" y="110" font-size="46" dominant-baseline="middle"><tspan x="68" dy="0">첫 줄</tspan><tspan x="68" dy="52">둘째 줄</tspan><tspan x="68" dy="52">셋째 줄</tspan></text>',
+  );
+  const { errors } = lintSvg(source, "title-rail-three-visual-lines.svg");
+  assert.ok(errors.some((f) => f.rule === "E-LAYOUT" && f.message.includes("found 3")));
+});
+
+test("an oversized page-title tolerance warns without hiding deterministic drift", () => {
+  const source = fixture("title-rail-valid.svg")
+    .replace('data-layout-subtitle-gap="16"', 'data-layout-subtitle-gap="16" data-layout-tolerance="999"')
+    .replace('height="93"', 'height="84"');
+  const { errors, warnings } = lintSvg(source, "title-rail-tolerance.svg");
+  assert.ok(errors.some((f) => f.rule === "E-LAYOUT" && f.message.includes("final title line")));
+  assert.ok(warnings.some((f) => f.rule === "W-LAYOUT" && f.message.includes("tolerance 999px")));
+});
+
+test("explicit layout budgets reject header collisions and card-center drift before rendering", () => {
+  const { errors } = lint("layout-budget-invalid.svg");
+  const layout = errors.filter((f) => f.rule === "E-LAYOUT");
+  assert.equal(layout.length, 6, "two invalid headers plus four invalid cards");
+  assert.equal(layout.filter((f) => f.message.includes("panel-header vertical budget failed")).length, 2);
+  assert.equal(layout.filter((f) => f.message.includes("icon-text-card center alignment failed")).length, 4);
+});
+
+test("layout contracts reject multi-line collisions, frame drift, incomplete roles, and divider ink overflow", () => {
+  const { errors, warnings } = lint("layout-budget-contract-invalid.svg");
+  const layout = errors.filter((f) => f.rule === "E-LAYOUT");
+  assert.equal(layout.length, 8);
+  assert.equal(layout.filter((f) => f.message.includes("panel-header vertical budget failed")).length, 2);
+  assert.equal(layout.filter((f) => f.message.includes("icon-text-card center alignment failed")).length, 2);
+  assert.equal(layout.filter((f) => f.message.includes("icon-text-card contract requires")).length, 4);
+  assert.ok(layout.some((f) => f.message.includes("at least one measurable line")));
+  assert.deepEqual(warnings.filter((f) => f.rule === "W-LAYOUT"), []);
+});
+
+test("unsupported layout geometry warns while defs and explicit opt-outs stay outside the contract", () => {
+  const { errors, warnings } = lint("layout-budget-unverified.svg");
+  assert.deepEqual(errors.filter((f) => f.rule === "E-LAYOUT"), []);
+  const layout = warnings.filter((f) => f.rule === "W-LAYOUT");
+  assert.equal(layout.length, 5);
+  assert.ok(layout.some((f) => f.message.includes("dominant-baseline")));
+  assert.ok(layout.some((f) => f.message.includes("non-translate transform")));
+  assert.ok(layout.some((f) => f.message.includes("tolerance 999px")));
+  assert.ok(layout.some((f) => f.message.includes("below its divider")));
+  assert.ok(layout.some((f) => f.message.includes("card frame needs plain y/height")));
+});
+
 test("CLI exits 0 on the valid fixture and 1 on a hard-error fixture", () => {
   const cli = join(here, "check-svg.mjs");
   const ok = spawnSync(process.execPath, [cli, join(here, "fixtures", "valid.svg")], { encoding: "utf8" });

--- a/skills/svg-infographic/scripts/fixtures/layout-budget-contract-invalid.svg
+++ b/skills/svg-infographic/scripts/fixtures/layout-budget-contract-invalid.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1350" viewBox="0 0 1080 1350">
+  <title>Invalid layout contract fixture</title>
+  <desc>Provable multi-line, frame-center, role, and stroke violations must fail.</desc>
+  <rect width="1080" height="1350" fill="#f7f9fc"/>
+
+  <g transform="translate(40 40)" data-layout-role="panel-header" data-layout-top="0" data-layout-bottom="130" data-layout-gap="12" data-layout-padding-top="10" data-layout-padding-bottom="20">
+    <text data-layout-role="header-title" x="0" y="30" font-size="24" dominant-baseline="middle"><tspan x="0" dy="0">Two-line</tspan><tspan x="0" dy="32">header title</tspan></text>
+    <text data-layout-role="header-subtitle" x="0" y="80" font-size="18" dominant-baseline="middle">Subtitle collision</text>
+    <line data-layout-role="header-divider" x1="0" y1="116" x2="460" y2="116" stroke="#c13d3d" stroke-width="2"/>
+  </g>
+
+  <g transform="translate(40 210)" data-layout-role="icon-text-card" data-layout-center-y="100">
+    <rect data-layout-role="card-frame" width="480" height="200" rx="20" fill="#fff" stroke="#ccd6e2"/>
+    <circle data-layout-role="icon-center" cx="60" cy="100" r="24"/>
+    <text data-layout-role="card-title" x="110" y="74" font-size="20" dominant-baseline="middle">Multi-line body</text>
+    <text data-layout-role="card-body" x="110" y="92" font-size="16" dominant-baseline="middle"><tspan x="110" dy="0">Line one</tspan><tspan x="110" dy="24">Line two</tspan><tspan x="110" dy="24">Line three</tspan></text>
+  </g>
+
+  <g transform="translate(560 210)" data-layout-role="icon-text-card" data-layout-center-y="160">
+    <rect data-layout-role="card-frame" width="480" height="200" rx="20" fill="#fff" stroke="#ccd6e2"/>
+    <circle data-layout-role="icon-center" cx="60" cy="160" r="24"/>
+    <text data-layout-role="card-title" x="110" y="148" font-size="20" dominant-baseline="middle">Wrong frame center</text>
+    <text data-layout-role="card-body" x="110" y="174" font-size="16" dominant-baseline="middle">Relative alignment is not enough</text>
+  </g>
+
+  <g transform="translate(40 450)" data-layout-role="icon-text-card">
+    <rect data-layout-role="card-frame" width="300" height="160" rx="20" fill="#fff" stroke="#ccd6e2"/>
+    <circle data-layout-role="icon-center" cx="50" cy="80" r="22"/>
+    <text data-layout-role="card-title" x="95" y="80" font-size="18" dominant-baseline="middle">Missing target</text>
+  </g>
+  <g transform="translate(380 450)" data-layout-role="icon-text-card" data-layout-center-y="80">
+    <rect data-layout-role="card-frame" width="300" height="160" rx="20" fill="#fff" stroke="#ccd6e2"/>
+    <circle data-layout-role="icon-center" cx="45" cy="80" r="20"/>
+    <circle data-layout-role="icon-center" cx="75" cy="80" r="20"/>
+    <text data-layout-role="card-title" x="115" y="80" font-size="18" dominant-baseline="middle">Duplicate icon</text>
+  </g>
+  <g transform="translate(720 450)" data-layout-role="icon-text-card" data-layout-center-y="80">
+    <rect data-layout-role="card-frame" width="300" height="160" rx="20" fill="#fff" stroke="#ccd6e2"/>
+    <circle data-layout-role="icon-center" cx="50" cy="80" r="22"/>
+  </g>
+
+  <g transform="translate(40 880)" data-layout-role="icon-text-card" data-layout-center-y="80">
+    <rect data-layout-role="card-frame" width="300" height="160" rx="20" fill="#fff" stroke="#ccd6e2"/>
+    <circle data-layout-role="icon-center" cx="50" cy="80" r="22"/>
+    <text data-layout-role="card-title" x="95" y="80" font-size="18" dominant-baseline="middle"></text>
+  </g>
+
+  <g transform="translate(40 660)" data-layout-role="panel-header" data-layout-top="0" data-layout-bottom="120" data-layout-gap="10" data-layout-padding-top="10" data-layout-padding-bottom="20">
+    <text data-layout-role="header-title" x="0" y="24" font-size="20" dominant-baseline="middle">Stroke bounds</text>
+    <text data-layout-role="header-subtitle" x="0" y="55" font-size="16" dominant-baseline="middle">Divider ink crosses the budget</text>
+    <line data-layout-role="header-divider" x1="0" y1="118" x2="460" y2="118" stroke="#c13d3d" stroke-width="8"/>
+  </g>
+</svg>

--- a/skills/svg-infographic/scripts/fixtures/layout-budget-invalid.svg
+++ b/skills/svg-infographic/scripts/fixtures/layout-budget-invalid.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1350" viewBox="0 0 1080 1350">
+  <title>Invalid layout budget fixture</title>
+  <desc>Headers collide with dividers and card text clusters drift from their icons.</desc>
+  <rect width="1080" height="1350" fill="#f7f9fc"/>
+
+  <g transform="translate(72 68)" data-layout-role="panel-header" data-layout-top="0" data-layout-bottom="100" data-layout-gap="16" data-layout-padding-top="20" data-layout-padding-bottom="20">
+    <text data-layout-role="header-title" x="0" y="32" font-size="32" dominant-baseline="middle">Cramped header</text>
+    <text data-layout-role="header-subtitle" x="0" y="50" font-size="20" dominant-baseline="middle">The divider crosses the content.</text>
+    <line data-layout-role="header-divider" x1="0" y1="58" x2="936" y2="58" stroke="#c13d3d" stroke-width="2"/>
+  </g>
+
+  <g transform="translate(72 220)" data-layout-role="panel-header" data-layout-top="0" data-layout-bottom="100" data-layout-gap="16" data-layout-padding-top="20" data-layout-padding-bottom="20">
+    <text data-layout-role="header-title" x="0" y="32" font-size="32" dominant-baseline="middle">Second collision</text>
+    <text data-layout-role="header-subtitle" x="0" y="50" font-size="20" dominant-baseline="middle">The same arithmetic fails again.</text>
+    <line data-layout-role="header-divider" x1="0" y1="58" x2="936" y2="58" stroke="#c13d3d" stroke-width="2"/>
+  </g>
+
+  <g transform="translate(72 408)" data-layout-role="icon-text-card" data-layout-center-y="118" data-layout-center-tolerance="2">
+    <rect data-layout-role="card-frame" width="444" height="236" rx="24" fill="#ffffff" stroke="#b9c7d8"/>
+    <circle data-layout-role="icon-center" cx="72" cy="118" r="28" fill="#fbe9e9"/>
+    <text data-layout-role="card-title" x="124" y="76" font-size="24" font-weight="700" dominant-baseline="middle">Text too high</text>
+    <text data-layout-role="card-body" x="124" y="104" font-size="16" dominant-baseline="middle">Centers do not match</text>
+  </g>
+  <g transform="translate(564 408)" data-layout-role="icon-text-card" data-layout-center-y="118" data-layout-center-tolerance="2">
+    <rect data-layout-role="card-frame" width="444" height="236" rx="24" fill="#ffffff" stroke="#b9c7d8"/>
+    <circle data-layout-role="icon-center" cx="72" cy="86" r="28" fill="#fbe9e9"/>
+    <text data-layout-role="card-title" x="124" y="106" font-size="24" font-weight="700" dominant-baseline="middle">Icon too high</text>
+    <text data-layout-role="card-body" x="124" y="134" font-size="16" dominant-baseline="middle">Centers do not match</text>
+  </g>
+  <g transform="translate(72 692)" data-layout-role="icon-text-card" data-layout-center-y="118" data-layout-center-tolerance="2">
+    <rect data-layout-role="card-frame" width="444" height="236" rx="24" fill="#ffffff" stroke="#b9c7d8"/>
+    <circle data-layout-role="icon-center" cx="72" cy="150" r="28" fill="#fbe9e9"/>
+    <text data-layout-role="card-title" x="124" y="106" font-size="24" font-weight="700" dominant-baseline="middle">Icon too low</text>
+    <text data-layout-role="card-body" x="124" y="134" font-size="16" dominant-baseline="middle">Centers do not match</text>
+  </g>
+  <g transform="translate(564 692)" data-layout-role="icon-text-card" data-layout-center-y="118" data-layout-center-tolerance="2">
+    <rect data-layout-role="card-frame" width="444" height="236" rx="24" fill="#ffffff" stroke="#b9c7d8"/>
+    <circle data-layout-role="icon-center" cx="72" cy="118" r="28" fill="#fbe9e9"/>
+    <text data-layout-role="card-title" x="124" y="132" font-size="24" font-weight="700" dominant-baseline="middle">Text too low</text>
+    <text data-layout-role="card-body" x="124" y="160" font-size="16" dominant-baseline="middle">Centers do not match</text>
+  </g>
+</svg>

--- a/skills/svg-infographic/scripts/fixtures/layout-budget-unverified.svg
+++ b/skills/svg-infographic/scripts/fixtures/layout-budget-unverified.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1350" viewBox="0 0 1080 1350">
+  <title>Unverified layout budget fixture</title>
+  <desc>Unsupported geometry stays visible as warnings while explicit opt-outs and definitions stay quiet.</desc>
+  <rect width="1080" height="1350" fill="#f7f9fc"/>
+
+  <defs>
+    <g id="card-template" data-layout-role="icon-text-card" data-layout-center-y="100">
+      <rect data-layout-role="card-frame" width="300" height="200"/>
+      <circle data-layout-role="icon-center" cx="40" cy="20" r="20"/>
+      <text data-layout-role="card-title" x="80" y="180" font-size="18" dominant-baseline="middle">Definition only</text>
+    </g>
+  </defs>
+  <use href="#card-template" x="720" y="80"/>
+
+  <g transform="translate(40 40)" data-layout-role="panel-header" data-layout-top="0" data-layout-bottom="130" data-layout-gap="12" data-layout-padding-top="10" data-layout-padding-bottom="20">
+    <text data-layout-role="header-title" x="0" y="30" font-size="24">Unsupported baseline</text>
+    <text data-layout-role="header-subtitle" x="0" y="75" font-size="18" dominant-baseline="middle">Must warn</text>
+    <line data-layout-role="header-divider" x1="0" y1="110" x2="460" y2="110" stroke="#2374ab"/>
+  </g>
+
+  <g transform="rotate(2)" data-layout-role="icon-text-card" data-layout-center-y="100">
+    <rect data-layout-role="card-frame" x="40" y="220" width="300" height="200"/>
+    <circle data-layout-role="icon-center" cx="90" cy="320" r="20"/>
+    <text data-layout-role="card-title" x="130" y="320" font-size="18" dominant-baseline="middle">Rotated card</text>
+  </g>
+
+  <g transform="translate(400 220)" data-layout-role="icon-text-card" data-layout-center-y="100" data-layout-center-tolerance="999">
+    <rect data-layout-role="card-frame" width="300" height="200"/>
+    <circle data-layout-role="icon-center" cx="50" cy="20" r="20"/>
+    <text data-layout-role="card-title" x="95" y="180" font-size="18" dominant-baseline="middle">Tolerance warning</text>
+  </g>
+
+  <g transform="translate(40 500)" data-layout-role="panel-header" data-layout-top="0" data-layout-bottom="500" data-layout-gap="12" data-layout-padding-top="10" data-layout-padding-bottom="20">
+    <text data-layout-role="header-title" x="0" y="30" font-size="24" dominant-baseline="middle">Oversized budget</text>
+    <text data-layout-role="header-subtitle" x="0" y="75" font-size="18" dominant-baseline="middle">Must warn</text>
+    <line data-layout-role="header-divider" x1="0" y1="110" x2="460" y2="110" stroke="#2374ab"/>
+  </g>
+
+  <g transform="translate(40 760)" data-layout-role="icon-text-card" data-layout-center-y="100">
+    <rect data-layout-role="card-frame" y="10%" width="300" height="200"/>
+    <circle data-layout-role="icon-center" cx="50" cy="100" r="20"/>
+    <text data-layout-role="card-title" x="95" y="100" font-size="18" dominant-baseline="middle">Relative frame position</text>
+  </g>
+
+  <g transform="translate(560 500)" data-layout-role="icon-text-card" data-lint-allow="layout-geometry">
+    <circle data-layout-role="icon-center" cx="50" cy="20" r="20"/>
+  </g>
+</svg>

--- a/skills/svg-infographic/scripts/fixtures/layout-budget-valid.svg
+++ b/skills/svg-infographic/scripts/fixtures/layout-budget-valid.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="1350" viewBox="0 0 1080 1350">
+  <title>Valid layout budget fixture</title>
+  <desc>Two panel headers and four icon-text cards share explicit vertical geometry.</desc>
+  <rect width="1080" height="1350" fill="#f7f9fc"/>
+
+  <g transform="translate(72 68)" data-layout-role="panel-header" data-layout-top="0" data-layout-bottom="132" data-layout-gap="16" data-layout-padding-top="20" data-layout-padding-bottom="24">
+    <text data-layout-role="header-title" x="0" y="38" font-size="32" dominant-baseline="middle">Layout budget</text>
+    <text data-layout-role="header-subtitle" x="0" y="82" font-size="20" dominant-baseline="middle">Define the vertical rhythm before rendering.</text>
+    <line data-layout-role="header-divider" x1="0" y1="120" x2="936" y2="120" stroke="#2374ab" stroke-width="2"/>
+  </g>
+
+  <g transform="translate(72 248)" data-layout-role="panel-header" data-layout-top="0" data-layout-bottom="132" data-layout-gap="16" data-layout-padding-top="20" data-layout-padding-bottom="24">
+    <text data-layout-role="header-title" x="0" y="38" font-size="32" dominant-baseline="middle">Shared center</text>
+    <text data-layout-role="header-subtitle" x="0" y="82" font-size="20" dominant-baseline="middle">Icon and copy derive from the same card geometry.</text>
+    <line data-layout-role="header-divider" x1="0" y1="120" x2="936" y2="120" stroke="#2374ab" stroke-width="2"/>
+  </g>
+
+  <g transform="translate(72 440)" data-layout-role="icon-text-card" data-layout-center-y="118" data-layout-center-tolerance="2">
+    <rect data-layout-role="card-frame" width="444" height="236" rx="24" fill="#ffffff" stroke="#b9c7d8"/>
+    <circle data-layout-role="icon-center" cx="72" cy="118" r="28" fill="#e7f2fa"/>
+    <text data-layout-role="card-title" x="124" y="106" font-size="24" font-weight="700" dominant-baseline="middle">Header budget</text>
+    <text data-layout-role="card-body" x="124" y="134" font-size="16" dominant-baseline="middle">Title, subtitle, divider</text>
+  </g>
+  <g transform="translate(564 440)" data-layout-role="icon-text-card" data-layout-center-y="118" data-layout-center-tolerance="2">
+    <rect data-layout-role="card-frame" width="444" height="236" rx="24" fill="#ffffff" stroke="#b9c7d8"/>
+    <circle data-layout-role="icon-center" cx="72" cy="118" r="28" fill="#e7f2fa"/>
+    <text data-layout-role="card-title" x="124" y="106" font-size="24" font-weight="700" dominant-baseline="middle">Text cluster</text>
+    <text data-layout-role="card-body" x="124" y="134" font-size="16" dominant-baseline="middle">One computed vertical center</text>
+  </g>
+  <g transform="translate(72 724)" data-layout-role="icon-text-card" data-layout-center-y="118" data-layout-center-tolerance="2">
+    <rect data-layout-role="card-frame" width="444" height="236" rx="24" fill="#ffffff" stroke="#b9c7d8"/>
+    <circle data-layout-role="icon-center" cx="72" cy="118" r="28" fill="#e7f2fa"/>
+    <text data-layout-role="card-title" x="124" y="106" font-size="24" font-weight="700" dominant-baseline="middle">Source check</text>
+    <text data-layout-role="card-body" x="124" y="134" font-size="16" dominant-baseline="middle">Fail before PNG rendering</text>
+  </g>
+  <g transform="translate(564 724)" data-layout-role="icon-text-card" data-layout-center-y="118" data-layout-center-tolerance="2">
+    <rect data-layout-role="card-frame" width="444" height="236" rx="24" fill="#ffffff" stroke="#b9c7d8"/>
+    <circle data-layout-role="icon-center" cx="72" cy="118" r="28" fill="#e7f2fa"/>
+    <text data-layout-role="card-title" x="124" y="106" font-size="24" font-weight="700" dominant-baseline="middle">Visual check</text>
+    <text data-layout-role="card-body" x="124" y="134" font-size="16" dominant-baseline="middle">Confirm the rendered result</text>
+  </g>
+</svg>

--- a/skills/svg-infographic/scripts/fixtures/title-rail-invalid.svg
+++ b/skills/svg-infographic/scripts/fixtures/title-rail-invalid.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 500" width="1080" height="500" role="img" style="font-family:Pretendard,'Apple SD Gothic Neo','Malgun Gothic','Noto Sans KR',sans-serif">
+  <title>Invalid fixed-height and subtitle-intruding page title rails</title>
+  <desc>Synthetic negative fixture for page title rail geometry.</desc>
+  <rect width="1080" height="500" fill="#fff"/>
+  <g data-layout-role="page-title-header" data-layout-rail-padding-top="12" data-layout-rail-padding-bottom="0" data-layout-subtitle-gap="16">
+    <rect data-layout-role="title-rail" x="40" y="40" width="6" height="93" rx="3" fill="#1F6FB2"/>
+    <text data-layout-role="title-eyebrow" x="68" y="60" font-size="16" dominant-baseline="middle">SKILL · FIXED HEIGHT</text>
+    <text data-layout-role="title-line" x="68" y="110" font-size="46" dominant-baseline="middle">첫 번째 제목 줄</text>
+    <text data-layout-role="title-line" x="68" y="162" font-size="46" dominant-baseline="middle">두 번째 제목 줄</text>
+    <text data-layout-role="title-subtitle" x="68" y="216" font-size="18" dominant-baseline="middle">rail이 마지막 제목 줄보다 짧다</text>
+  </g>
+  <g data-layout-role="page-title-header" data-layout-rail-padding-top="12" data-layout-rail-padding-bottom="24" data-layout-subtitle-gap="16">
+    <rect data-layout-role="title-rail" x="40" y="270" width="6" height="117" rx="3" fill="#B86B18"/>
+    <text data-layout-role="title-eyebrow" x="68" y="290" font-size="16" dominant-baseline="middle">SKILL · SUBTITLE</text>
+    <text data-layout-role="title-line" x="68" y="340" font-size="46" dominant-baseline="middle">한 줄 제목</text>
+    <text data-layout-role="title-subtitle" x="68" y="392" font-size="18" dominant-baseline="middle">rail이 설명 여백을 침범한다</text>
+  </g>
+</svg>

--- a/skills/svg-infographic/scripts/fixtures/title-rail-unverified.svg
+++ b/skills/svg-infographic/scripts/fixtures/title-rail-unverified.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 250" width="1080" height="250" role="img" style="font-family:Pretendard,'Apple SD Gothic Neo','Malgun Gothic','Noto Sans KR',sans-serif">
+  <title>Unverified page title rail geometry</title>
+  <desc>Synthetic fixture preserving a warning for unsupported rail units.</desc>
+  <rect width="1080" height="250" fill="#fff"/>
+  <g data-layout-role="page-title-header" data-layout-rail-padding-top="12" data-layout-rail-padding-bottom="0" data-layout-subtitle-gap="16">
+    <rect data-layout-role="title-rail" x="40" y="10%" width="6" height="93" rx="3" fill="#1F6FB2"/>
+    <text data-layout-role="title-eyebrow" x="68" y="60" font-size="16" dominant-baseline="middle">SKILL · UNVERIFIED</text>
+    <text data-layout-role="title-line" x="68" y="110" font-size="46" dominant-baseline="middle">지원하지 않는 좌표</text>
+    <text data-layout-role="title-subtitle" x="68" y="164" font-size="18" dominant-baseline="middle">warning으로 남긴다</text>
+  </g>
+</svg>

--- a/skills/svg-infographic/scripts/fixtures/title-rail-valid.svg
+++ b/skills/svg-infographic/scripts/fixtures/title-rail-valid.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 500" width="1080" height="500" role="img" style="font-family:Pretendard,'Apple SD Gothic Neo','Malgun Gothic','Noto Sans KR',sans-serif">
+  <title>Valid one-line and two-line page title rails</title>
+  <desc>Synthetic fixture proving that the accent rail follows the final title line.</desc>
+  <rect width="1080" height="500" fill="#fff"/>
+  <g data-layout-role="page-title-header" data-layout-rail-padding-top="12" data-layout-rail-padding-bottom="0" data-layout-subtitle-gap="16">
+    <rect data-layout-role="title-rail" x="40" y="40" width="6" height="93" rx="3" fill="#1F6FB2"/>
+    <text data-layout-role="title-eyebrow" x="68" y="60" font-size="16" dominant-baseline="middle">SKILL · ONE LINE</text>
+    <text data-layout-role="title-line" x="68" y="110" font-size="46" dominant-baseline="middle">한 줄 제목</text>
+    <text data-layout-role="title-subtitle" x="68" y="164" font-size="18" dominant-baseline="middle">한 줄 설명</text>
+  </g>
+  <g data-layout-role="page-title-header" data-layout-rail-padding-top="12" data-layout-rail-padding-bottom="0" data-layout-subtitle-gap="16">
+    <rect data-layout-role="title-rail" x="40" y="250" width="6" height="145" rx="3" fill="#0F7A5F"/>
+    <text data-layout-role="title-eyebrow" x="68" y="270" font-size="16" dominant-baseline="middle">SKILL · TWO LINES</text>
+    <text data-layout-role="title-line" x="68" y="320" font-size="46" dominant-baseline="middle">두 줄 제목은</text>
+    <text data-layout-role="title-line" x="68" y="372" font-size="46" dominant-baseline="middle">rail도 함께 늘어난다</text>
+    <text data-layout-role="title-subtitle" x="68" y="426" font-size="18" dominant-baseline="middle">마지막 제목 줄에서 계산한 설명</text>
+  </g>
+</svg>


### PR DESCRIPTION
## What changed

- adds opt-in source layout contracts for panel headers and icon-text cards
- adds a one-line/two-line page-title contract whose accent rail follows the eyebrow and final title line
- rejects deterministic padding, collision, center-alignment, rail-height, width, and subtitle-clearance violations before rendering
- preserves unsupported geometry as actionable warnings instead of silent passes
- adds positive, invalid, contract-invalid, and unverified SVG fixtures
- documents the layout arithmetic and authoring roles in the skill guidance

## Why

Repeated infographic work exposed source-lint blind spots: panel headings could overlap their dividers, icon and text clusters could drift from the card center, and a fixed title rail could stop before the final line of a two-line title. These failures were only discovered after rendering and then manually corrected.

The new contracts are explicit and opt-in, so generic or deliberately unusual SVG remains outside deterministic layout checks.

## User impact

Authors can calculate repeated vertical structures before rendering and receive precise `E-LAYOUT` or `W-LAYOUT` findings when the declared geometry is invalid or cannot be proved from source. Final rendered-ink and optical alignment still belong to the exact 2× PNG review.

## Validation

- source lint tests: `52/52`
- renderer regression: `19/19`
- repository tests: `178/178`
- repository validator: `0 finding(s)`
- generic skill validator: `Skill is valid!`
- title fixtures: valid `0E/0W`, invalid `2E/0W`, unverified `0E/1W`
- existing layout fixtures: valid `0E/0W`, invalid `6E/0W`, contract-invalid `8E/0W`, unverified `0E/6W`
- `git diff --check` and public-intent identifier scan clean

## Release boundary

The changelog remains under `[Unreleased]`. Version bump, tag, and GitHub Release are intentionally excluded and will use a separate release gate after this PR merges.
