### PR TITLE
feat(svg-infographic): CP2B batch 1 — process-flow·approval-gate를 등록한다

### DIFF
--- a/skills/svg-infographic/references/types/inputs/approval-gate.canonical.yaml
+++ b/skills/svg-infographic/references/types/inputs/approval-gate.canonical.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: approval-gate
 case: canonical
-preset: social-4x5
+preset: document-compact
 layout: row
 count: 3
 prompt_ko: "요청이 승인 게이트를 지나 반영되는 경로를 보여줘. 4:5."

--- a/skills/svg-infographic/references/types/inputs/approval-gate.stress-copy.yaml
+++ b/skills/svg-infographic/references/types/inputs/approval-gate.stress-copy.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: approval-gate
 case: stress-copy
-preset: social-4x5
+preset: document-compact
 layout: row
 count: 3
 prompt_ko: "노드 이름과 게이트 문구를 예산 한계까지 길게 써줘. 4:5."

--- a/skills/svg-infographic/references/types/inputs/process-flow.canonical.yaml
+++ b/skills/svg-infographic/references/types/inputs/process-flow.canonical.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: process-flow
 case: canonical
-preset: social-4x5
+preset: document-compact
 layout: column
 count: 4
 prompt_ko: "배포 절차를 4단계로 위에서 아래로 보여줘. 4:5 세로."

--- a/skills/svg-infographic/references/types/inputs/process-flow.stress-cardinality.yaml
+++ b/skills/svg-infographic/references/types/inputs/process-flow.stress-cardinality.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: process-flow
 case: stress-cardinality
-preset: social-4x5
+preset: document-compact
 layout: column
 count: 5
 prompt_ko: "배포 절차를 5단계로 위에서 아래로 보여줘. 4:5 세로."

--- a/skills/svg-infographic/references/types/inputs/process-flow.stress-copy.yaml
+++ b/skills/svg-infographic/references/types/inputs/process-flow.stress-copy.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: process-flow
 case: stress-copy
-preset: social-4x5
+preset: document-compact
 layout: column
 count: 4
 prompt_ko: "각 단계 이름을 예산 한계까지 길게 써서 4단계로 보여줘. 4:5 세로."

--- a/skills/svg-infographic/references/types/manifest.yaml
+++ b/skills/svg-infographic/references/types/manifest.yaml
@@ -93,6 +93,8 @@ typepacks:
     support: experimental
     spec: types/specs/cards-kpi-grid.md
     presets: [document-compact, social-4x5, presentation-16x9]
+    # module 규모 카드 묶음은 고정 판형을 채우지 못한다(오너 승인 2026-08-14).
+    preferred_preset: document-compact
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -169,6 +171,8 @@ typepacks:
     support: experimental
     spec: types/specs/layer-stack.md
     presets: [social-4x5, presentation-16x9]
+    # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -224,6 +228,8 @@ typepacks:
     support: experimental
     spec: types/specs/nested-scope.md
     presets: [social-4x5, presentation-16x9]
+    # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -268,6 +274,8 @@ typepacks:
     support: experimental
     spec: types/specs/topology-component.md
     presets: [social-4x5, presentation-16x9]
+    # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -321,7 +329,9 @@ typepacks:
     profile: constrained-layout
     support: experimental
     spec: types/specs/process-flow.md
-    presets: [social-4x5, presentation-16x9]
+    presets: [document-compact, social-4x5, presentation-16x9]
+    # 구조적으로 좁은 flow/band라 고정 판형을 채우지 못한다 — 기본은 fluid, 넓은 구성만 고정 판형.
+    preferred_preset: document-compact
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -335,18 +345,23 @@ typepacks:
     migration_origin: legacy
     legacy_section: "Flow"
     inputs:
-      canonical: { id: process-flow-canonical, path: types/inputs/process-flow.canonical.yaml, preset: social-4x5, layout: column, count: 4 }
+      canonical:
+        id: process-flow-canonical
+        path: types/inputs/process-flow.canonical.yaml
+        preset: document-compact
+        layout: column
+        count: 4
       stress:
         - id: process-flow-stress-cardinality
           path: types/inputs/process-flow.stress-cardinality.yaml
