### PR TITLE
feat(svg-infographic): CP2B batch 2 — layer-stack·nested-scope를 등록한다

### DIFF
--- a/skills/svg-infographic/references/types/inputs/layer-stack.canonical.yaml
+++ b/skills/svg-infographic/references/types/inputs/layer-stack.canonical.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: layer-stack
 case: canonical
-preset: social-4x5
+preset: document-compact
 layout: column
 count: 4
 prompt_ko: "플랫폼 역량을 4개 계층으로 쌓아서 보여줘. 4:5."
@@ -15,15 +15,52 @@ layers:
     label:
       ko: "제품 경험"
       en: "Product experience"
+    items:
+      - id: "layer-1-chip-1"
+        label:
+          ko: "검색"
+          en: "Search"
+      - id: "layer-1-chip-2"
+        label:
+          ko: "결제"
+          en: "Checkout"
   - id: "layer-2"
     label:
       ko: "애플리케이션 서비스"
       en: "Application services"
+    items:
+      - id: "layer-2-chip-1"
+        label:
+          ko: "주문"
+          en: "Orders"
+      - id: "layer-2-chip-2"
+        label:
+          ko: "정산"
+          en: "Billing"
   - id: "layer-3"
     label:
       ko: "플랫폼 런타임"
       en: "Platform runtime"
+    items:
+      - id: "layer-3-chip-1"
+        label:
+          ko: "배포"
+          en: "Deploy"
+      - id: "layer-3-chip-2"
+        label:
+          ko: "관측"
+          en: "Observe"
   - id: "layer-4"
     label:
       ko: "데이터 기반"
       en: "Data foundation"
+
+    items:
+      - id: "layer-4-chip-1"
+        label:
+          ko: "적재"
+          en: "Ingest"
+      - id: "layer-4-chip-2"
+        label:
+          ko: "공개"
+          en: "Publish"

--- a/skills/svg-infographic/references/types/inputs/layer-stack.stress-cardinality.yaml
+++ b/skills/svg-infographic/references/types/inputs/layer-stack.stress-cardinality.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: layer-stack
 case: stress-cardinality
-preset: social-4x5
+preset: presentation-16x9
 layout: column
 count: 5
 prompt_ko: "플랫폼 역량을 5개 계층으로 보여줘. 4:5."
@@ -15,19 +15,104 @@ layers:
     label:
       ko: "제품 경험"
       en: "Product experience"
+    items:
+      - id: "layer-1-chip-1"
+        label:
+          ko: "검색"
+          en: "Search"
+      - id: "layer-1-chip-2"
+        label:
+          ko: "추천"
+          en: "Recommend"
+      - id: "layer-1-chip-3"
+        label:
+          ko: "결제"
+          en: "Checkout"
+      - id: "layer-1-chip-4"
+        label:
+          ko: "알림"
+          en: "Notify"
   - id: "layer-2"
     label:
       ko: "애플리케이션 서비스"
       en: "Application services"
+    items:
+      - id: "layer-2-chip-1"
+        label:
+          ko: "주문"
+          en: "Orders"
+      - id: "layer-2-chip-2"
+        label:
+          ko: "정산"
+          en: "Billing"
+      - id: "layer-2-chip-3"
+        label:
+          ko: "재고"
+          en: "Stock"
+      - id: "layer-2-chip-4"
+        label:
+          ko: "배송"
+          en: "Shipping"
   - id: "layer-3"
     label:
       ko: "플랫폼 런타임"
       en: "Platform runtime"
+    items:
+      - id: "layer-3-chip-1"
+        label:
+          ko: "실행"
+          en: "Runtime"
+      - id: "layer-3-chip-2"
+        label:
+          ko: "배포"
+          en: "Deploy"
+      - id: "layer-3-chip-3"
+        label:
+          ko: "관측"
+          en: "Observe"
+      - id: "layer-3-chip-4"
+        label:
+          ko: "보안"
+          en: "Security"
   - id: "layer-4"
     label:
       ko: "데이터 기반"
       en: "Data foundation"
+    items:
+      - id: "layer-4-chip-1"
+        label:
+          ko: "적재"
+          en: "Ingest"
+      - id: "layer-4-chip-2"
+        label:
+          ko: "정제"
+          en: "Clean"
+      - id: "layer-4-chip-3"
+        label:
+          ko: "집계"
+          en: "Aggregate"
+      - id: "layer-4-chip-4"
+        label:
+          ko: "공개"
+          en: "Publish"
   - id: "layer-5"
     label:
       ko: "기반 인프라"
       en: "Foundation infrastructure"
+    items:
+      - id: "layer-5-chip-1"
+        label:
+          ko: "계정"
+          en: "Accounts"
+      - id: "layer-5-chip-2"
+        label:
+          ko: "권한"
+          en: "Access"
+      - id: "layer-5-chip-3"
+        label:
+          ko: "감사"
+          en: "Audit"
+      - id: "layer-5-chip-4"
+        label:
+          ko: "정책"
+          en: "Policy"

--- a/skills/svg-infographic/references/types/inputs/layer-stack.stress-copy.yaml
+++ b/skills/svg-infographic/references/types/inputs/layer-stack.stress-copy.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: layer-stack
 case: stress-copy
-preset: social-4x5
+preset: document-compact
 layout: column
 count: 4
 prompt_ko: "각 계층 이름을 예산 한계까지 길게 써서 4개 계층으로 보여줘. 4:5."

--- a/skills/svg-infographic/references/types/inputs/nested-scope.canonical.yaml
+++ b/skills/svg-infographic/references/types/inputs/nested-scope.canonical.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: nested-scope
 case: canonical
-preset: social-4x5
+preset: document-compact
 layout: concentric
 count: 3
 prompt_ko: "신뢰 경계를 3겹 동심 구조로 보여줘. 4:5."
