### PR TITLE
release(writing-quality-editor): prepare v0.11.0

### DIFF
--- a/.skillstead/release-notes/writing-quality-editor-v0.11.0.md
+++ b/.skillstead/release-notes/writing-quality-editor-v0.11.0.md
@@ -1,0 +1,40 @@
+> **Latest** refers to the most recently published individual skill release, not a catalog version.
+
+## writing-quality-editor 0.11.0
+
+This minor release makes wording and naturalness requests start with local editing when the document's paragraph
+and section order already works. The skill marks the smallest complete phrase, clause, or sentence with a concrete
+reader problem, leaves the surrounding text unchanged, and checks every resulting delta against that marked change surface.
+It can still use structural revision when it identifies a separate structural problem.
+
+The naturalness pass now turns indirect metaphors and nominalized instructions into concrete actor-and-action
+wording without using a mechanical replacement list. If a phrase could mean discretion, approval, or notification,
+the skill leaves that span unchanged under `Needs Human` and continues with other safe edits. Direct short-text
+requests return only the usable revision by default, or the unchanged source when no edit is needed.
+
+### 한국어
+
+이번 minor release부터 문장 표현이나 자연스러움을 고쳐 달라는 요청은 기존 문단과 섹션 순서에 문제가
+없는 한 국소 편집부터 시작합니다. 독자가 실제로 막히는 가장 작은 완결된 구·절·문장만 수정 대상으로
+표시하고 나머지는 수정 범위에서 제외합니다. 구조 문제가 별도로 확인된 경우에만 구조 변경으로 범위를 넓힙니다.
+
+간접적인 은유나 명사형 지시는 기계적인 치환 목록이 아니라 문맥에 맞는 주체와 행동이 보이는 문장으로
+고칩니다. 하나의 표현이 임의 변경, 승인 없는 변경, 사전 고지 없는 변경 중 무엇을 뜻하는지 확정할 수
+없다면 해당 구간은 그대로 두고 `Needs Human`으로 표시한 뒤, 안전한 다른 부분만 계속 다듬습니다. 짧은
+문장 수정 요청에는 기본적으로 수정한 문장만, 고칠 필요가 없다면 원문만 반환합니다.
+
+## Evidence And Limits
+
+- Package: `skills/writing-quality-editor/`
+- Tag: `writing-quality-editor/v0.11.0`
+- Validation: repository tests `178/178`, repository validator `0 finding(s)`, generic skill validator
+  `Skill is valid!`, and `git diff --check` pass
+- Runtime observation: a corrected project-local targeted run passed Codex F28-B; Codex F25 changed one locked
+  span to an equivalent phrase; Claude Code F12 preserved the source but added a disproportionate report
+- Compatibility or migration: no migration is required; replace the complete installed skill folder when updating
+- Known limitations: agent output is non-deterministic. The new defaults reduce unnecessary changes but do not
+  guarantee that every run avoids preference-driven changes outside the marked spans; review the final delta for
+  important documents
+
+The versioned unit is the package above. GitHub's source archive is a snapshot of the whole repository at the
+tagged commit; it is not a standalone package artifact.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Granular, per-change entries begin at the first public release. Earlier developm
 - `svg-infographic` `0.9.0` — opt-in source layout contracts for panel headers, icon-text cards, and one-line or
   two-line page-title rails, with deterministic failures for provable geometry drift and warnings for unsupported
   source geometry.
+- `writing-quality-editor` `0.11.0` — local-first revision for wording and naturalness requests, smallest complete
+  span boundaries, ambiguity holds for discretion/approval/notification meaning, and proportional direct
+  short-text output. Important documents still require final delta review because agent output is non-deterministic.
 
 ## 2026-07-30
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,7 +47,7 @@
 | [`svg-infographic`](./skills/svg-infographic) | 아키텍처 설명, 작업 흐름, 비교 자료를 수정 가능한 SVG와 검증된 2× PNG로 제작 | `0.9.0` | Supported: Claude Code + Codex | Stable |
 | [`docs-claim-check`](./skills/docs-claim-check) | 공개 문서의 주장이 제공된 근거로 뒷받침되는지 확인 | `0.9.1` | Claude Code | Beta |
 | [`github-release-guide`](./skills/github-release-guide) | 비공개 GitHub 저장소의 첫 공개 전환 또는 공개 후 매 버전 릴리스를 점검하고 단계별로 안내 | `0.9.0` | Supported: Claude Code + Codex | Stable |
-| [`writing-quality-editor`](./skills/writing-quality-editor) | 사용자 문서를 처음부터 작성하거나 자연스럽게 다듬고, 사실·의도·목소리·운영 제약을 보존하면서 영어↔한국어 내용을 재구성 | `0.10.1` | Supported: Claude Code + Codex | Beta |
+| [`writing-quality-editor`](./skills/writing-quality-editor) | 사용자 문서를 처음부터 작성하거나 자연스럽게 다듬고, 사실·의도·목소리·운영 제약을 보존하면서 영어↔한국어 내용을 재구성 | `0.11.0` | Supported: Claude Code + Codex | Beta |
 
 각 스킬은 필요한 파일을 모두 갖춘 독립 패키지입니다. 전체 목록을 설치할 필요 없이, 사용할 스킬의
 폴더만 통째로 복사하면 됩니다. 개인용·프로젝트용 설치 경로, 고정 버전 설치, 깨끗한 업데이트 방법,

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ required pipeline: start with the skill you need, skip the others, and recheck a
 | [`svg-infographic`](./skills/svg-infographic) | Turning architecture notes, process flows, comparisons, and technical concepts into editable SVG + verified 2× PNG | `0.9.0` | Supported: Claude Code + Codex | Stable |
 | [`docs-claim-check`](./skills/docs-claim-check) | Checking whether public documentation claims are supported by supplied evidence | `0.9.1` | Claude Code | Beta |
 | [`github-release-guide`](./skills/github-release-guide) | Guiding a private repository's first public transition and every later version release, with separate approval before each change | `0.9.0` | Supported: Claude Code + Codex | Stable |