-          preset: social-4x5
+          preset: document-compact
           layout: column
           count: 5
           geometry_expected: fits
           covers: [cardinality-max]
         - id: process-flow-stress-copy
           path: types/inputs/process-flow.stress-copy.yaml
-          preset: social-4x5
+          preset: document-compact
           layout: column
           count: 4
           geometry_expected: fits
@@ -366,6 +381,7 @@ typepacks:
         - { count: 5, layout: row, w: 836, h: 88 }
         - { count: 5, layout: column, w: 132, h: 584 }
       feasibility:
+        - { preset: document-compact, orientation: portrait, count: 5, layout: column, result: fits }
         - { preset: social-4x5, orientation: portrait, count: 5, layout: row, result: needs-split }
         - { preset: social-4x5, orientation: portrait, count: 5, layout: column, result: fits }
         - { preset: presentation-16x9, orientation: landscape, count: 5, layout: row, result: fits }
@@ -375,7 +391,9 @@ typepacks:
     profile: constrained-layout
     support: experimental
     spec: types/specs/approval-gate.md
-    presets: [social-4x5, presentation-16x9]
+    presets: [document-compact, social-4x5, presentation-16x9]
+    # 구조적으로 좁은 flow/band라 고정 판형을 채우지 못한다 — 기본은 fluid, 넓은 구성만 고정 판형.
+    preferred_preset: document-compact
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -389,18 +407,26 @@ typepacks:
     migration_origin: legacy
     legacy_section: "Approval / sequence-lite"
     inputs:
-      canonical: { id: approval-gate-canonical, path: types/inputs/approval-gate.canonical.yaml, preset: social-4x5, layout: row, count: 3 }
+      canonical:
+        id: approval-gate-canonical
+        path: types/inputs/approval-gate.canonical.yaml
+        preset: document-compact
+        layout: row
+        count: 3
       stress:
+        # 오너 판정(2026-08-14): 이 구성은 stress evidence이지 gallery 승격 대상이 아니다.
+        # (선언된 breathing을 허용하는 이유이기도 하다 — 기계 강제는 아니며 승격 심사에서 확인한다.)
         - id: approval-gate-stress-cardinality
           path: types/inputs/approval-gate.stress-cardinality.yaml
           preset: presentation-16x9
           layout: row
           count: 4
+          residual_disposition: { bottom: 484, reason: "4-node band는 fluid 판형의 폭(680)을 넘어 preferred preset을 쓸 수 없다 — 더 넓은 고정 판형을 택한 대가로 남는 세로 breathing이다." }
           geometry_expected: fits
           covers: [cardinality-max]
         - id: approval-gate-stress-copy
           path: types/inputs/approval-gate.stress-copy.yaml
-          preset: social-4x5
+          preset: document-compact
           layout: row
           count: 3
           geometry_expected: fits
@@ -419,6 +445,8 @@ typepacks:
       footprint:
         - { count: 4, layout: row, extraW: 0, extraH: 40, w: 728, h: 128 }
       feasibility:
+        # 4-node band는 fluid 폭(680)을 넘는다 — 그래서 이 구성만 가로 preset을 쓴다.
+        - { preset: document-compact, orientation: portrait, count: 4, layout: row, result: needs-split }
         - { preset: social-4x5, orientation: portrait, count: 4, layout: row, result: needs-split }
         - { preset: presentation-16x9, orientation: landscape, count: 4, layout: row, result: fits }
   - id: before-after
@@ -427,6 +455,8 @@ typepacks:
     support: experimental
     spec: types/specs/before-after.md
     presets: [social-4x5, presentation-16x9]
+    # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -471,6 +501,8 @@ typepacks:
     support: experimental
     spec: types/specs/roadmap-timeline.md
     presets: [social-4x5, presentation-16x9]
+    # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -522,6 +554,8 @@ typepacks:
     support: experimental
     spec: types/specs/decision-matrix.md
     presets: [social-4x5, presentation-16x9]
