### PR TITLE
docs: 갤러리 예제 재작성을 root CHANGELOG에 기록한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Granular, per-change entries begin at the first public release. Earlier developm
 
 ## 2026-08-09
 
+### Repository
+
+- **Gallery examples regenerated.** Rebuilt all fourteen `svg-infographic` examples in English and Korean with
+  `svg-infographic` `0.9.0`, so the published SVG and PNG reflect the current authoring contracts. The previous set
+  had drifted — nine of fifteen examples shipped an SVG and a PNG built from different revisions — and three Korean
+  variants carried English labels their own documented prompt did not ask for. Two examples grew taller to fit the
+  new title-rail and connector budgets; the other twelve kept their original canvas.
+- **Gallery preview source.** Added a composite SVG that references the six featured example exports, so the preview
+  can be re-rendered instead of rebuilt from scratch. Sketch examples were re-subset per file, because an embedded
+  font subset only carries the glyphs present when it was made.
+
 ### Skills
 
 - `svg-infographic` `0.9.0` — opt-in source layout contracts for panel headers, icon-text cards, and one-line or


### PR DESCRIPTION
## 무엇을

`#47`의 갤러리 예제 재작성을 root CHANGELOG `2026-08-09` 섹션의 `### Repository` 하위에 기록한다.

## 왜

예제 재작성은 스킬 버전 bump가 아니라 repo 차원 변경이라 `### Skills`의 릴리스 항목만으로는 드러나지 않는다. 기존 `2026-07-30` 섹션도 문서 경로 정비·playbook 추가 같은 repo 변경을 `### Repository`에 남기고 있어 같은 관례를 따랐다.

## 남긴 내용

- 예제 14개를 KO/EN 모두 `svg-infographic` `0.9.0`으로 재생성했다는 사실
- 이전 상태가 어긋나 있었다는 근거 — 15개 중 9개가 서로 다른 revision의 SVG/PNG를 함께 배포
- KO 3건이 자기 prompt가 요구하지 않은 영어 라벨을 달고 있던 것을 교정
- 캔버스를 늘린 2건과 원본을 유지한 12건의 경계
- gallery preview에 재사용 가능한 composite SVG 소스를 추가한 것과 sketch 폰트 재subset 이유

## 검증

`PYTHONPATH=tools python3 -m skillstead_validate repo --repo-root .` → **0 finding**

🤖 Generated with [Claude Code](https://claude.com/claude-code)