@@ -23,3 +23,4 @@ rings:
     label:
       ko: "내부 서비스망"
       en: "Internal service mesh"
+    core_icon: "lock"

--- a/skills/svg-infographic/references/types/inputs/nested-scope.stress-cardinality.yaml
+++ b/skills/svg-infographic/references/types/inputs/nested-scope.stress-cardinality.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: nested-scope
 case: stress-cardinality
-preset: social-4x5
+preset: document-compact
 layout: concentric
 count: 4
 prompt_ko: "신뢰 경계를 4겹 동심 구조로 보여줘. 4:5."

--- a/skills/svg-infographic/references/types/inputs/nested-scope.stress-copy.yaml
+++ b/skills/svg-infographic/references/types/inputs/nested-scope.stress-copy.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: nested-scope
 case: stress-copy
-preset: social-4x5
+preset: document-compact
 layout: concentric
 count: 3
 prompt_ko: "각 겹 라벨을 예산 한계까지 길게 써서 3겹으로 보여줘. 4:5."

--- a/skills/svg-infographic/references/types/manifest.yaml
+++ b/skills/svg-infographic/references/types/manifest.yaml
@@ -170,9 +170,10 @@ typepacks:
     profile: constrained-layout
     support: experimental
     spec: types/specs/layer-stack.md
-    presets: [social-4x5, presentation-16x9]
+    presets: [document-compact, social-4x5, presentation-16x9]
     # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
-    preferred_preset: social-4x5
+    # 장면별 실측(잔여 27~62%) 근거로 fluid를 기본으로 한다.
+    preferred_preset: document-compact
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -186,18 +187,20 @@ typepacks:
     migration_origin: legacy
     legacy_section: "Layer stack"
     inputs:
-      canonical: { id: layer-stack-canonical, path: types/inputs/layer-stack.canonical.yaml, preset: social-4x5, layout: column, count: 4 }
+      canonical: { id: layer-stack-canonical, path: types/inputs/layer-stack.canonical.yaml, preset: document-compact, layout: column, count: 4 }
       stress:
         - id: layer-stack-stress-cardinality
           path: types/inputs/layer-stack.stress-cardinality.yaml
-          preset: social-4x5
+          # chip 4개가 fluid 폭에 들어가지 않는다 — 규칙에 따라 더 넓은 지원 preset을 쓴다.
+          preset: presentation-16x9
           layout: column
           count: 5