+    # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/compose-fixtures/manifest.yaml
+++ b/skills/svg-infographic/scripts/compose-fixtures/manifest.yaml
@@ -7,6 +7,7 @@ typepacks:
     support: experimental
     spec: compose-fixtures/specs/summary-cards.md
     presets: [social-4x5]
+    preferred_preset: social-4x5
     orientations: [portrait]
     verifier: null
     receipt_schema: null
@@ -53,6 +54,7 @@ typepacks:
     support: experimental
     spec: compose-fixtures/specs/tree.md
     presets: [social-4x5]
+    preferred_preset: social-4x5
     orientations: [portrait]
     verifier: null
     receipt_schema: null
@@ -101,6 +103,7 @@ typepacks:
     support: experimental
     spec: compose-fixtures/specs/not-composable.md
     presets: [social-4x5]
+    preferred_preset: social-4x5
     orientations: [portrait]
     verifier: null
     receipt_schema: null
@@ -137,6 +140,7 @@ typepacks:
     support: experimental
     spec: compose-fixtures/specs/icon-band.md
     presets: [social-4x5]
+    preferred_preset: social-4x5
     orientations: [portrait]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/generate.mjs
+++ b/skills/svg-infographic/scripts/generate.mjs
@@ -337,6 +337,146 @@ function renderTopology(input, loc, cb, sc, tp, degradeLevel = 0) {
 }
 
 
