### PR TITLE
release(svg-infographic): prepare v0.9.0

### DIFF
--- a/.skillstead/release-notes/svg-infographic-v0.9.0.md
+++ b/.skillstead/release-notes/svg-infographic-v0.9.0.md
@@ -1,0 +1,38 @@
+> **Latest** refers to the most recently published individual skill release, not a catalog version.
+
+## svg-infographic 0.9.0
+
+This minor release catches recurring vertical-layout drift in the editable SVG source before rendering. Authors
+can opt page titles, panel headers, and icon-text cards into explicit layout contracts. The source lint then checks
+that a one-line or two-line title rail follows the actual title stack, panel text clears its divider, and card
+frames, icons, and complete text clusters use the same vertical center.
+
+Existing SVGs are unaffected unless they use the new `data-layout-role` annotations. Geometry that can be proved
+from source produces deterministic errors when it violates the declared budget. Unsupported units, transforms,
+or typography remain warnings that require review in the final 2× PNG; the source model does not claim to measure
+rendered glyph ink or optical centering.
+
+### 한국어
+
+이번 minor release는 반복적으로 발생하던 세로 배치 오류를 렌더링 전에 편집 가능한 SVG 원본에서
+찾도록 개선했습니다. Page title, panel header와 icon-text card에 명시적인 layout contract를 적용하면,
+source lint가 한 줄·두 줄 제목의 rail이 실제 title stack을 따라가는지, panel text와 divider 사이에
+필요한 여백이 있는지, card frame·icon·전체 text cluster가 같은 세로 중심을 사용하는지 검사합니다.
+
+새 `data-layout-role` annotation을 사용하지 않는 기존 SVG에는 영향을 주지 않습니다. 원본에서 확정할 수
+있는 배치가 선언한 범위를 벗어나면 명확한 error를 보고합니다. 단위, transform 또는 typography 때문에
+원본만으로 판단할 수 없는 경우에는 warning을 남기며, 최종 2× PNG에서 직접 확인해야 합니다. 이 검사는
+렌더링된 글자의 실제 영역이나 시각적 중심까지 측정한다고 주장하지 않습니다.
+
+## Evidence And Limits
+
+- Package: `skills/svg-infographic/`
+- Tag: `svg-infographic/v0.9.0`
+- Validation: source lint `52/52`, renderer regression `19/19`, repository tests `178/178`, repository validator
+  `0 finding(s)`, and the generic skill validator reported `Skill is valid!`
+- Compatibility or migration: no migration is required; the new layout contracts are opt-in
+- Known limitations: source-coordinate checks do not replace rendered-ink and optical-alignment review in the
+  final 2× PNG
+
+The versioned unit is the package above. GitHub's source archive is a snapshot of the whole repository at the
+tagged commit; it is not a standalone package artifact.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Notable changes to this repository. Format based on [Keep a Changelog](https://k
 
 Granular, per-change entries begin at the first public release. Earlier development history is in the git log.
 
+## 2026-08-09
+
+### Skills
+
+- `svg-infographic` `0.9.0` — opt-in source layout contracts for panel headers, icon-text cards, and one-line or
+  two-line page-title rails, with deterministic failures for provable geometry drift and warnings for unsupported
+  source geometry.
+
 ## 2026-07-30
 
 ### Repository

--- a/README.ko.md
+++ b/README.ko.md
@@ -44,7 +44,7 @@
 
 | 스킬 | 이런 작업에 적합 | 버전 | 지원 실행 환경 | 성숙도 |
 | --- | --- | --- | --- | --- |
-| [`svg-infographic`](./skills/svg-infographic) | 아키텍처 설명, 작업 흐름, 비교 자료를 수정 가능한 SVG와 검증된 2× PNG로 제작 | `0.8.3` | Supported: Claude Code + Codex | Stable |
+| [`svg-infographic`](./skills/svg-infographic) | 아키텍처 설명, 작업 흐름, 비교 자료를 수정 가능한 SVG와 검증된 2× PNG로 제작 | `0.9.0` | Supported: Claude Code + Codex | Stable |
 | [`docs-claim-check`](./skills/docs-claim-check) | 공개 문서의 주장이 제공된 근거로 뒷받침되는지 확인 | `0.9.1` | Claude Code | Beta |
 | [`github-release-guide`](./skills/github-release-guide) | 비공개 GitHub 저장소의 첫 공개 전환 또는 공개 후 매 버전 릴리스를 점검하고 단계별로 안내 | `0.9.0` | Supported: Claude Code + Codex | Stable |
 | [`writing-quality-editor`](./skills/writing-quality-editor) | 사용자 문서를 처음부터 작성하거나 자연스럽게 다듬고, 사실·의도·목소리·운영 제약을 보존하면서 영어↔한국어 내용을 재구성 | `0.10.1` | Supported: Claude Code + Codex | Beta |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ required pipeline: start with the skill you need, skip the others, and recheck a
 
 | Skill | Best for | Version | Runtime support | Maturity |
 | --- | --- | --- | --- | --- |
-| [`svg-infographic`](./skills/svg-infographic) | Turning architecture notes, process flows, comparisons, and technical concepts into editable SVG + verified 2× PNG | `0.8.3` | Supported: Claude Code + Codex | Stable |
+| [`svg-infographic`](./skills/svg-infographic) | Turning architecture notes, process flows, comparisons, and technical concepts into editable SVG + verified 2× PNG | `0.9.0` | Supported: Claude Code + Codex | Stable |
 | [`docs-claim-check`](./skills/docs-claim-check) | Checking whether public documentation claims are supported by supplied evidence | `0.9.1` | Claude Code | Beta |
 | [`github-release-guide`](./skills/github-release-guide) | Guiding a private repository's first public transition and every later version release, with separate approval before each change | `0.9.0` | Supported: Claude Code + Codex | Stable |
 | [`writing-quality-editor`](./skills/writing-quality-editor) | Composing and revising user-facing text, plus natural English↔Korean adaptation, without inventing or changing facts, intent, voice, or operational constraints | `0.10.1` | Supported: Claude Code + Codex | Beta |

--- a/docs/INSTALL.ko.md
+++ b/docs/INSTALL.ko.md
@@ -11,7 +11,7 @@ Skillstead의 각 스킬은 폴더 하나로 설치할 수 있는 독립 패키�
 
 | 스킬 폴더 | 현재 고정 태그 | 지원 실행 환경 |
 | --- | --- | --- |
-| `svg-infographic` | `svg-infographic/v0.8.3` | Claude Code와 Codex |
+| `svg-infographic` | `svg-infographic/v0.9.0` | Claude Code와 Codex |
 | `docs-claim-check` | `docs-claim-check/v0.9.1` | Claude Code |
 | `github-release-guide` | `github-release-guide/v0.9.0` | Claude Code와 Codex |
 | `writing-quality-editor` | `writing-quality-editor/v0.10.1` | Claude Code와 Codex |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,7 +11,7 @@ Each skill has its own release tag. Choose the matching tag and folder as a pair
 
 | Skill folder | Current pinned tag | Runtime support |
 | --- | --- | --- |
-| `svg-infographic` | `svg-infographic/v0.8.3` | Claude Code and Codex |
+| `svg-infographic` | `svg-infographic/v0.9.0` | Claude Code and Codex |
 | `docs-claim-check` | `docs-claim-check/v0.9.1` | Claude Code |
 | `github-release-guide` | `github-release-guide/v0.9.0` | Claude Code and Codex |
 | `writing-quality-editor` | `writing-quality-editor/v0.10.1` | Claude Code and Codex |

--- a/skills/svg-infographic/CHANGELOG.md
+++ b/skills/svg-infographic/CHANGELOG.md
@@ -11,7 +11,7 @@ automated checks read the topmost released heading to confirm it matches `metada
 `SKILL.md`. The full grammar is documented at
 [`docs/VERSIONING.md`](https://github.com/kyungseo/skillstead/blob/main/docs/VERSIONING.md).
 
-## [Unreleased]
+## [0.9.0] — 2026-08-09
 
 - Added opt-in source layout contracts for panel title/subtitle/divider budgets and icon-text card center alignment,
   with deterministic error/warning fixtures for provable and unsupported geometry.

--- a/skills/svg-infographic/README.ko.md
+++ b/skills/svg-infographic/README.ko.md
@@ -50,8 +50,9 @@ svg-infographic으로 이 아키텍처 메모를 수정 가능한 한국어 기�
 3. **레이아웃 계산** — 그리기 전에 캔버스 영역, 카드 격자와 박스별 글자 분량을 *수치로*
    확정합니다. 박스에 들어가지 않을 문구는 렌더링이 깨진 뒤가 아니라 이 단계에서 줄입니다.
 4. **SVG 작성과 source lint** — 계산한 수치에 맞춰 SVG를 작성한 뒤,
-   `scripts/check-svg.mjs`로 끊어진 참조, 명시하지 않았거나 지나치게 큰 marker 크기와 명백한
-   text overflow를 찾습니다. 추정에 따른 warning은 통과로 간주하지 않고 직접 확인합니다.
+   `scripts/check-svg.mjs`로 끊어진 참조, 명시하지 않았거나 지나치게 큰 marker 크기, opt-in
+   header/card 배치 오류와 명백한 text overflow를 찾습니다. 추정에 따른 warning은 통과로 간주하지
+   않고 직접 확인합니다.
 5. **렌더링과 검증** — 표준 `scripts/render.mjs`로 2× PNG를 내보냅니다. 선택형 Bash wrapper인
    `scripts/render.sh`도 같은 렌더러를 호출합니다. 렌더러는 browser를 열기 전에 lint를 다시 실행하고
    PNG 크기를 자동 확인하며, 그다음 실제 이미지의 렌더링, 배치와 메시지를 검토합니다.
@@ -192,8 +193,10 @@ svg-infographic으로 아래 내용을 한국어 기술 인포그래픽으로 �
 
 결과물은 마지막에 한 번만 보는 것이 아니라 세 가지 관점에서 점검합니다.
 
-- **렌더링 전 원본** — source lint가 hard error의 위치와 수정 방향을 알려줍니다. 영역 포함 관계,
-  색상 대비, 영문판과 한국어판의 배치 일치와 heuristic warning은 별도로 직접 확인합니다.
+- **렌더링 전 원본** — source lint가 hard error의 위치와 수정 방향을 알려줍니다. 반복되는 page title,
+  panel header와 icon-text card에는 layout contract를 적용해 rail 범위, divider 여백과 공통 세로 중심을
+  검사할 수 있습니다. 영역 포함 관계, 렌더링된 글자의 시각적 정렬, 색상 대비, 영문판과 한국어판의
+  배치 일치와 heuristic warning은 별도로 직접 확인합니다.
 - **PNG 렌더링** — 글자가 넘치지 않는지, 한국어/CJK 글자가 깨지지 않는지, PNG 크기가 정확히
   2×인지, 아이콘이 정상적으로 보이는지, SVG가 계속 편집 가능한지 확인합니다.
 - **메시지** — 다이어그램 유형이 내용에 맞는지, 읽는 순서가 분명한지, 제목이 결론을 담는지,

--- a/skills/svg-infographic/README.md
+++ b/skills/svg-infographic/README.md
@@ -47,8 +47,8 @@ The skill follows a fixed five-step workflow designed so the **first render pass
 2. **Archetype** — picks the diagram shape from your content (see the table below) and loads that archetype's layout skeleton, visual guidance, and failure checks.
 3. **Layout pass** — fixes the canvas regions, card grid, and per-box text budgets *numerically* before drawing. Copy that won't fit its box is shortened here — not after a broken render.
 4. **Author + source lint** — writes the SVG from the computed numbers, runs `scripts/check-svg.mjs` to catch
-   broken references, implicit or extreme marker sizing, and high-confidence text overflow, then reviews any
-   heuristic warnings instead of treating them as a pass.
+   broken references, implicit or extreme marker sizing, opt-in header/card layout drift, and high-confidence
+   text overflow, then reviews any heuristic warnings instead of treating them as a pass.
 5. **Render + verify** — exports a 2× PNG via the canonical `scripts/render.mjs`. The optional
    `scripts/render.sh` Bash wrapper calls the same renderer. It runs the lint again before opening a browser and
    verifies the PNG dimensions; the skill then reviews the pixels against a quality bar (rendering, containment,
@@ -182,8 +182,10 @@ The skill proposes an output directory inside your current project before writin
 
 The skill checks the output at three stages, not just at the end:
 
-- **Pre-render (source)** — the source lint reports hard failures with a location and suggested fix; remaining
-  containment arithmetic, contrast classes, EN/KO geometry parity, and heuristic warnings are reviewed explicitly.
+- **Pre-render (source)** — the source lint reports hard failures with a location and suggested fix. Repeated
+  page-title, panel-header, and icon-text-card structures can opt into layout contracts that check rail bounds,
+  divider clearance, and shared vertical centers. Remaining containment arithmetic, rendered-ink alignment,
+  contrast classes, EN/KO geometry parity, and heuristic warnings are reviewed explicitly.
 - **Rendering (PNG)** — no text overflow, correct Korean/CJK glyphs (no tofu), PNG dimensions verified as exactly 2× (automated by the render script), icons render, and the SVG stays editable.
 - **Message** — the archetype fits the content, there is one clear reading order, the title carries the conclusion, text density stays low per box, and the depth and language fit your audience.
 

--- a/skills/svg-infographic/SKILL.md
+++ b/skills/svg-infographic/SKILL.md
@@ -3,7 +3,7 @@ name: svg-infographic
 description: Author technical/structured SVG infographics and diagrams, then render them to crisp PNG with a headless browser. Best for architecture diagrams, topology maps, flows, before/after comparisons, nested/onion layer models, roadmaps, decision matrices, and social-ready technical one-pagers. Prefers clean line icons in soft tinted circles. First-class Korean/CJK text. Includes an opt-in "tidy hand-drawn" sketch preset (paper background, Korean handwriting font, rough strokes, highlighter). Not for photo-heavy or illustration-heavy graphics, statistical charts, or mascot/character illustration.
 license: LICENSE.txt
 metadata:
-  version: 0.8.3
+  version: 0.9.0
 ---
 
 # svg-infographic


### PR DESCRIPTION
## What changed

- bumps `svg-infographic` from `0.8.3` to `0.9.0` under the repository's minor-version policy
- promotes the package changelog entry from `[Unreleased]` to `[0.9.0] — 2026-08-09`
- documents the opt-in page-title, panel-header, and icon-text-card layout guards in the English and Korean package READMEs
- updates both root catalog versions and both pinned installation tags
- records the release in the root changelog
- adds bilingual GitHub Release notes with the required Latest marker and source-archive boundary

## Why

PR #43 added observable layout-lint contracts and behavior, which requires a minor release. These release surfaces keep the package version, catalog, installation instructions, changelogs, and user-facing notes aligned before the tag is created.

## User impact

Users installing the pinned `svg-infographic/v0.9.0` tag receive source-level checks for recurring title-rail, panel-header, and icon/text-card alignment drift. Existing SVGs remain unaffected unless they opt into the new `data-layout-role` annotations.

## Validation

- repository tests: `178/178`
- repository validator: `0 finding(s)`
- generic skill validator: `Skill is valid!`
- `git diff --check`
- English/Korean claim, limitation, identifier, and install-pin parity reviewed

## Release boundary

This PR prepares the release surface only. It does not create `svg-infographic/v0.9.0` or publish a GitHub Release. Tag creation and Release publication remain separate approval units after merge and release preflight.