+          residual_disposition: { bottom: 132, reason: \"chip 4개를 담으려 더 넓은 가로 판형을 택한 대가로 남는 세로 breathing이다 — 띠를 늘려 채우지 않는다.\" }
           geometry_expected: fits
-          covers: [cardinality-max]
+          covers: [cardinality-max, chips-max]
         - id: layer-stack-stress-copy
           path: types/inputs/layer-stack.stress-copy.yaml
-          preset: social-4x5
+          preset: document-compact
           layout: column
           count: 4
           geometry_expected: fits
@@ -218,6 +221,8 @@ typepacks:
         - { count: 5, layout: column, w: 612, h: 520 }
         - { count: 5, layout: column, floor: wide, w: 1084, h: 520 }
       feasibility:
+        - { preset: document-compact, orientation: portrait, count: 5, layout: column, result: fits }
+        - { preset: document-compact, orientation: portrait, count: 5, layout: column, floor: wide, result: needs-split }
         - { preset: social-4x5, orientation: portrait, count: 5, layout: column, result: fits }
         - { preset: social-4x5, orientation: portrait, count: 5, layout: column, floor: wide, result: needs-split }
         - { preset: presentation-16x9, orientation: landscape, count: 5, layout: column, result: fits }
@@ -227,9 +232,10 @@ typepacks:
     profile: constrained-layout
     support: experimental
     spec: types/specs/nested-scope.md
-    presets: [social-4x5, presentation-16x9]
+    presets: [document-compact, social-4x5, presentation-16x9]
     # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
-    preferred_preset: social-4x5
+    # 장면별 실측(잔여 27~62%) 근거로 fluid를 기본으로 한다.
+    preferred_preset: document-compact
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -243,18 +249,18 @@ typepacks:
     migration_origin: legacy
     legacy_section: "Nested / onion"
     inputs:
-      canonical: { id: nested-scope-canonical, path: types/inputs/nested-scope.canonical.yaml, preset: social-4x5, layout: concentric, count: 3 }
+      canonical: { id: nested-scope-canonical, path: types/inputs/nested-scope.canonical.yaml, preset: document-compact, layout: concentric, count: 3 }
       stress:
         - id: nested-scope-stress-cardinality
           path: types/inputs/nested-scope.stress-cardinality.yaml
-          preset: social-4x5
+          preset: document-compact
           layout: concentric
           count: 4
           geometry_expected: fits
           covers: [cardinality-max, containment-depth]
         - id: nested-scope-stress-copy
           path: types/inputs/nested-scope.stress-copy.yaml
-          preset: social-4x5
+          preset: document-compact
           layout: concentric
           count: 3
           geometry_expected: fits
@@ -266,6 +272,7 @@ typepacks:
       footprint:
         - { count: 4, layout: concentric, w: 560, h: 360 }
       feasibility:
+        - { preset: document-compact, orientation: portrait, count: 4, layout: concentric, result: fits }
         - { preset: social-4x5, orientation: portrait, count: 4, layout: concentric, result: fits }
         - { preset: presentation-16x9, orientation: landscape, count: 4, layout: concentric, result: fits }
   - id: topology-component

--- a/skills/svg-infographic/references/types/specs/layer-stack.md
+++ b/skills/svg-infographic/references/types/specs/layer-stack.md
@@ -74,6 +74,12 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
   coordinates.
 - A layer label and its chips share one computed vertical center per band.
 - The optional annotation column reduces `bandWidth` for **every** band equally.
+- Chips are **content-sized** (the widest chip text across locales sets one uniform
+  width); the run is right-aligned so the last chip's right edge meets
+  `bandRight − bandPad` by construction. Everything left of the run is the reserved
+  label column — declared, not implied, so the symmetry check measures from it.
+  A band **without** chips is the minimal variant of this type (canonical carries
+  representative chips; `stress-copy` exercises the chip-less form).
 - **No connectors.** Adjacency carries the dependency; one colour family per layer,
   optional light → saturated progression toward the most important layer; at most
   one band emphasised.

--- a/skills/svg-infographic/scripts/check-layout.mjs
+++ b/skills/svg-infographic/scripts/check-layout.mjs
@@ -17,7 +17,8 @@
 //
 // Annotation grammar:
 //   containers: data-layout-container="<id>" data-min-pad data-layout-count
-//               [data-min-visual-pad=8] [data-reserve-top=0] [data-symmetry=x|y|xy]
+//               [data-min-visual-pad=8] [data-reserve-top=0] [data-reserve-left=0]
+//               [data-symmetry=x|y|xy]
 //               [data-symmetry-tol=4]        (min-pad and layout-count REQUIRED)
 //   membership: data-layout-parent="<id>"
 //   groups:     data-layout-group="<id>" data-distribution="equal-gap"
@@ -163,12 +164,15 @@ export function checkLayoutFile(file) {
     const declaredCount = field(c.a, "data-layout-count", errors, ctx, { required: true });
     const visPad = field(c.a, "data-min-visual-pad", errors, ctx, { def: 8 });
     const reserve = field(c.a, "data-reserve-top", errors, ctx, { def: 0 });
+    // 라벨 열처럼 **가로로** 예약된 구간이 있으면 내용 경계는 그만큼 오른쪽에서 시작한다.
+    const reserveLeft = field(c.a, "data-reserve-left", errors, ctx, { def: 0 });
     const symTol = field(c.a, "data-symmetry-tol", errors, ctx, { def: 4 });
     const symAxes = c.a["data-symmetry"] ?? "";
     if (!["", "x", "y", "xy"].includes(symAxes)) errors.push(`E-LAYOUT-SCHEMA ${ctx}: data-symmetry must be x|y|xy (got "${symAxes}")`);
     if (minPad == null || declaredCount == null) continue;
     const frame = { x: c.geom.x, y: c.geom.y, x2: c.geom.x + c.geom.w, y2: c.geom.y + c.geom.h };
-    const contentTop = frame.y + reserve; // title reservation excluded from content bounds
+    const contentTop = frame.y + reserve;     // title reservation excluded from content bounds
+    const contentLeft = frame.x + reserveLeft; // label-column reservation, same idea on the x axis
     const kids = els.filter((e) => e.a["data-layout-parent"] === id);
     // title participant: 실측 line-box (중앙 baseline: y ± 0.6×font-size 보수 범위)
     const titleEls = els.filter((e) => e.a["data-layout-title"] === id);
@@ -210,10 +214,10 @@ export function checkLayoutFile(file) {
       const kid = k.a["data-layout-container"] || k.a["data-layout-item"] || k.a["data-cluster-id"] || "child";
       if (k.uv) continue;  // unverified 멤버: 집계만, 검증은 exit 3 검토 상태
       if (!k.geom) { errors.push(`E-LAYOUT-SCHEMA ${ctx}/${kid}: layout child must carry numeric rect/circle bounds`); continue; }
-      const gi = { left: k.geom.x - frame.x, right: frame.x2 - (k.geom.x + k.geom.w),
-                   top: k.geom.y - frame.y, bottom: frame.y2 - (k.geom.y + k.geom.h) };
-      const vi = { left: k.vis.x - frame.x, right: frame.x2 - k.vis.x2,
-                   top: k.vis.y - frame.y, bottom: frame.y2 - k.vis.y2 };
+      const gi = { left: k.geom.x - contentLeft, right: frame.x2 - (k.geom.x + k.geom.w),
+                   top: k.geom.y - contentTop, bottom: frame.y2 - (k.geom.y + k.geom.h) };
+      const vi = { left: k.vis.x - contentLeft, right: frame.x2 - k.vis.x2,
+                   top: k.vis.y - contentTop, bottom: frame.y2 - k.vis.y2 };
       for (const side of ["left", "right", "top", "bottom"]) {
         if (vi[side] <= 0)
           errors.push(`E-LAYOUT-TOUCH ${ctx}/${kid}: visual ${side} edge touches or crosses the parent edge (${r1(vi[side])}px)`);
@@ -223,6 +227,8 @@ export function checkLayoutFile(file) {
           errors.push(`E-LAYOUT-PAD ${ctx}/${kid}: ${side} inset ${r1(gi[side])}px < declared min padding ${minPad}px`);
         geo[side].push(gi[side]); vis[side].push(vi[side]);
       }
+      if (reserveLeft > 0 && k.vis.x < contentLeft - 0.5)
+        errors.push(`E-LAYOUT-RESERVE ${ctx}: child "${k.a["data-layout-item"] ?? k.a["data-layout-parent"]}" starts left of the declared data-reserve-left boundary`);
       if (reserve > 0 && k.vis.y < contentTop - 0.5)
         errors.push(`E-LAYOUT-RESERVE ${ctx}/${kid}: visual top ${r1(k.vis.y)} enters the title reservation (content starts at ${r1(contentTop)}) — title and content collide`);
       if (titleBox && titleGapMin != null && k.vis.y - titleBox.bottom < titleGapMin - 0.05)
@@ -303,7 +309,9 @@ export function checkLayoutFile(file) {
     const pc = parentId && containers.get(parentId);
     if (pc && items.every((i2) => i2.a["data-layout-parent"] === parentId)) {
       const reserve = num(pc.a["data-reserve-top"]) || 0;
-      const cL = axis === "x" ? pc.geom.x : pc.geom.y + reserve;
+      const pcReserveTop = num(pc.a["data-reserve-top"]) || 0;
+      const pcReserveLeft = num(pc.a["data-reserve-left"]) || 0;
+      const cL = axis === "x" ? pc.geom.x + pcReserveLeft : pc.geom.y + pcReserveTop;
       const cR = axis === "x" ? pc.geom.x + pc.geom.w : pc.geom.y + pc.geom.h;
       outer = { start: r1(glo(items[0]) - cL), end: r1(cR - ghi(items[items.length - 1])) };
       const tol = num(pc.a["data-symmetry-tol"]) || 4;

--- a/skills/svg-infographic/scripts/check-layout.test.mjs
+++ b/skills/svg-infographic/scripts/check-layout.test.mjs
@@ -111,3 +111,11 @@ test("data-layout-unverified는 exit 3 (명시적 검토 상태, 성공 아님)"
   assert.equal(r.code, 3, r.out);
   assert.match(r.out, /explicit review state, not a pass/);
 });
+
+// --- 가로 예약(data-reserve-left) — 세로 예약과 같은 개념의 축 대칭 -----------------
+test("positive: 라벨 열을 예약하면 내용은 예약 경계 기준으로 대칭 판정된다", () => {
+  const r = run([path.join(FIX, "lp-reserve-left.svg")]);
+  assert.equal(r.code, 0, r.out);
+});
+test("12 예약된 라벨 열 안으로 자식이 들어가면 거부", () =>
+  neg("ln-reserve-left-breach.svg", /E-LAYOUT-RESERVE container "band"/));

--- a/skills/svg-infographic/scripts/generate.mjs
+++ b/skills/svg-infographic/scripts/generate.mjs
@@ -70,6 +70,12 @@ function computeFit(tp, sc) {
     const npz = Number(prm.maxNodesPerZone), pad = Number(prm.zonePad), band = Number(prm.zoneLabelBand), zg = Number(prm.zoneGap);
     return { w: npz * iw + (npz - 1) * gx + 2 * pad, h: n * (band + ih + 2 * pad) + (n - 1) * zg };
   }
+  if (sc.layout === "concentric") {
+    // 동심은 ring마다 사방으로 같은 inset이 들어간다(manifest validator와 동일한 식).
+    // label은 그 위쪽 inset 띠 안에 앉는다 — 별도 strip을 더하지 않는다.
+    const inset = Number(prm.inset);
+    return { w: iw + 2 * (n - 1) * inset, h: ih + 2 * (n - 1) * inset };
+  }
   console.error(`generate: unsupported layout "${sc.layout}"`); process.exit(1);
 }
 
@@ -477,6 +483,115 @@ function assemble({ routed, consumed, zoneArt, nodeArt, labels, bounds }) {
         ports: [rt.sideFrom, rt.sideTo], bends: rt.bends, style: rt.style, targetGap: rt.targetGap, hops: rt.hops.length })) } };
 }
 