+
+// ---------- process-flow (main path 한 축, feedback은 되돌이) ----------
+function renderProcessFlow(input, loc, cb, sc, tp) {
+  const steps = input.steps, n = steps.length;
+  const column = sc.layout === "column";
+  const P = tp.fit?.params ?? {};
+  const gap = column ? Number(P.gapY ?? 36) : Number(P.gapX ?? 44);
+  const badge = 26;
+
+  // 카드 크기: 내용에서 파생하고 선언된 floor를 하한으로 둔다(두 locale 최대값 — 기하는 언어에 안정적이어야).
+  const w = column ? Math.min(cb.w, Math.max(Number(P.itemMinW ?? 132), cb.w * 0.62))
+    : (cb.w - (n - 1) * gap) / n;
+  const textW = w - badge - 36;
+  const linesFor = (lc) => steps.map((st) => wrapLines(st.name[lc], textW, 15, true, 2));
+  const maxLines = Math.max(...["ko", "en"].flatMap((lc) => linesFor(lc).map((r) => r.lines.length)));
+  if (["ko", "en"].some((lc) => linesFor(lc).some((r) => r.overflow))) {
+    console.error(`generate: a step name exceeds the §2 line budget at this layout`); process.exit(1);
+  }
+  const h = Math.max(Number(P.itemMinH ?? 88), maxLines * 20 + 40);
+  const x0 = column ? cb.x + (cb.w - w) / 2 : cb.x;
+  const nodes = {}, consumed = [];
+  steps.forEach((st, i) => {
+    nodes[st.id] = column ? { x: x0, y: cb.y + i * (h + gap), w, h }
+      : { x: cb.x + i * (w + gap), y: cb.y, w, h };
+    consumed.push(st.id);
+  });
+  // main path는 인접 단계를 잇는다. feedback이 있으면 되돌이(secondary·dashed)로 마지막 → 첫 단계.
+  const edges = [];
+  for (let i = 0; i + 1 < n; i++) edges.push({ id: `flow-${i + 1}`, from: steps[i].id, to: steps[i + 1].id, weight: "primary" });
+  if (input.feedback) edges.push({ id: "feedback", from: steps[n - 1].id, to: steps[0].id, weight: "secondary", dashed: true });
+
+  const plan = planChannels({ zoneOrder: [], nodeZone: new Map(), nodeIndex: new Map(), edges });
+  const blockH = column ? n * h + (n - 1) * gap : h;
+  const frame = { x: cb.x, y: cb.y, w: cb.w, h: Math.max(blockH + 2 * ROUTE_DEFAULTS.outerClearance, cb.h) };
+  const routed = routeEdges({ nodes, zones: [], plan, frame });
+
+  const laid = linesFor(loc);
+  const nodeArt = steps.map((st, i) => {
+    const b = nodes[st.id], t = laid[i];
+    const ty = b.y + b.h / 2 - (t.lines.length - 1) * 10;
+    return `  <g data-comp-entity="${st.id}" data-entity="${st.id}">
+    <rect x="${r1(b.x)}" y="${r1(b.y)}" width="${r1(b.w)}" height="${r1(b.h)}" rx="12" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1" data-fill-role="surface" data-stroke-role="rule" data-layout-item="flow-column"/>
+    <circle cx="${r1(b.x + 24)}" cy="${r1(b.y + b.h / 2)}" r="13" fill="#E4EDF3" data-fill-role="surface-tint"/>
+    <text x="${r1(b.x + 24)}" y="${r1(b.y + b.h / 2)}" font-size="12" font-weight="700" fill="#2E6DA4" data-fill-role="focus" text-anchor="middle" dominant-baseline="central">${i + 1}</text>
+    <text font-size="15" font-weight="700" fill="#252B35" data-fill-role="ink" dominant-baseline="central">${tspans(t.lines, b.x + badge + 24, ty, 20)}</text>
+  </g>`;
+  });
+  return assemble({ routed, consumed, nodes, zoneArt: [`  <g data-layout-group="flow-column" data-distribution="equal-gap" data-axis="${column ? "y" : "x"}" data-group-count="${n}"></g>`],
+    nodeArt, labels: [], loc, bounds: { x: cb.x, y: cb.y, w: cb.w, h: blockH } });
+}
+
+// ---------- approval-gate (한 행 + 게이트 pill과 기준 caption) ----------
+function renderApprovalGate(input, loc, cb, sc, tp) {
+  const list = input.nodes, n = list.length, g = input.gate;
+  const P = tp.fit?.params ?? {};
+  const gap = Number(P.gapX ?? 56);
+  const w = (cb.w - (n - 1) * gap) / n;
+  const textW = w - 24;
+  const linesFor = (lc) => list.map((nd) => wrapLines(nd.name[lc], textW, 14, true, 2));
+  if (["ko", "en"].some((lc) => linesFor(lc).some((r) => r.overflow))) {
+    console.error("generate: a node name exceeds the §2 line budget at this layout"); process.exit(1);
+  }
+  const maxLines = Math.max(...["ko", "en"].flatMap((lc) => linesFor(lc).map((r) => r.lines.length)));
+  const h = Math.max(Number(P.itemMinH ?? 88), maxLines * 19 + 44);
+  // 게이트 pill은 그것이 지키는 화살표 **위**에 놓고 점선으로 내려 닿게 한다(spec §5).
+  const pillH = 26, pillGap = 18;
+  const rowY = cb.y + pillH + pillGap;
+  const nodes = {}, consumed = [];
+  list.forEach((nd, i) => { nodes[nd.id] = { x: cb.x + i * (w + gap), y: rowY, w, h }; consumed.push(nd.id); });
+  const edges = list.slice(0, -1).map((nd, i) => ({ id: `step-${i + 1}`, from: nd.id, to: list[i + 1].id, weight: "primary" }));
+  const plan = planChannels({ zoneOrder: [], nodeZone: new Map(), nodeIndex: new Map(), edges });
+  const routed = routeEdges({ nodes, zones: [], plan, frame: { x: cb.x, y: cb.y, w: cb.w, h: cb.h } });
+
+  const laid = linesFor(loc);
+  const nodeArt = list.map((nd, i) => {
+    const b = nodes[nd.id], t = laid[i];
+    const ty = b.y + b.h / 2 - (t.lines.length - 1) * 9.5;
+    return `  <g data-comp-entity="${nd.id}" data-entity="${nd.id}">
+    <rect x="${r1(b.x)}" y="${r1(b.y)}" width="${r1(b.w)}" height="${r1(b.h)}" rx="12" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1" data-fill-role="surface" data-stroke-role="rule" data-layout-item="gate-row"/>
+    <text font-size="14" font-weight="700" fill="#252B35" data-fill-role="ink" text-anchor="middle" dominant-baseline="central">${tspans(t.lines, b.x + b.w / 2, ty, 19)}</text>
+  </g>`;
+  });
+
+  // 지키는 화살표를 찾아 그 중점 위에 pill을 세우고 점선을 내린다.
+  const guarded = routed.routes.find((r) => r.from === g.from && r.to === g.to);
+  const labels = [];
+  if (guarded) {
+    const pts = guarded.points;
+    const mid = { x: (pts[0].x + pts[pts.length - 1].x) / 2, y: (pts[0].y + pts[pts.length - 1].y) / 2 };
+    const label = String(g.label[loc]);
+    const pw = 28 + estimateWidth(label, 12, true, 0) + 16;   // icon 자리(28) + 글자 + 오른쪽 여백
+    const px = mid.x - pw / 2, py = rowY - pillGap - pillH;
+    labels.push(`  <g data-comp-entity="${g.id}" data-entity="${g.id}" data-layout-role="gate">
+    <path d="M${r1(mid.x)} ${r1(py + pillH)} V${r1(mid.y)}" fill="none" stroke="#B07A31" stroke-width="1.4" stroke-dasharray="3 3" data-stroke-role="warning"/>
+    <rect x="${r1(px)}" y="${r1(py)}" width="${r1(pw)}" height="${pillH}" rx="${pillH / 2}" fill="#FBF3E6" stroke="#D8B075" stroke-width="1" data-fill-role="surface-tint" data-stroke-role="warning"/>
+    ${icon("check", px + 16, py + pillH / 2, 13)}
+    <text x="${r1(px + 28)}" y="${r1(py + pillH / 2)}" font-size="12" font-weight="700" fill="#8A5D22" data-fill-role="warning" dominant-baseline="central">${esc(label)}</text>
+  </g>`);
+    consumed.push(g.id);
+  }
+  // 기준은 pill 안이 아니라 band 아래 caption이다(spec §5).
+  const capY = rowY + h + 26;
+  labels.push(`  <g data-layout-role="gate-caption">
+    <text x="${r1(cb.x)}" y="${r1(capY)}" font-size="12.5" fill="#636A75" data-fill-role="muted" dominant-baseline="central">${esc(g.criterion[loc])}</text>
+  </g>`);
+  return assemble({ routed, consumed, nodes,
+    zoneArt: [`  <g data-layout-group="gate-row" data-distribution="equal-gap" data-axis="x" data-group-count="${n}"></g>`],
+    nodeArt, labels, loc, bounds: { x: cb.x, y: cb.y, w: cb.w, h: capY + 10 - cb.y } });
+}
+
+// 두 renderer가 공유하는 조립 — layer 순서와 배선 receipt는 한 곳에서만 만든다.
+function assemble({ routed, consumed, zoneArt, nodeArt, labels, bounds }) {
+  const EDGE = "#7C93AB";
+  const connectors = routed.routes.map((rt) => {
+    const shaft = rt.weight === "primary" ? 2.5 : 2.2;
+    return `  <g data-comp-entity="${rt.id}"><path data-route-id="${rt.id}" data-route-from="${rt.from}" data-route-to="${rt.to}" data-route-kind="${rt.kindPath}" data-route-weight="${rt.weight}" data-route-role="${rt.role ?? "flow"}" d="${pathData(rt)}" fill="none" data-stroke-role="edge-line" stroke="${EDGE}" stroke-width="${shaft}" stroke-linecap="round" stroke-linejoin="round"${rt.style === "dashed" ? ' stroke-dasharray="5 4"' : ""} marker-end="url(#${rt.weight === "primary" ? "ah-primary" : "ah-secondary"})"/></g>`;
+  });
+  const defs = `  <defs>
+    ${["ah-primary", "ah-secondary"].map((id, i) => {
+      const shaft = i === 0 ? 2.5 : 2.2, mw = r1(4.5 * shaft);
+      return `<marker id="${id}" viewBox="0 0 12 12" refX="9" refY="6" markerWidth="${mw}" markerHeight="${mw}" markerUnits="userSpaceOnUse" orient="auto-start-reverse"><path d="M2 2 L10 6 L2 10" fill="none" data-stroke-role="edge-line" stroke="${EDGE}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></marker>`;
+    }).join("\n    ")}
+  </defs>`;
+  const body = [defs,
+    `  <g data-layer="containers">`, ...zoneArt, `  </g>`,
+    `  <g data-layer="connectors">`, ...connectors, `  </g>`,
+    `  <g data-layer="nodes">`, ...nodeArt, `  </g>`,
+    `  <g data-layer="annotations">`, ...labels, `  </g>`];
+  if (routed.problems.length) {
+    return { needsSplit: true, consumed: [], routing: { degradeLevel: 0, ladder: [], problems: routed.problems,
+      diagnostics: routed.diagnostics, attempts: routed.attempts, hops: routed.hopCount,
+      unrouted: routed.diagnostics.map((d) => d.subject), edgeCount: routed.routes.length + routed.diagnostics.length } };
+  }
+  return { body: body.join("\n"), consumed, bounds,
+    routing: { degradeLevel: 0, ladder: [], problems: [], hops: routed.hopCount, legend: routed.legendRequired,
+      alignment: [], attempts: routed.attempts, diagnostics: routed.diagnostics, demoted: [],
+      routes: routed.routes.map((rt) => ({ id: rt.id, from: rt.from, to: rt.to, path: rt.kindPath,
+        ports: [rt.sideFrom, rt.sideTo], bends: rt.bends, style: rt.style, targetGap: rt.targetGap, hops: rt.hops.length })) } };
+}
+
 // ---------- font delivery (portable = 사용 glyph subset embed) ----------
 // 계약: portable은 대상 환경의 설치 글꼴에 의존하지 않는다. subset 도구가 없거나 glyph가
 // 빠지면 **full embed로도, system fallback으로도 조용히 넘어가지 않고 실패한다**.
@@ -429,7 +569,9 @@ function build(argv) {
   }
   const render = (cbox) => tid === "cards-kpi-grid" ? renderCards(input, loc, cbox, sc, tp)
     : tid === "topology-component" ? renderTopology(input, loc, cbox, sc, tp)
-    : (console.error(`generate: canary supports cards-kpi-grid and topology-component only (got ${tid})`), process.exit(2));
+    : tid === "process-flow" ? renderProcessFlow(input, loc, cbox, sc, tp)
+    : tid === "approval-gate" ? renderApprovalGate(input, loc, cbox, sc, tp)
+    : (console.error(`generate: no renderer registered for "${tid}"`), process.exit(2));
   let pf = spawnJson([skinCli, "pageframe", preset, "--json"], "skin.mjs pageframe");
   if (pf.regions.fluid) {
     // fluid 캔버스는 내용 높이를 따라간다 — 블록을 먼저 재고 그 높이로 프레임을 다시 만든다.
@@ -441,7 +583,8 @@ function build(argv) {
   const geometry = need.w <= cb.w && need.h <= cb.h ? "fits" : "needs-split";
   const expected = sc.geometry_expected ?? "fits";
   const base = { schemaVersion: 1, command: "generate", typepack: tid, case: sc.id, locale: loc,
-    preset, presetDeclared: tp.presets.includes(preset), audition: Boolean(override) && !tp.presets.includes(preset), layout: sc.layout, count: Number(sc.count), inputDigest,
+    preset, presetDeclared: tp.presets.includes(preset), presetPreferred: tp.preferred_preset ?? null,
+    presetsSupported: tp.presets ?? [], audition: Boolean(override) && !tp.presets.includes(preset), layout: sc.layout, count: Number(sc.count), inputDigest,
     geometry, geometryExpected: expected, routingExpected: sc.routing_expected ?? null,
     footprint: { w: r1(need.w), h: r1(need.h) }, contentBox: { w: cb.w, h: cb.h } };
 
@@ -533,6 +676,11 @@ ${R.body}
 function semanticIds(input, tid) {
   const ids = [];
   if (tid === "cards-kpi-grid") for (const c of input.cards ?? []) ids.push(c.id);
+  if (tid === "process-flow") for (const st of input.steps ?? []) ids.push(st.id);
+  if (tid === "approval-gate") {
+    for (const nd of input.nodes ?? []) ids.push(nd.id);
+    if (input.gate?.id) ids.push(input.gate.id);
+  }
   if (tid === "topology-component") {
     for (const z of input.zones ?? []) { ids.push(z.id); for (const n of z.nodes ?? []) ids.push(n.id); }
     for (const e of input.edges ?? []) ids.push(e.id);

--- a/skills/svg-infographic/scripts/skin-fixtures/manifest-bad-role.yaml
+++ b/skills/svg-infographic/scripts/skin-fixtures/manifest-bad-role.yaml
@@ -7,6 +7,7 @@ typepacks:
     support: experimental
     spec: skin-fixtures/types/fixture-spec.md
     presets: [social-4x5, presentation-16x9]
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/skin-fixtures/manifest-comp-bad-aspect.yaml
+++ b/skills/svg-infographic/scripts/skin-fixtures/manifest-comp-bad-aspect.yaml
@@ -7,6 +7,7 @@ typepacks:
     support: experimental
     spec: skin-fixtures/types/fixture-spec.md
     presets: [social-4x5, presentation-16x9]
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/skin-fixtures/manifest-comp-bad-port.yaml
+++ b/skills/svg-infographic/scripts/skin-fixtures/manifest-comp-bad-port.yaml
@@ -7,6 +7,7 @@ typepacks:
     support: experimental
     spec: skin-fixtures/types/fixture-spec.md
     presets: [social-4x5, presentation-16x9]
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/skin-fixtures/manifest-comp-positive.yaml
+++ b/skills/svg-infographic/scripts/skin-fixtures/manifest-comp-positive.yaml
@@ -7,6 +7,7 @@ typepacks:
     support: experimental
     spec: skin-fixtures/types/fixture-spec.md
     presets: [social-4x5, presentation-16x9]
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/skin-fixtures/manifest-comp-unknown.yaml
+++ b/skills/svg-infographic/scripts/skin-fixtures/manifest-comp-unknown.yaml
@@ -7,6 +7,7 @@ typepacks:
     support: experimental
     spec: skin-fixtures/types/fixture-spec.md
     presets: [social-4x5, presentation-16x9]
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/skin-fixtures/manifest-dup-id.yaml
+++ b/skills/svg-infographic/scripts/skin-fixtures/manifest-dup-id.yaml
@@ -7,6 +7,7 @@ typepacks:
     support: experimental
     spec: skin-fixtures/types/fixture-spec.md
     presets: [social-4x5, presentation-16x9]
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/skin-fixtures/manifest-missing-spec.yaml
+++ b/skills/svg-infographic/scripts/skin-fixtures/manifest-missing-spec.yaml
@@ -7,6 +7,7 @@ typepacks:
     support: experimental
     spec: skin-fixtures/types/no-such-spec.md
     presets: [social-4x5, presentation-16x9]
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/skin-fixtures/manifest-positive.yaml
+++ b/skills/svg-infographic/scripts/skin-fixtures/manifest-positive.yaml
@@ -7,6 +7,7 @@ typepacks:
     support: experimental
     spec: skin-fixtures/types/fixture-spec.md
     presets: [social-4x5, presentation-16x9]
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/skin-fixtures/manifest-unknown-field.yaml
+++ b/skills/svg-infographic/scripts/skin-fixtures/manifest-unknown-field.yaml
@@ -7,6 +7,7 @@ typepacks:
     support: experimental
     spec: skin-fixtures/types/fixture-spec.md
     presets: [social-4x5, presentation-16x9]
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/skin-fixtures/manifest-v1-rejected.yaml
+++ b/skills/svg-infographic/scripts/skin-fixtures/manifest-v1-rejected.yaml
@@ -7,6 +7,7 @@ typepacks:
     support: experimental
     spec: skin-fixtures/types/fixture-spec.md
     presets: [social-4x5, presentation-16x9]
+    preferred_preset: social-4x5
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null

--- a/skills/svg-infographic/scripts/skin.mjs
+++ b/skills/svg-infographic/scripts/skin.mjs
@@ -1377,7 +1377,7 @@ function main() {
       const FIELDS = ["id", "selection_signal", "profile", "support", "spec", "presets",
         "orientations", "verifier", "receipt_schema", "fixtures", "examples",
         "required_roles", "optional_aliases", "canonical_prompt", "annexes", "gate",
-        "migration_origin", "legacy_section", "fit", "inputs", "composition"];
+        "migration_origin", "legacy_section", "fit", "inputs", "composition", "preferred_preset"];
       for (const k of Object.keys(p)) if (!FIELDS.includes(k)) errors.push(`manifest: ${id}: unknown field "${k}" (locked schema: ${FIELDS.join("/")})`);
       for (const k of FIELDS) if (k !== "composition" && !(k in p)) errors.push(`manifest: ${id}: missing field "${k}"`); // composition은 optional capability (absent => composable: false)
       let pfPresets = [];
@@ -1569,6 +1569,10 @@ function main() {
           const want = fits ? "fits" : "needs-split";
           if (fs.result !== want)
             errors.push(`manifest: ${id}: fit.feasibility(${fs.preset}, count ${fs.count}) declares "${fs.result}" but ${Math.round(fp.w)}×${Math.round(fp.h)} against contentBox ${cb.w}×${cb.h} computes "${want}"`);
+        }
+        if (p.preferred_preset !== undefined) {
+          if (!Array.isArray(p.presets) || !p.presets.includes(p.preferred_preset))
+            errors.push(`manifest: ${id}: preferred_preset "${p.preferred_preset}" must be one of the declared presets`);
         }
         for (const pr of (Array.isArray(p.presets) ? p.presets : []))
           if (!seen.has(`${pr}:${card.max}`)) errors.push(`manifest: ${id}: fit.feasibility must cover preset "${pr}" at the maximum cardinality (${card.max})`);


### PR DESCRIPTION
## 요약

CP2B 두 번째 단계. connector-heavy 유형 2종(`process-flow`, `approval-gate`)을 **기존 router 위에** 올리고, 판형은 공통 선택 규칙으로 확정한다.

## router 재사용

별도 배선 코드 없이 기존 router로 라우팅됐다 — process-flow main path는 전부 0-bend 수직 직선, approval-gate는 0-bend 수평 직선. gate pill은 그것이 지키는 화살표 위에 놓여 점선으로 닿는다(spec §5). 새 배선 계약 결손은 나오지 않았다.

## batch가 잡아낸 것

- `semanticIds`에 두 TypePack이 없어 산출물 전체가 invented entity로 판정
- **파생 connector와 caption에 `data-entity`를 찍어 payload에 없는 id를 주장** → 파생 요소는 content entity가 아니므로 route 주석만 남김
- gate pill 폭을 텍스트 폭만으로 계산해 2px overflow

## 판형 선택 규칙

1. 고정 판형에서 의미 있는 콘텐츠 확장 없이 큰 residual이 남으면 fluid 선택
2. 고정 판형을 자연스럽게 채우는 타입은 기존 preset 유지
3. 빈 공간을 없애려고 카드·글자·화살표를 임의 확대하지 않음
4. TypePack별 preferred/supported preset을 manifest와 receipt에 기록
5. 같은 TypePack의 KO/EN은 같은 판형·같은 geometry

두 TypePack은 구조적으로 narrow flow/band라 **fluid document-compact가 preferred**. 6개 시나리오 중 5개가 잔여 0이 됐고, approval-gate 4-node만 band 폭(728px)이 fluid 폭(680px)을 넘어 더 넓은 고정 판형(16:9)을 택하고 남는 breathing을 선언했다(stress evidence이며 gallery 승격 대상 아님).

`preferred_preset`은 9개 TypePack 전부에 기록했고(미평가 타입은 현재 기본값, 해당 batch에서 재평가) validator가 supported 포함 여부를 검사한다.

## 검증

skin 118/118 · route-orthogonal 27/27 · generate 12/12 · check-svg 70/70 · check-layout 34/34 · preflight 29/29 · render 23/23 · font-probe 6/6 · compose 51/51 — **실패 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)