-| [`writing-quality-editor`](./skills/writing-quality-editor) | Composing and revising user-facing text, plus natural English↔Korean adaptation, without inventing or changing facts, intent, voice, or operational constraints | `0.10.1` | Supported: Claude Code + Codex | Beta |
+| [`writing-quality-editor`](./skills/writing-quality-editor) | Composing and revising user-facing text, plus natural English↔Korean adaptation, without inventing or changing facts, intent, voice, or operational constraints | `0.11.0` | Supported: Claude Code + Codex | Beta |
 
 Each skill is self-contained and can be installed independently. You do not need to install the entire
 catalog—copy only the complete folder for the skill you want to use. See

--- a/docs/INSTALL.ko.md
+++ b/docs/INSTALL.ko.md
@@ -14,7 +14,7 @@ Skillstead의 각 스킬은 폴더 하나로 설치할 수 있는 독립 패키�
 | `svg-infographic` | `svg-infographic/v0.9.0` | Claude Code와 Codex |
 | `docs-claim-check` | `docs-claim-check/v0.9.1` | Claude Code |
 | `github-release-guide` | `github-release-guide/v0.9.0` | Claude Code와 Codex |
-| `writing-quality-editor` | `writing-quality-editor/v0.10.1` | Claude Code와 Codex |
+| `writing-quality-editor` | `writing-quality-editor/v0.11.0` | Claude Code와 Codex |
 
 아래 명령은 `github-release-guide`를 설치하는 예시입니다. 다른 스킬을 설치하려면
 `github-release-guide/v0.9.0`과 `github-release-guide`를 같은 행에 있는 값으로 함께 바꾸세요.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -14,7 +14,7 @@ Each skill has its own release tag. Choose the matching tag and folder as a pair
 | `svg-infographic` | `svg-infographic/v0.9.0` | Claude Code and Codex |
 | `docs-claim-check` | `docs-claim-check/v0.9.1` | Claude Code |
 | `github-release-guide` | `github-release-guide/v0.9.0` | Claude Code and Codex |
-| `writing-quality-editor` | `writing-quality-editor/v0.10.1` | Claude Code and Codex |
+| `writing-quality-editor` | `writing-quality-editor/v0.11.0` | Claude Code and Codex |
 
 The commands below use `github-release-guide` as a worked example. To install another skill, replace both
 `github-release-guide/v0.9.0` and `github-release-guide` with the matching values from the same row. Replacing

--- a/skills/writing-quality-editor/CHANGELOG.md
+++ b/skills/writing-quality-editor/CHANGELOG.md
@@ -11,7 +11,7 @@ automated checks read the topmost released heading to confirm it matches `metada
 `SKILL.md`. The full grammar is documented at
 [`docs/VERSIONING.md`](https://github.com/kyungseo/skillstead/blob/main/docs/VERSIONING.md).
 
-## [Unreleased]
+## [0.11.0] — 2026-08-09
 
 - Made local editing the default for wording, naturalness, and clarity requests when the existing paragraph and
   section order already works. The skill now marks the smallest complete phrase, clause, or sentence with a named

--- a/skills/writing-quality-editor/SKILL.md
+++ b/skills/writing-quality-editor/SKILL.md
@@ -3,7 +3,7 @@ name: writing-quality-editor
 description: Writing Quality Editor (WQE) composes, assesses, revises, and adapts user-facing writing so it reads naturally while preserving meaning, claims, intent, voice, conditions, numbers, identifiers, exceptions, and risks. Use when a user asks to write, review, polish, fix, improve, supplement, clarify, translate, localize, or make a document sound natural; no skill or mode name is required. Covers README, onboarding, release notes, manuals, UI, errors, gallery copy, research-backed briefs, technical comparisons, and natural English↔Korean adaptation. If a host repository workflow owns document classification, path, indexing, lifecycle, or approval, keep it primary and use this skill only as an optional authoring layer. Locale-neutral design; EN↔KO (`ko-KR`) is the initial profile under validation. Do not game detectors, conceal provenance, invent claims, replace evidence review, or bypass host workflows.
 license: LICENSE.txt
 metadata:
-  version: 0.10.1
+  version: 0.11.0
 ---
 
 # Writing Quality Editor


### PR DESCRIPTION
## Summary

- bump writing-quality-editor package metadata and changelog to 0.11.0
- update the bilingual catalog and pinned installation tables
- add the canonical bilingual GitHub Release note

## Validation

- repository tests: 178/178
- repository validator: 0 findings
- generic skill validator: Skill is valid!
- git diff --check

## Release boundary

This PR prepares the release surfaces only. It does not create the tag or publish the GitHub Release.