+
+// ---------- layer-stack (연결선 없음 — 인접이 관계다) ----------
+function renderLayerStack(input, loc, cb, sc, tp) {
+  const layers = input.layers, n = layers.length;
+  const P = tp.fit?.params ?? {};
+  const gapY = Number(P.gapY ?? 20), pad = 18, chipGap = 12;
+  const bandW = cb.w;
+  const labelW = Math.max(...["ko", "en"].flatMap((lc) => layers.map((L) => estimateWidth(L.label[lc], 15, true, 0))));
+  // chip 폭은 band에서만 파생하지 않는다 — **실제 chip 문안**(두 locale 최대)이 들어가야 한다.
+  const chipPad = 12;
+  const maxChips = Math.max(0, ...layers.map((L) => (L.items ?? []).length));
+  const chipTextW = Math.max(0, ...["ko", "en"].flatMap((lc) =>
+    layers.flatMap((L) => (L.items ?? []).map((c) => estimateWidth(c?.label?.[lc] ?? "", 12, false, 0)))));
+  const chipNeed = maxChips ? chipTextW + 2 * chipPad : 0;
+  const chipRunNeed = maxChips ? maxChips * chipNeed + (maxChips - 1) * chipGap : 0;
+  // chip은 내용 폭으로 크기를 정한다 — 남는 공간을 채우려고 늘리지 않는다.
+  // 대신 **마지막 chip의 오른쪽 끝**이 band 안쪽 끝과 계산으로 만나도록 run을 오른쪽에 붙인다(spec §5).
+  const chipW = maxChips ? Math.max(chipNeed, 72) : 0;
+  const runW = maxChips ? maxChips * chipW + (maxChips - 1) * chipGap : 0;
+  const runStart = cb.x + bandW - pad - runW;
+  // run 왼쪽은 전부 라벨 열 + 여백으로 예약된다(내용이 쓸 수 없는 구간).
+  const labelCol = maxChips ? runStart - pad - cb.x : Math.min(bandW * 0.42, labelW + 2 * pad);
+  if (maxChips && labelCol < labelW + pad) {
+    console.error(`generate: the layer label needs ${r1(labelW + pad)}px but the chip run leaves ${r1(labelCol)}px — shorten the label or the chips (spec §6), or choose a wider preset`);
+    process.exit(1);
+  }
+  const h = Math.max(Number(P.itemMinH ?? 88), 64);
+  const consumed = [], bandArt = [], chipArt = [];
+  layers.forEach((L, i) => {
+    const y = cb.y + i * (h + gapY);
+    consumed.push(L.id);
+    const chips = L.items ?? [];
+    // 마지막 chip의 오른쪽 끝은 계산으로 band 안쪽 끝과 만난다(수기 좌표 금지, spec §5)
+    const m = chips.length;
+
+    const chipY = y + h / 2 - 13;
+    bandArt.push(`  <g data-comp-entity="${L.id}" data-entity="${L.id}" data-layout-role="band">
+    <rect x="${r1(cb.x)}" y="${r1(y)}" width="${r1(bandW)}" height="${r1(h)}" rx="12" fill="#F4F8FC" stroke="#DEE0E2" stroke-width="1" data-fill-role="surface-tint" data-stroke-role="rule" data-layout-item="layer-stack" data-layout-container="${L.id}" data-min-pad="${pad}" data-layout-count="${m}"${m ? ` data-reserve-left="${r1(labelCol)}" data-symmetry="x"` : ""}/>
+    <text x="${r1(cb.x + pad)}" y="${r1(y + h / 2)}" font-size="15" font-weight="700" fill="#252B35" data-fill-role="ink" dominant-baseline="central">${esc(L.label[loc])}</text>
+  </g>`);
+    if (m) {
+      chipArt.push(`  <g data-layout-group="${L.id}-chips" data-distribution="equal-gap" data-axis="x" data-group-count="${m}"></g>`);
+      chips.forEach((c, k) => {
+        // chip은 {id, label{ko,en}} 계약이다. 문안이 없으면 조용히 "undefined"를 그리지 않고 실패한다
+        // (기하 gate는 글자 내용을 보지 않으므로 여기서 막는다).
+        consumed.push(c.id);
+        const chipText = c?.label?.[loc];
+        if (!chipText) { console.error(`generate: chip "${c?.id ?? k + 1}" in layer "${L.id}" has no ${loc} label`); process.exit(1); }
+        const cx = runStart + k * (chipW + chipGap);
+        chipArt.push(`  <g data-comp-entity="${c.id}" data-entity="${c.id}">
+    <rect x="${r1(cx)}" y="${r1(chipY)}" width="${r1(chipW)}" height="26" rx="8" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1" data-fill-role="surface" data-stroke-role="rule" data-layout-parent="${L.id}" data-layout-item="${L.id}-chips"/>
+    <text x="${r1(cx + chipW / 2)}" y="${r1(chipY + 13)}" font-size="12" fill="#636A75" data-fill-role="muted" text-anchor="middle" dominant-baseline="central">${esc(chipText)}</text>
+  </g>`);
+      });
+    }
+  });
+  const blockH = n * h + (n - 1) * gapY;
+  return { body: [`  <g data-layer="containers">`,
+      `  <g data-layout-group="layer-stack" data-distribution="equal-gap" data-axis="y" data-group-count="${n}"></g>`,
+      ...bandArt, ...chipArt, `  </g>`,
+      `  <g data-layer="connectors"></g>`, `  <g data-layer="nodes"></g>`, `  <g data-layer="annotations"></g>`].join("\n"),
+    consumed, bounds: { x: cb.x, y: cb.y, w: bandW, h: blockH },
+    routing: { degradeLevel: 0, ladder: [], problems: [], hops: 0, legend: false, alignment: [],
+      attempts: [], diagnostics: [], demoted: [], routes: [] } };
+}
+
+// ---------- nested-scope (동심 — 화살표 없이 포함이 관계다) ----------
+function renderNestedScope(input, loc, cb, sc, tp) {
+  const rings = input.rings, n = rings.length;
+  const P = tp.fit?.params ?? {};
+  const inset = Number(P.inset ?? 44);
+  // 사방 균일 inset — label은 위쪽 inset 띠 안에서 가운데 놓인다(spec §5, fit 계약과 동일).
+  const w0 = Math.min(cb.w, Number(P.itemMinW ?? 296) + 2 * (n - 1) * inset);
+  const h0 = Math.min(cb.h, Number(P.itemMinH ?? 96) + 2 * (n - 1) * inset);
+  const x0 = cb.x + (cb.w - w0) / 2;
+  const consumed = [], art = [], labels = [];
+  const tint = ["#F4F8FC", "#E9F1F8", "#DCE9F4", "#CFE0F0"];
+  let box = { x: x0, y: cb.y, w: w0, h: h0 };
+  const labelWidest = Math.max(...["ko", "en"].flatMap((lc) => rings.map((rg) => estimateWidth(rg.label[lc], 13, true, 0))));
+  rings.forEach((rg, i) => {
+    consumed.push(rg.id);
+    const last = i + 1 === n;
+    const inner = last ? null : { x: box.x + inset, y: box.y + inset, w: box.w - 2 * inset, h: box.h - 2 * inset };
+    art.push(`  <g data-comp-entity="${rg.id}" data-entity="${rg.id}" data-layout-role="ring">
+    <rect x="${r1(box.x)}" y="${r1(box.y)}" width="${r1(box.w)}" height="${r1(box.h)}" rx="16" fill="${tint[Math.min(i, tint.length - 1)]}" stroke="#C7D3DE" stroke-width="1" data-fill-role="surface-tint" data-stroke-role="rule"${inner ? ` data-layout-container="${rg.id}" data-min-pad="${inset}" data-layout-count="1" data-symmetry="xy"` : ""}${i > 0 ? ` data-layout-parent="${rings[i - 1].id}"` : ""}/>
+  </g>`);
+    // ring label은 자기 띠(위쪽 inset) 안에서 측정한다 — ring 전체가 아니라 그 띠가 기준이다.
+    const stripH = last ? Math.min(inset, box.h) : inset;
+    labels.push(`  <g data-layout-role="ring-label" data-label-bounds="${r1(box.x)},${r1(box.y)},${r1(box.w)},${r1(stripH)}">
+    <text x="${r1(box.x + box.w / 2)}" y="${r1(box.y + stripH / 2)}" font-size="13" font-weight="700" fill="#3C4657" data-fill-role="ink" text-anchor="middle" dominant-baseline="central">${esc(rg.label[loc])}</text>
+  </g>`);
+    if (last && rg.core_icon)
+      labels.push(`  <g data-layout-role="core-icon">${icon(rg.core_icon, box.x + box.w / 2, box.y + stripH + (box.h - stripH) / 2, 26)}</g>`);
+    if (inner) box = inner;
+  });
+  // label이 자기 띠 폭을 넘으면 기하가 아니라 문안 문제다 — 조용히 넘기지 않는다.
+  const innerW = w0 - 2 * (n - 1) * inset;
+  if (labelWidest > innerW - 16) {
+    console.error(`generate: a ring label needs ${r1(labelWidest)}px but the innermost strip is ${r1(innerW)}px — shorten the label (spec §6) or widen the scope`);
+    process.exit(1);
+  }
+  return { body: [`  <g data-layer="containers">`, ...art, `  </g>`,
+      `  <g data-layer="connectors"></g>`, `  <g data-layer="nodes"></g>`,
+      `  <g data-layer="annotations">`, ...labels, `  </g>`].join("\n"),
+    consumed, bounds: { x: x0, y: cb.y, w: w0, h: h0 },
+    routing: { degradeLevel: 0, ladder: [], problems: [], hops: 0, legend: false, alignment: [],
+      attempts: [], diagnostics: [], demoted: [], routes: [] } };
+}
+
 // ---------- font delivery (portable = 사용 glyph subset embed) ----------
 // 계약: portable은 대상 환경의 설치 글꼴에 의존하지 않는다. subset 도구가 없거나 glyph가
 // 빠지면 **full embed로도, system fallback으로도 조용히 넘어가지 않고 실패한다**.
@@ -571,6 +686,8 @@ function build(argv) {
     : tid === "topology-component" ? renderTopology(input, loc, cbox, sc, tp)
     : tid === "process-flow" ? renderProcessFlow(input, loc, cbox, sc, tp)
     : tid === "approval-gate" ? renderApprovalGate(input, loc, cbox, sc, tp)
+    : tid === "layer-stack" ? renderLayerStack(input, loc, cbox, sc, tp)
+    : tid === "nested-scope" ? renderNestedScope(input, loc, cbox, sc, tp)
     : (console.error(`generate: no renderer registered for "${tid}"`), process.exit(2));
   let pf = spawnJson([skinCli, "pageframe", preset, "--json"], "skin.mjs pageframe");
   if (pf.regions.fluid) {
@@ -677,6 +794,8 @@ function semanticIds(input, tid) {
   const ids = [];
   if (tid === "cards-kpi-grid") for (const c of input.cards ?? []) ids.push(c.id);
   if (tid === "process-flow") for (const st of input.steps ?? []) ids.push(st.id);
+  if (tid === "layer-stack") for (const L of input.layers ?? []) { ids.push(L.id); for (const c of L.items ?? []) ids.push(c.id); }
+  if (tid === "nested-scope") for (const rg of input.rings ?? []) ids.push(rg.id);
   if (tid === "approval-gate") {
     for (const nd of input.nodes ?? []) ids.push(nd.id);
     if (input.gate?.id) ids.push(input.gate.id);

--- a/skills/svg-infographic/scripts/generate.test.mjs
+++ b/skills/svg-infographic/scripts/generate.test.mjs
@@ -211,3 +211,21 @@ test("G-11: portable 산출물은 subset을 embed하고 근거를 남긴다 (pin
   assert.ok(!/@font-face\{font-family:'[^']*Pretendard/i.test(svg), "subset은 Reserved Font Name을 쓸 수 없다");
   drop(pkg);
 });
+
+test("G-12: connector 없는 산출물의 layer 순서를 흐트러뜨리면 verify가 non-zero로 끝난다", () => {
+  const pkg = pkgCopy();
+  const b = build(pkg, "layer-stack", "canonical", "ko");
+  assert.equal(b.code, 0, b.out);
+  const clean = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+  assert.equal(clean.code, 0, clean.out);
+  // annotations 레이어를 맨 앞으로 옮긴다 — 기하는 그대로이고 그리는 순서만 어긋난다
+  const svg = readFileSync(b.svg, "utf8");
+  const ann = svg.match(/  <g data-layer="annotations">[\s\S]*?<\/g>\n?/);
+  assert.ok(ann, "annotations layer not found");
+  const moved = svg.replace(ann[0], "").replace('  <g data-layer="containers">', ann[0] + '  <g data-layer="containers">');
+  writeFileSync(b.svg, moved);
+  const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /A-LAYER-ORDER/);
+  drop(pkg);
+});

--- a/skills/svg-infographic/scripts/layout-fixtures/ln-reserve-left-breach.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/ln-reserve-left-breach.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 120" width="400" height="120">
+  <!-- 첫 chip이 예약된 라벨 열 안으로 들어갔다 — 예약이 거짓이 된다 -->
+  <rect data-layout-container="band" data-min-pad="16" data-layout-count="2"
+        data-reserve-left="120" data-symmetry="x"
+        x="20" y="20" width="360" height="80" fill="#F4F8FC" stroke="#DEE0E2" stroke-width="1"/>
+  <g data-layout-group="band-chips" data-distribution="equal-gap" data-axis="x" data-group-count="2"></g>
+  <rect data-layout-parent="band" data-layout-item="band-chips" x="60" y="47" width="60" height="26" rx="8" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-layout-parent="band" data-layout-item="band-chips" x="300" y="47" width="60" height="26" rx="8" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+</svg>

--- a/skills/svg-infographic/scripts/layout-fixtures/lp-reserve-left.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/lp-reserve-left.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 120" width="400" height="120">
+  <!-- 라벨 열을 가로로 예약한 band: 내용(chip)은 예약 경계 뒤에서 좌우 대칭으로 놓인다 -->
+  <rect data-layout-container="band" data-min-pad="16" data-layout-count="3"
+        data-reserve-left="120" data-symmetry="x"
+        x="20" y="20" width="360" height="80" fill="#F4F8FC" stroke="#DEE0E2" stroke-width="1"/>
+  <text x="36" y="60" font-size="14">label</text>
+  <g data-layout-group="band-chips" data-distribution="equal-gap" data-axis="x" data-group-count="3"></g>
+  <rect data-layout-parent="band" data-layout-item="band-chips" x="156" y="47" width="60" height="26" rx="8" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-layout-parent="band" data-layout-item="band-chips" x="228" y="47" width="60" height="26" rx="8" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-layout-parent="band" data-layout-item="band-chips" x="300" y="47" width="60" height="26" rx="8" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+</svg>

--- a/skills/svg-infographic/scripts/route-orthogonal.mjs
+++ b/skills/svg-infographic/scripts/route-orthogonal.mjs
@@ -496,7 +496,7 @@ export function auditTopology(svg) {
       marker: /marker-end="url\(#[^)]+\)"/.test(at),
       dashed: /stroke-dasharray=/.test(at),
     }; });
-  if (!paths.length) return { errors, notes: ["no annotated routes in this artifact"] };
+  const layersOnly = paths.length === 0;
 
   const polys = new Map();
   const hopPoints = [];
@@ -571,6 +571,7 @@ export function auditTopology(svg) {
       errors.push(`A-LABEL ${id}: the route crosses a zone label box — drawing the label on top hides the connection instead of routing around it`);
       break;
     }
+  if (layersOnly) { checkLayerOrder(svg, errors); return { errors, notes: ["no annotated routes in this artifact — paint layers still checked"] }; }
   // --- port 방향: 선언된 side가 아니라 **실제 첫·마지막 구간**으로 다시 계산한다 -----------
   for (const p of paths) {
     const poly = polys.get(p.id);
@@ -599,30 +600,7 @@ export function auditTopology(svg) {
     if (tFace && dirOf(segs2[segs2.length - 1]) !== inward[tFace])
       errors.push(`A-PORT-DIR ${p.id}: enters the ${tFace} face heading ${dirOf(segs2[segs2.length - 1])} — the last segment must run ${inward[tFace]}`);
   }
-  // --- paint order: 선언이 아니라 **DOM 순서**로 검증한다 -------------------------
-  // canvas → container 배경/테두리 → connector와 marker → node surface → icon·text·label·legend
-  const LAYERS = ["containers", "connectors", "nodes", "annotations"];
-  const marks = [...svg.matchAll(/<g[^>]*data-layer="([a-z]+)"/g)].map((m) => ({ name: m[1], at: m.index }));
-  if (marks.length) {
-    const seen = marks.map((m) => m.name);
-    if (seen.join(",") !== LAYERS.join(","))
-      errors.push(`A-LAYER-ORDER: paint layers appear as [${seen.join(", ")}] — the contract is [${LAYERS.join(", ")}]`);
-    const spanOf = (name) => {
-      const i = marks.findIndex((m) => m.name === name);
-      if (i < 0) return null;
-      return { from: marks[i].at, to: i + 1 < marks.length ? marks[i + 1].at : svg.length };
-    };
-    const conn = spanOf("connectors"), nodesSpan = spanOf("nodes"), ann = spanOf("annotations");
-    for (const m of svg.matchAll(/<path[^>]*data-route-id="([^"]+)"/g))
-      if (conn && (m.index < conn.from || m.index > conn.to))
-        errors.push(`A-LAYER ${m[1]}: a connector is drawn outside the connectors layer`);
-    for (const m of svg.matchAll(/<rect[^>]*data-entity="([^"]+)"/g))
-      if (nodesSpan && (m.index < nodesSpan.from || m.index > nodesSpan.to))
-        errors.push(`A-LAYER ${m[1]}: a node surface is drawn outside the nodes layer`);
-    for (const m of svg.matchAll(/data-layout-role="(zone-label|legend)"/g))
-      if (ann && (m.index < ann.from || m.index > ann.to))
-        errors.push(`A-LAYER ${m[1]}: an annotation is drawn outside the annotations layer`);
-  }
+  checkLayerOrder(svg, errors);
   // --- visibility: 기하가 아니라 **가려지는지**를 따로 본다 ---------------------------
   // connector 뒤에 오는 불투명 면이 선 위를 덮으면, 선은 존재해도 끊겨 보인다.
   const opaque = [...svg.matchAll(/<rect([^>]*)\/>/g)].map((m) => {
@@ -649,6 +627,34 @@ export function auditTopology(svg) {
   if (mixed && !/data-layout-role="legend"/.test(svg))
     errors.push("A-LEGEND artifact: solid and dashed connectors appear together but there is no legend");
   return { errors, notes };
+}
+
+// paint order는 선언이 아니라 **DOM 순서**로 검증한다.
+// canvas → container 배경/테두리 → connector와 marker → node surface → icon·text·label·legend
+function checkLayerOrder(svg, errors) {
+  const LAYERS = ["containers", "connectors", "nodes", "annotations"];
+  const marks = [...svg.matchAll(/<g[^>]*data-layer="([a-z]+)"/g)].map((m) => ({ name: m[1], at: m.index }));
+  if (!marks.length) return;
+  const seen = marks.map((m) => m.name);
+  if (seen.join(",") !== LAYERS.join(","))
+    errors.push(`A-LAYER-ORDER: paint layers appear as [${seen.join(", ")}] — the contract is [${LAYERS.join(", ")}]`);
+  const spanOf = (name) => {
+    const i = marks.findIndex((m) => m.name === name);
+    if (i < 0) return null;
+    return { from: marks[i].at, to: i + 1 < marks.length ? marks[i + 1].at : svg.length };
+  };
+  const conn = spanOf("connectors"), nodesSpan = spanOf("nodes"), ann = spanOf("annotations");
+  for (const m of svg.matchAll(/<path[^>]*data-route-id="([^"]+)"/g))
+    if (conn && (m.index < conn.from || m.index > conn.to))
+      errors.push(`A-LAYER ${m[1]}: a connector is drawn outside the connectors layer`);
+  // node surface 규칙은 **connector의 endpoint**에만 적용한다 — 선이 그 아래로 지나가야 하는 면이 그것뿐이다.
+  const endpoints = new Set([...svg.matchAll(/data-route-(?:from|to)="([^"]+)"/g)].map((m) => m[1]));
+  for (const m of svg.matchAll(/<rect[^>]*data-entity="([^"]+)"/g))
+    if (nodesSpan && endpoints.has(m[1]) && (m.index < nodesSpan.from || m.index > nodesSpan.to))
+      errors.push(`A-LAYER ${m[1]}: a connector endpoint surface is drawn outside the nodes layer`);
+  for (const m of svg.matchAll(/data-layout-role="(zone-label|legend)"/g))
+    if (ann && (m.index < ann.from || m.index > ann.to))
+      errors.push(`A-LAYER ${m[1]}: an annotation is drawn outside the annotations layer`);
 }
 
 // --- geometry helpers --------------------------------------------------------

--- a/skills/svg-infographic/scripts/route-orthogonal.test.mjs
+++ b/skills/svg-infographic/scripts/route-orthogonal.test.mjs
@@ -302,3 +302,18 @@ test("R-25: zone 경계를 넘는 connector는 배경에 가리지 않고 이어
   const errs = auditTopology(hidden).errors;
   assert.ok(errs.some((e) => e.startsWith("A-OCCLUDED")), errs.join("; "));
 });
+
+test("R-26: connector가 없는 산출물도 layer 순서를 검사한다 (조기 반환 금지)", () => {
+  // layer-stack·nested-scope처럼 route가 하나도 없는 산출물 — 예전에는 여기서 감사가 조기 반환했다.
+  const bands = `<rect data-entity="layer-1" x="20" y="20" width="360" height="60" fill="#F4F8FC"/>`;
+  const ok = layered(`<g data-layer="containers">${bands}</g><g data-layer="connectors"></g>
+    <g data-layer="nodes"></g><g data-layer="annotations"></g>`);
+  const okRes = auditTopology(ok);
+  assert.deepEqual(okRes.errors, [], okRes.errors.join("; "));
+  assert.ok(okRes.notes.some((n) => /paint layers still checked/.test(n)), JSON.stringify(okRes.notes));
+
+  const swapped = layered(`<g data-layer="annotations"></g><g data-layer="containers">${bands}</g>
+    <g data-layer="connectors"></g><g data-layer="nodes"></g>`);
+  const bad = auditTopology(swapped);
+  assert.ok(bad.errors.some((e) => e.startsWith("A-LAYER-ORDER")), bad.errors.join("; "));
+});


### PR DESCRIPTION
## 요약

CP2B 세 번째 단계. **연결선이 없고 container 계층이 본체인** 두 타입을 등록한다.

## 동심 구조 — 새 primitive 없이

spec이 "concentric rounded rects (or circles)"를 허용하고 사각형이 먼저 적혀 있어 사각형으로 구현했다. 기존 container/symmetry 계약이 그대로 성립해 **radial/annular 전용 검증은 추가하지 않았다**. ring 하나당 container 1개로 containment가 검사된다.

## 실제 결손은 chip 행에 있었다

라벨 열 때문에 좌우 예약이 비대칭인데 그것을 표현할 primitive가 없어 guard가 221.7px 비대칭으로 거부했다. 기존 `data-reserve-top`과 **같은 개념의 축 대칭**인 `data-reserve-left`만 최소로 추가했다(범용 geometry engine 아님) — 대칭·pad·outer 판정이 예약 경계에서 재도록 하고 positive/negative fixture로 봉인.

chip 폭은 band가 아니라 **실제 chip 문안(KO/EN 최대)**이 정하고, run을 오른쪽에 붙여 마지막 chip의 오른쪽 끝만 band 안쪽 끝과 계산으로 만난다 — 빈 공간을 채우려 늘리지 않는다.

## audit 조기 반환 수정

connector가 없는 산출물에서 감사가 조기 반환해 **paint layer 검사 자체가 건너뛰어지고 있었다**. route 0개에서도 layer 순서·소속을 검사하고, node surface 규칙은 connector endpoint에만 적용하도록 좁혔다. route-free negative fixture 2종(R-26 감사 수준, G-12 CLI non-zero)으로 고정.

## batch가 잡아낸 것

- `concentric` 배치를 generate가 계산하지 못해 nested-scope 생성 불가 → validator와 같은 식으로 통일
- chip 행 좌우 예약 비대칭 (`E-LAYOUT-SYM`, `E-LAYOUT-OUTER`)
- chip 문안이 `undefined`로 렌더 — **기하 gate는 글자 내용을 보지 않는다** → fail-closed
- EN chip이 chip 폭을 1.1px 초과 → 폭 산식을 문안 기반으로
- `chips-max` 관측이 선언과 어긋남 → covers 선언

## 판형 (장면별 실측)

layer-stack·nested-scope 모두 fluid preferred(고정 4:5는 42~62% 잔여로 **계약이 거부**). chip 4개 장면만 폭 부족으로 presentation-16x9 + 잔여 선언.

## 검증

skin 118/118 · preflight 29/29 · render 23/23 · font-probe 6/6 · compose 51/51 · check-layout 36/36 · route-orthogonal 28/28 · generate 13/13 · check-svg 70/70 — **실패 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)