### PR TITLE
feat(svg-infographic): CP2B batch 3A — before-after·decision-matrix를 등록한다

### DIFF
--- a/skills/svg-infographic/references/design-kernel.md
+++ b/skills/svg-infographic/references/design-kernel.md
@@ -371,13 +371,49 @@ numbers are schema errors (never NaN-silenced), and duplicate container/group/
 cluster ids are rejected. Symmetry and receipts carry **both** geometric and
 visual values; the canonical visual-spacing judgement uses the visual safe inset.
 
-**7d. Hard-gate integration.** The canonical renderer runs `check-svg →
+**7d. Cross-container alignment contract.** 7a–7c prove structure *inside* one
+container; a mirrored comparison or a matrix also asserts alignment *across*
+containers, and that claim needs its own guard. Participants that must share a
+horizontal band declare `data-align-row="<id>"`, ones that must share a vertical
+band declare `data-align-col="<id>"`; members of a row share top edge and height,
+members of a column share left edge and width, both within 1px. Reservation is
+symmetric with 7a: `data-reserve-top` withholds a title band from the padding and
+symmetry judgement, and `data-reserve-left` does the same for a side band (axis
+labels, rail legends) so the grid is judged inside the remaining content box
+rather than against the raw frame.
+
+Alignment differs from distribution in what a missing annotation costs. An
+equal-gap group that loses a member fails on `data-group-count`; an alignment
+group that loses one simply has fewer members that still agree with each other,
+so the artifact passes while the visible claim is broken. Completeness is
+therefore declared on two independent levels, and both are enforced fail-closed:
+
+- **Per group** — every participant carries `data-align-row-count` /
+  `data-align-col-count`; members must agree on the number, and the measured
+  participant count must equal it. A count below 2 is a schema error: a
+  one-member alignment band asserts nothing, so it must not be declared at all.
+- **Per artifact** — a single `data-align-inventory` lists every expected group as
+  `row|col:<id>=<n>`, compared 1:1 against what the artifact actually carries.
+  Per-group counts cannot catch a group that vanished *entirely* (no participant
+  left to carry the count); the inventory can. `generate verify` recomputes the
+  expected inventory from the **original input**, never from the artifact, so a
+  renderer that drops a band cannot also drop its own expectation.
+
+The two levels together make partial grids representable without weakening
+anything. An incomplete last row declares no equal-gap row group — column
+alignment governs those members instead — and an axis whose participant count
+falls to one emits no group and appears in no inventory. The rule is not
+"incomplete grids are exempt"; it is that a band is declared only where two or
+more members actually make the claim, and wherever it is declared it must be
+complete. No placeholder cells are invented to square the grid.
+
+**7e. Hard-gate integration.** The canonical renderer runs `check-svg →
 check-layout → browser` fail-closed on any SVG carrying layout annotations; a
 layout-negative source is refused before the browser starts.
 `data-layout-unverified` yields exit 3 — an explicit review state that hard gates
 must never treat as success.
 
-**7e. No local coordinate patching.** Canonical generators derive geometry from
+**7f. No local coordinate patching.** Canonical generators derive geometry from
 inputs — parent contentBox (PageFrame receipt), child count/sizes, outer insets,
 gaps, distribution mode, title reservation, connector corridors — and fail closed
 when the budget does not match the contentBox exactly. `check-layout.mjs --json`

--- a/skills/svg-infographic/references/package-surface.yaml
+++ b/skills/svg-infographic/references/package-surface.yaml
@@ -14,7 +14,7 @@
 # evidence 또는 CI artifact로만 저장한다.
 
 schema_version: 1
-surface_revision: 8
+surface_revision: 9
 
 canonicalization:
   version: 1
@@ -98,6 +98,7 @@ entries:
   - { path: scripts/skin.test.mjs, kind: verification }
   - { path: scripts/check-svg.test.mjs, kind: verification }
   - { path: scripts/check-layout.test.mjs, kind: verification }
+  - { path: scripts/run-tests.sh, kind: verification }
   - { path: scripts/render.test.mjs, kind: verification }
   - { path: scripts/compose.test.mjs, kind: verification }
   - { path: scripts/font-probe.test.mjs, kind: verification }

--- a/skills/svg-infographic/references/types/inputs/before-after.canonical.yaml
+++ b/skills/svg-infographic/references/types/inputs/before-after.canonical.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: before-after
 case: canonical
-preset: social-4x5
+preset: document-compact
 layout: row
 count: 2
 prompt_ko: "마이그레이션 전후를 두 항목으로 비교해줘. 4:5."

--- a/skills/svg-infographic/references/types/inputs/before-after.stress-cardinality.yaml
+++ b/skills/svg-infographic/references/types/inputs/before-after.stress-cardinality.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: before-after
 case: stress-cardinality
-preset: social-4x5
+preset: document-compact
 layout: row
 count: 2
 prompt_ko: "전후 비교를 미러 슬롯 5개로 보여줘. 4:5."

--- a/skills/svg-infographic/references/types/inputs/before-after.stress-copy.yaml
+++ b/skills/svg-infographic/references/types/inputs/before-after.stress-copy.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: before-after
 case: stress-copy
-preset: social-4x5
+preset: document-compact
 layout: row
 count: 2
 prompt_ko: "각 슬롯 문구를 예산 경계까지 길게 써줘. 4:5."

--- a/skills/svg-infographic/references/types/inputs/decision-matrix.canonical.yaml
+++ b/skills/svg-infographic/references/types/inputs/decision-matrix.canonical.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: decision-matrix
 case: canonical
-preset: social-4x5
+preset: document-compact
 layout: grid
 cols: 2
 count: 4
@@ -13,21 +13,29 @@ title:
   en: "Two axes set the priority"
 axes:
   x:
-    low:
-      ko: "좁은 범위"
-      en: "Narrow"
-    high:
-      ko: "넓은 범위"
-      en: "Broad"
+    tiers:
+      - id: "narrow"
+        label:
+          ko: "좁은 범위"
+          en: "Narrow"
+      - id: "broad"
+        label:
+          ko: "넓은 범위"
+          en: "Broad"
   y:
-    low:
-      ko: "낮은 영향"
-      en: "Low impact"
-    high:
-      ko: "높은 영향"
-      en: "High impact"
+    tiers:
+      - id: "low"
+        label:
+          ko: "낮은 영향"
+          en: "Low impact"
+      - id: "high"
+        label:
+          ko: "높은 영향"
+          en: "High impact"
 cells:
   - id: "cell-1"
+    x: "narrow"
+    y: "high"
     name:
       ko: "지금 실행"
       en: "Do now"
@@ -35,6 +43,8 @@ cells:
       ko: "영향이 크고 범위가 좁다"
       en: "High impact, narrow scope"
   - id: "cell-2"
+    x: "broad"
+    y: "high"
     name:
       ko: "계획 수립"
       en: "Plan"
@@ -42,6 +52,8 @@ cells:
       ko: "영향이 크고 범위가 넓다"
       en: "High impact, broad scope"
   - id: "cell-3"
+    x: "narrow"
+    y: "low"
     name:
       ko: "위임"
       en: "Delegate"
@@ -49,6 +61,8 @@ cells:
       ko: "영향이 작고 범위가 좁다"
       en: "Low impact, narrow scope"
   - id: "cell-4"
+    x: "broad"
+    y: "low"
     name:
       ko: "보류"
       en: "Defer"

--- a/skills/svg-infographic/references/types/inputs/decision-matrix.stress-copy.yaml
+++ b/skills/svg-infographic/references/types/inputs/decision-matrix.stress-copy.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: decision-matrix
 case: stress-copy
-preset: social-4x5
+preset: document-compact
 layout: grid
 cols: 2
 count: 4
@@ -13,21 +13,29 @@ title:
   en: "Two axes set the priority"
 axes:
   x:
-    low:
-      ko: "좁은 범위"
-      en: "Narrow"
-    high:
-      ko: "넓은 범위"
-      en: "Broad"
+    tiers:
+      - id: "narrow"
+        label:
+          ko: "좁은 범위"
+          en: "Narrow"
+      - id: "broad"
+        label:
+          ko: "넓은 범위"
+          en: "Broad"
   y:
-    low:
-      ko: "낮은 영향"
-      en: "Low impact"
-    high:
-      ko: "높은 영향"
-      en: "High impact"
+    tiers:
+      - id: "low"
+        label:
+          ko: "낮은 영향"
+          en: "Low impact"
+      - id: "high"
+        label:
+          ko: "높은 영향"
+          en: "High impact"
 cells:
   - id: "cell-1"
+    x: "narrow"
+    y: "high"
     name:
       ko: "즉시 실행 대상"
       en: "Act immediately"
@@ -35,6 +43,8 @@ cells:
       ko: "영향이 크고 범위가 좁아 지금 바로 처리한다고 본다"
       en: "High impact and narrow scope, handle now"
   - id: "cell-2"
+    x: "broad"
+    y: "high"
     name:
       ko: "분기 계획 대상"
       en: "Plan this quarter"
@@ -42,6 +52,8 @@ cells:
       ko: "영향이 크지만 범위가 넓어 계획 수립이 먼저 필요하다"
       en: "High impact but broad scope, plan first"
   - id: "cell-3"
+    x: "narrow"
+    y: "low"
     name:
       ko: "위임 가능 항목"
       en: "Delegate safely"
@@ -49,6 +61,8 @@ cells:
       ko: "영향이 작고 범위가 좁아 위임할 수 있다"
       en: "Low impact and narrow scope, delegate"
   - id: "cell-4"
+    x: "broad"
+    y: "low"
     name:
       ko: "다음 주기 보류"
       en: "Defer to next cycle"

--- a/skills/svg-infographic/references/types/inputs/decision-matrix.stress-degrade.yaml
+++ b/skills/svg-infographic/references/types/inputs/decision-matrix.stress-degrade.yaml
@@ -1,8 +1,8 @@
 schema_version: 1
 kind: typepack-input
 typepack: decision-matrix
-case: stress-cardinality
-preset: presentation-16x9
+case: stress-degrade
+preset: document-compact
 layout: grid
 cols: 3
 count: 9

--- a/skills/svg-infographic/references/types/manifest.yaml
+++ b/skills/svg-infographic/references/types/manifest.yaml
@@ -171,7 +171,6 @@ typepacks:
     support: experimental
     spec: types/specs/layer-stack.md
     presets: [document-compact, social-4x5, presentation-16x9]
-    # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
     # 장면별 실측(잔여 27~62%) 근거로 fluid를 기본으로 한다.
     preferred_preset: document-compact
     orientations: [portrait, landscape]
@@ -233,7 +232,6 @@ typepacks:
     support: experimental
     spec: types/specs/nested-scope.md
     presets: [document-compact, social-4x5, presentation-16x9]
-    # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
     # 장면별 실측(잔여 27~62%) 근거로 fluid를 기본으로 한다.
     preferred_preset: document-compact
     orientations: [portrait, landscape]
@@ -461,9 +459,9 @@ typepacks:
     profile: constrained-layout
     support: experimental
     spec: types/specs/before-after.md
-    presets: [social-4x5, presentation-16x9]
-    # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
-    preferred_preset: social-4x5
+    presets: [document-compact, social-4x5, presentation-16x9]
+    # 장면별 실측(고정 4:5에서 잔여 27~79%)에 따라 fluid를 기본으로 한다.
+    preferred_preset: document-compact
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -477,18 +475,18 @@ typepacks:
     migration_origin: legacy
     legacy_section: "Before / after"
     inputs:
-      canonical: { id: before-after-canonical, path: types/inputs/before-after.canonical.yaml, preset: social-4x5, layout: row, count: 2 }
+      canonical: { id: before-after-canonical, path: types/inputs/before-after.canonical.yaml, preset: document-compact, layout: row, count: 2 }
       stress:
         - id: before-after-stress-cardinality
           path: types/inputs/before-after.stress-cardinality.yaml
-          preset: social-4x5
+          preset: document-compact
           layout: row
           count: 2
           geometry_expected: fits
           covers: [cardinality-max, mirrored-slots]
         - id: before-after-stress-copy
           path: types/inputs/before-after.stress-copy.yaml
-          preset: social-4x5
+          preset: document-compact
           layout: row
           count: 2
           geometry_expected: fits
@@ -496,10 +494,14 @@ typepacks:
     fit:
       floor_basis: geometry
       cardinality: { min: 2, canonical: 2, max: 2 }
-      params: { itemMinW: 260, itemMinH: 320, gapX: 32, gapY: 32 }
+      # panel 최소 높이는 **최소 합법 문법에서 계산**한다(임의 수치가 아니다):
+      #   2×panelPad + panelHeaderH + minSlots×slotMinH + (minSlots-1)×slotGap
+      #   = 2×16 + 34 + 2×38 + 1×10 = 152. validator가 이 합과 itemMinH를 대조한다.
+      params: { itemMinW: 260, itemMinH: 152, gapX: 32, gapY: 32, panelPad: 16, panelHeaderH: 34, slotMinH: 38, slotGap: 10, minSlots: 2 }
       footprint:
-        - { count: 2, layout: row, w: 552, h: 320 }
+        - { count: 2, layout: row, w: 552, h: 152 }
       feasibility:
+        - { preset: document-compact, orientation: portrait, count: 2, layout: row, result: fits }
         - { preset: social-4x5, orientation: portrait, count: 2, layout: row, result: fits }
         - { preset: presentation-16x9, orientation: landscape, count: 2, layout: row, result: fits }
   - id: roadmap-timeline
@@ -560,9 +562,9 @@ typepacks:
     profile: constrained-layout
     support: experimental
     spec: types/specs/decision-matrix.md
-    presets: [social-4x5, presentation-16x9]
-    # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
-    preferred_preset: social-4x5
+    presets: [document-compact, social-4x5, presentation-16x9]
+    # 장면별 실측(고정 4:5에서 잔여 27~79%)에 따라 fluid를 기본으로 한다.
+    preferred_preset: document-compact
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -576,19 +578,29 @@ typepacks:
     migration_origin: legacy
     legacy_section: "Decision / risk matrix"
     inputs:
-      canonical: { id: decision-matrix-canonical, path: types/inputs/decision-matrix.canonical.yaml, preset: social-4x5, layout: grid, cols: 2, count: 4 }
+      canonical: { id: decision-matrix-canonical, path: types/inputs/decision-matrix.canonical.yaml, preset: document-compact, layout: grid, cols: 2, count: 4 }
       stress:
         - id: decision-matrix-stress-cardinality
           path: types/inputs/decision-matrix.stress-cardinality.yaml
-          preset: social-4x5
+          # 3×3은 fluid 폭을 넘는다 — 이 구성만 더 넓은 지원 판형을 쓴다.
+          preset: presentation-16x9
           layout: grid
           cols: 3
           count: 9
+          residual_disposition: { bottom: 358, reason: "3×3 격자는 축 예약을 포함해 fluid 폭을 넘으므로 폭이 되는 유일한 선언 판형이 16:9다. cell 높이는 내용이 정하고 canvas를 채우려고 늘리지 않는다 — 가로를 얻은 대가로 남는 세로 여백이다." }
           geometry_expected: fits
           covers: [cardinality-max]
+        - id: decision-matrix-stress-degrade
+          path: types/inputs/decision-matrix.stress-degrade.yaml
+          preset: document-compact
+          layout: grid
+          cols: 3
+          count: 9
+          geometry_expected: needs-split
+          covers: [cardinality-max, degrade-path]
         - id: decision-matrix-stress-copy
           path: types/inputs/decision-matrix.stress-copy.yaml
-          preset: social-4x5
+          preset: document-compact
           layout: grid
           cols: 2
           count: 4
@@ -597,10 +609,15 @@ typepacks:
     fit:
       floor_basis: geometry
       cardinality: { min: 4, canonical: 4, max: 9 }
-      params: { itemMinW: 180, itemMinH: 150, gapX: 16, gapY: 16 }
+      # cell 높이는 canvas가 아니라 내용이 정한다. itemMinH는 **최소 합법 cell**의 geometry floor다:
+      # 2 × cellPadY + nameLine + nameGap + traitLine = 28 + 18 + 6 + 16. 실제 높이는 두 locale
+      # 최대 line-box에서 나오고, 예측 floor를 넘으면 렌더 뒤 측정 gate가 다시 판정한다.
+      params: { itemMinW: 180, itemMinH: 68, gapX: 16, gapY: 16, cellPadY: 14, nameLine: 18, nameGap: 6, traitLine: 16 }
       footprint:
-        - { count: 4, layout: grid, cols: 2, extraW: 56, extraH: 44, w: 432, h: 360 }
-        - { count: 9, layout: grid, cols: 3, extraW: 56, extraH: 44, w: 628, h: 526 }
+        - { count: 4, layout: grid, cols: 2, extraW: 72, extraH: 58, w: 448, h: 210 }
+        - { count: 9, layout: grid, cols: 3, extraW: 72, extraH: 58, w: 644, h: 294 }
       feasibility:
+        # 3×3 격자는 fluid 폭(616)을 넘는다 — 그 구성만 더 넓은 판형을 쓴다.
+        - { preset: document-compact, orientation: portrait, count: 9, layout: grid, result: needs-split }
         - { preset: social-4x5, orientation: portrait, count: 9, layout: grid, result: fits }
         - { preset: presentation-16x9, orientation: landscape, count: 9, layout: grid, result: fits }

--- a/skills/svg-infographic/references/types/specs/before-after.md
+++ b/skills/svg-infographic/references/types/specs/before-after.md
@@ -49,11 +49,20 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
   contentBox**(preset별 live receipt)와 대조돼 `fits` 또는 `needs-split`으로 확정된다.
   manifest validator가 두 계산을 모두 재수행하므로 선언만으로 통과할 수 없다.
 - 경계: 두 패널과 gutter가 두 preset에서 성립한다. 높이는 긴 쪽이 정하고 짧은 쪽을 **패딩**한다.
+- 패널 높이 floor는 상수가 아니라 **최소 합법 문법에서 유도한다**: 헤더 예약 + (최소 slot 수 ×
+  slot 높이) + slot 사이 간격 + 패널 안쪽 여백. 기호로 쓰면
+  `panelFloor = panelHeaderH + minSlots × slotMinH + (minSlots − 1) × slotGap + 2 × panelPad`이고,
+  변수 값은 모두 manifest `fit.params`가 소유한다. validator와 renderer가 **같은 derive helper**를
+  호출하므로 문서·검증·렌더가 갈라질 수 없다. floor를 맞추려고 canonical의 slot 수를 늘리거나
+  임의의 낮은 상수로 내리지 않는다.
 
 ## 5. Layout, encoding and connector rules
 
 - Two equal-height, equal-width panels with a 32–48px gutter; optional centre arrow or migration chip between them; optional delta strip below.
-- Mirrored slots align to the same y in both panels.
+- Mirrored slots align to the same y in both panels. 이 대칭은 눈으로 판정하지 않는다: slot `i`는
+  두 패널에서 하나의 `data-align-row`에 속하고 참여 수 2를 선언하므로, 한쪽 slot이 어긋나거나
+  annotation이 빠지면 hard error가 된다(design-kernel §7d). 패널 헤더는 `data-reserve-top`으로
+  예약돼 대칭 판정에서 빠진다.
 - A legend is required when three or more semantic colours appear.
 - No connectors between panel internals — the mirror alignment carries the correspondence.
 
@@ -67,7 +76,7 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
 ## 7. Verifier, receipt and fixture contract
 
 - **Machine verifier**: none (`verifier: null`).
-- Checks: panel heights and widths equal; mirrored slots share a y; gutter ≥ 24 with balanced outer margins; legend present when required.
+- Checks: panel heights and widths equal; mirrored slots share a y; gutter ≥ 24 with balanced outer margins; legend present when required. 앞의 두 항목은 `check-layout.mjs`의 alignment 계약이 기계로 판정하고, artifact의 `data-align-inventory`는 원본 input에서 다시 계산한 기대치와 대조된다.
 - **Receipt**: the mirrored slot list, per-slot change class, and the padding applied to the shorter panel.
 - **Fixtures**: positive per preset + a baseline-red with ragged panel ends. Required before `core`.
 
@@ -81,5 +90,6 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
 
 - Panels ending ragged because content differed.
 - Slots that do not mirror, so the eye cannot diff.
+- 한쪽 패널의 slot annotation만 남아 정렬 검사가 "남은 것끼리는 맞다"로 통과하는 경우.
 - Colour-only change encoding with no legend and no text.
 - A third panel bolted on.

--- a/skills/svg-infographic/references/types/specs/decision-matrix.md
+++ b/skills/svg-infographic/references/types/specs/decision-matrix.md
@@ -22,14 +22,19 @@ Options placed by two qualitative axes.
 
 | Field | Cardinality | Budget |
 | --- | --- | --- |
-| `axes` | exactly 2, each with both end labels | ≤ 1 line per end |
+| `axes.{x,y}.tiers[]` | 2–3 ordered steps, **low → high** | label ≤ 1 line per step |
 | `cells[]` | 4 (2×2) or 9 (3×3) | name ≤ 1 line, trait ≤ 1 line |
+| `cells[].{x,y}` | required tier id on each axis | — |
 | `cells[].examples[]` | optional | ≤ 2, ≤ 1 line each |
 | `cells[].action` | optional pill | ≤ 1 line |
 
 ## 3. Semantic model and invariants
 
-- Entities are **cells** addressed by their axis position; position is the claim.
+- Entities are **cells** addressed by their axis position; position is the claim. 자리는 배열 순서가
+  아니라 cell이 선언한 **축 값**(`x`/`y` tier id)에서 파생한다: x tier는 낮음→높음이 왼→오,
+  y tier는 낮음→높음이 **아래→위**다. 같은 칸을 두 cell이 주장할 수 없고, 축 값과 어긋난 자리는
+  통과하지 못한다. cell `name`은 선택이며 없으면 두 축 tier label에서 파생한다 — "낮음-높음"처럼
+  어느 축이 먼저인지 알 수 없는 문안을 입력이 지어내지 않게 하기 위해서다.
 - Invariants: all cells are equal in size; both axes label **both** ends; every cell carries a name; at most one cell takes the emphasis toolkit.
 - Qualitative only — saturation may encode severity but no numeric scale is asserted.
 
@@ -51,10 +56,28 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
   manifest validator가 두 계산을 모두 재수행하므로 선언만으로 통과할 수 없다.
 - 경계: 축 gutter를 제외한 뒤에도 2×2와 3×3이 두 preset에서 성립한다. corner decoration 간격은
   cell floor에 포함된 예산이다.
+- 격자 폭은 frame 폭이 아니라 **예약을 뺀 나머지**에서 계산한다:
+  `gridW = contentW − reserveLeft − 2 × pad`, `cellW = (gridW − (cols − 1) × gapX) ÷ cols`
+  (세로도 동형). 축 라벨 열은 `data-reserve-left`로 예약되며, 라벨 폭은 상수가 아니라 KO·EN 실제
+  문자열을 측정한 값의 최댓값이다. 이 예약을 빼지 않고 좌표를 잡으면 셀이 경계에 닿고, 경계에
+  정확히 닿는 경우도 통과가 아니라 hard error다.
 
 ## 5. Layout, encoding and connector rules
 
 - Four or nine equal panels with visible gutters; axis arrows drawn **outside** the panels; quadrant name labels inside their panel.
+- **Ordinal axis grammar (this TypePack only).** 격자 왼쪽에 세로 keyline, 아래에 가로 keyline을
+  그리고 positive 끝(위·오른쪽)에만 작은 direction marker를 둔다. 양끝 tier label이 각 축 끝점에
+  정렬하고, 축선은 예약 구간 안에서 격자와 label 어느 쪽에도 닿지 않는다(clearance는 계산값이며
+  고정 상수가 아니다). 이 축은 **ordinal category direction**이다 — 수치 간격을 나타내는 chart
+  axis가 아니므로 tick·숫자 눈금·gridline으로 확장하지 않는다. 축은 connector가 아니다:
+  `data-route-*`로 분류하지 않고 routing audit 대상도 아니며, direction marker는 primary
+  connector arrow보다 얇게(시각적 우선순위가 낮게) 같은 arrow scale 산식에서 파생한다.
+  2×2·3×3·불완전 격자가 모두 같은 문법을 쓰고 KO/EN이 같은 축 기하를 갖는다.
+- 셀은 행 id와 열 id를 **동시에** 갖는다(`data-align-row` + `data-align-col`, 각각 참여 수 선언).
+  위치가 곧 주장이므로 교차 정렬은 기계로 판정한다(design-kernel §7d).
+- 격자가 완전히 차지 않을 수 있다. 마지막 행이 부족하면 그 행은 등간격 group을 주장하지 않고
+  **열 정렬이 대신 지배**하며, 참여자가 하나뿐인 축은 group 자체를 만들지 않는다. 빈 칸을 채우는
+  자리표시자 셀은 만들지 않는다.
 - One colour family per cell; risk grids encode severity by saturation (low light → high saturated).
 - Corner decorations are placed by rule: badge top-left, status label on the same row right of the badge, icon top-right.
 - No connectors between cells.
@@ -69,8 +92,14 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
 ## 7. Verifier, receipt and fixture contract
 
 - **Machine verifier**: none (`verifier: null`).
-- Checks: cells exactly equal; both ends of both axes labelled; axis labels clear of panel corners; corner decorations meet the ≥ 20–24px separation. **Corner crowding is this type's top failure — verify it against the exported PNG, not only the SVG source.**
+- Checks: cells exactly equal; both ends of both axes labelled; axis labels clear of panel corners; corner decorations meet the ≥ 20–24px separation. 셀 동일성과 행·열 교차 정렬은 `check-layout.mjs`가 판정하고, `data-align-inventory`는 원본 input에서 다시 계산한 기대치와 대조된다. **Corner crowding is this type's top failure — verify it against the exported PNG, not only the SVG source.**
+- Axis checks (기하까지 본다 — 라벨만 보면 축이 없어도 통과한다): 두 축이 각각 정확히 한 번 그려지고
+  orientation이 맞을 것 · positive 끝에 direction marker가 있을 것 · 끝점 label의 배치가 그 방향과
+  같은 뜻일 것 · 축이 grid/cell bounds를 침범하지 않을 것 · cell 자리가 입력 축 값에서 다시 계산한
+  기대 행·열과 일치할 것. 마지막 항목은 receipt가 아니라 **원본 입력**에서 재계산해 대조한다.
 - **Receipt**: cells with their axis position, the emphasised cell, and dropped optional content.
+  `matrix` 블록에 축 kind(`ordinal-direction`)·tier 순서·positive 방향과 cell별 축 값·행·열·정렬
+  group id를 기록한다.
 - **Fixtures**: positive per preset + a baseline-red with crowded corners. Required before `core`.
 
 ## 8. Reading order, accessibility and locale
@@ -87,4 +116,9 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
 - Corner crowding — the top failure; badge, status and icon collide at small sizes.
 - One axis labelled at only one end.
 - Cells resized to fit longer text.
+- 축 라벨 예약을 무시하고 frame 폭으로 격자를 계산해 셀이 경계에 닿는 경우.
+- 배열 순서대로 채워 "낮음" 행이 위로 올라가는 경우 — 축 라벨과 cell 의미가 반대가 된다.
+- 축 끝 label만 띄우고 축선·방향 marker를 생략해 2축 방향성이 읽히지 않는 경우.
+- cell을 canvas 높이에 맞춰 늘려 두 줄짜리 내용이 빈 세로 면적을 갖는 경우.
+- 격자를 네모나게 보이려고 빈 자리표시자 셀을 넣는 경우.
 - Saturation read as a numeric severity score.

--- a/skills/svg-infographic/scripts/check-layout.mjs
+++ b/skills/svg-infographic/scripts/check-layout.mjs
@@ -24,6 +24,9 @@
 //   groups:     data-layout-group="<id>" data-distribution="equal-gap"
 //               data-axis="x|y" data-group-count [data-gap-tol=1]
 //               (distribution/axis/group-count REQUIRED); items: data-layout-item="<id>"
+//   alignment:  data-align-row="<id>" data-align-row-count="<n≥2>" — 같은 y·같은 높이, 참여 수 고정
+//               data-align-col="<id>" data-align-col-count="<n≥2>" — 같은 x·같은 폭, 참여 수 고정
+//               (서로 다른 container에 걸친 교차 정렬 전용. 격자 엔진이 아니다)
 //   clusters:   item frame: data-cluster-id="<id>" data-cluster-count
 //               components: data-cluster="<id>" on circle/rect (bounds) or
 //               text/g/use (anchor point)
@@ -104,7 +107,8 @@ export function checkLayoutFile(file) {
     if (a.transform != null && !tm) broken = true;
     if (name === "g" && !self) stack.push({ tx: tm ? Number(tm[1]) : 0, ty: tm ? Number(tm[2]) : 0, broken: a.transform != null && !tm });
     const declared = a["data-layout-container"] || a["data-layout-parent"] || a["data-layout-item"]
-      || a["data-layout-group"] || a["data-cluster-id"] || a["data-cluster"] || a["data-layout-title"];
+      || a["data-layout-group"] || a["data-cluster-id"] || a["data-cluster"] || a["data-layout-title"]
+      || a["data-align-row"] || a["data-align-col"];
     if (!declared) continue;
     if (a["data-layout-unverified"] != null) {
       unverified.push({ id: declared, reason: a["data-layout-unverified"] });
@@ -148,6 +152,83 @@ export function checkLayoutFile(file) {
   }
 
   const r1 = (v) => Math.round(v * 10) / 10;
+  // --- alignment inventory: group이 **통째로 빠진 것**까지 잡는다 ------------------------
+  const invAttr = [...src.matchAll(/data-align-inventory="([^"]*)"/g)].map((m) => m[1]);
+  if (invAttr.length > 1) errors.push(`E-LAYOUT-ALIGN-SCHEMA: more than one data-align-inventory declaration`);
+  const declaredInv = invAttr.length
+    ? new Map(invAttr[0].split(";").filter(Boolean).map((t) => {
+        const m = t.match(/^(row|col):(.+)=(\d+)$/);
+        if (!m) { errors.push(`E-LAYOUT-ALIGN-SCHEMA: unparseable inventory entry "${t}"`); return ["?", NaN]; }
+        return [`${m[1]}:${m[2]}`, Number(m[3])];
+      }))
+    : null;
+
+  // --- alignment rows/cols: 교차축 정렬 + **참여 완결성** ------------------------------
+  // 정렬이 맞는지만 보면 한쪽 annotation이 빠졌을 때 남은 것만으로 통과한다.
+  // 그래서 group마다 기대 참여 수를 선언하게 하고, 수가 어긋나면 거부한다.
+  const alignTol = 1;
+  for (const [attr, cntAttr, axis, pos, size, label] of [
+    ["data-align-row", "data-align-row-count", "row", "y", "h", "top edge"],
+    ["data-align-col", "data-align-col-count", "col", "x", "w", "left edge"],
+  ]) {
+    const byName = new Map();
+    for (const e of els.filter((x) => x.a[attr])) {
+      const k = e.a[attr];
+      if (!byName.has(k)) byName.set(k, []);
+      byName.get(k).push(e);
+    }
+    for (const [name, list] of byName) {
+      const ctxA = `${axis} "${name}"`;
+      const counts = [...new Set(list.map((e) => e.a[cntAttr]))];
+      if (counts.some((c) => c === undefined)) {
+        errors.push(`E-LAYOUT-ALIGN-SCHEMA ${ctxA}: every participant must declare ${cntAttr} — without it a missing participant passes unnoticed`);
+        continue;
+      }
+      if (counts.length > 1) {
+        errors.push(`E-LAYOUT-ALIGN-SCHEMA ${ctxA}: participants disagree on ${cntAttr} (${counts.join(", ")})`);
+        continue;
+      }
+      const expected = num(counts[0]);
+      if (!Number.isFinite(expected) || expected < 2) {
+        errors.push(`E-LAYOUT-ALIGN-SCHEMA ${ctxA}: ${cntAttr} must be an integer ≥ 2 — a one-member alignment ${axis} asserts nothing`);
+        continue;
+      }
+      if (list.length !== expected) {
+        errors.push(`E-LAYOUT-ALIGN-SCHEMA ${ctxA}: declared ${expected} participant(s) but found ${list.length} — a missing annotation is a missing alignment claim`);
+        continue;
+      }
+      const withGeom = list.filter((e) => e.geom);
+      if (withGeom.length !== list.length) {
+        errors.push(`E-LAYOUT-ALIGN-SCHEMA ${ctxA}: ${list.length - withGeom.length} participant(s) have no provable geometry`);
+        continue;
+      }
+      const posOf = (e) => (pos === "y" ? e.geom.y : e.geom.x);
+      const sizeOf = (e) => (size === "h" ? e.geom.h : e.geom.w);
+      const pSpread = r1(Math.max(...withGeom.map(posOf)) - Math.min(...withGeom.map(posOf)));
+      const sSpread = r1(Math.max(...withGeom.map(sizeOf)) - Math.min(...withGeom.map(sizeOf)));
+      if (pSpread > alignTol)
+        errors.push(`E-LAYOUT-ALIGN ${ctxA}: ${label}s differ by ${pSpread}px across ${withGeom.length} member(s) — members of one alignment ${axis} must share it`);
+      if (sSpread > alignTol)
+        errors.push(`E-LAYOUT-ALIGN ${ctxA}: ${size === "h" ? "heights" : "widths"} differ by ${sSpread}px — an alignment ${axis} implies equal extent`);
+    }
+  }
+
+  if (declaredInv) {
+    const actual = new Map();
+    for (const [attr, cntAttr, axis] of [["data-align-row", "data-align-row-count", "row"], ["data-align-col", "data-align-col-count", "col"]])
+      for (const e of els.filter((x) => x.a[attr])) {
+        const k = `${axis}:${e.a[attr]}`;
+        actual.set(k, (actual.get(k) ?? 0) + 1);
+        void cntAttr;
+      }
+    for (const [k, n] of declaredInv) {
+      if (!actual.has(k)) errors.push(`E-LAYOUT-ALIGN-SCHEMA: alignment group "${k}" is declared in the inventory but no participant carries it — the whole group is missing`);
+      else if (actual.get(k) !== n) errors.push(`E-LAYOUT-ALIGN-SCHEMA: alignment group "${k}" has ${actual.get(k)} participant(s) but the inventory declares ${n}`);
+    }
+    for (const k of actual.keys())
+      if (!declaredInv.has(k)) errors.push(`E-LAYOUT-ALIGN-SCHEMA: alignment group "${k}" exists in the artifact but is absent from the inventory`);
+  }
+
   const receipt = { file: path.basename(file), containers: [], groups: [], clusters: [], unverified };
 
   // ---- containers (duplicate id = error) ----

--- a/skills/svg-infographic/scripts/check-layout.test.mjs
+++ b/skills/svg-infographic/scripts/check-layout.test.mjs
@@ -119,3 +119,31 @@ test("positive: 라벨 열을 예약하면 내용은 예약 경계 기준으로 
 });
 test("12 예약된 라벨 열 안으로 자식이 들어가면 거부", () =>
   neg("ln-reserve-left-breach.svg", /E-LAYOUT-RESERVE container "band"/));
+
+// --- alignment grid: 정렬 + **참여 완결성** ------------------------------------------
+test("positive: mirrored row와 격자 column이 정렬·참여 수를 모두 만족", () => {
+  const r = run([path.join(FIX, "lp-align-grid.svg")]);
+  assert.equal(r.code, 0, r.out);
+});
+test("13 mirrored row 한쪽 annotation 누락", () =>
+  neg("ln-align-missing-mirror.svg", /E-LAYOUT-ALIGN-SCHEMA row "slot-1": declared 2 participant\(s\) but found 1/));
+test("14 격자 셀 하나의 align annotation 누락", () =>
+  neg("ln-align-missing-cell.svg", /E-LAYOUT-ALIGN-SCHEMA col "col-b": declared 2 participant\(s\) but found 1/));
+test("15 같은 row의 y drift", () =>
+  neg("ln-align-row-drift.svg", /E-LAYOUT-ALIGN row "slot-1": top edges differ by 6px/));
+test("16 같은 column의 width drift", () =>
+  neg("ln-align-col-drift.svg", /E-LAYOUT-ALIGN col "col-a": widths differ by 20px/));
+test("17 참여 수 선언 충돌(위조)", () =>
+  neg("ln-align-count-forged.svg", /E-LAYOUT-ALIGN-SCHEMA row "slot-1": participants disagree/));
+test("18 singleton alignment group은 통과하지 않는다", () =>
+  neg("ln-align-singleton.svg", /E-LAYOUT-ALIGN-SCHEMA row "lonely": data-align-row-count must be an integer ≥ 2/));
+
+// --- alignment inventory: group 전체 누락·예상 밖 group -------------------------------
+test("19 mirrored row 양쪽 annotation을 모두 제거해도 inventory가 잡는다", () =>
+  neg("ln-align-inventory-group-gone.svg", /alignment group "row:slot-2" is declared in the inventory but no participant carries it/));
+test("20 격자 row group 전체 제거", () =>
+  neg("ln-align-inventory-row-gone.svg", /alignment group "row:matrix-r1" is declared in the inventory but no participant carries it/));
+test("21 격자 column group 전체 제거", () =>
+  neg("ln-align-inventory-col-gone.svg", /alignment group "col:matrix-c1" is declared in the inventory but no participant carries it/));
+test("22 inventory에 없는 group 추가", () =>
+  neg("ln-align-inventory-unexpected.svg", /alignment group "row:slot-9" exists in the artifact but is absent from the inventory/));

--- a/skills/svg-infographic/scripts/font-probe.mjs
+++ b/skills/svg-infographic/scripts/font-probe.mjs
@@ -16,11 +16,13 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { pathToFileURL, fileURLToPath } from "node:url";
-import { resolveBrowser } from "./render.mjs";
+import { resolveBrowser, dumpDom } from "./render.mjs";
 import { preflight } from "./preflight-lib.mjs";
+
 
 preflight({ entrypointUrl: import.meta.url });
 
+const PROBE_NAME = "font-probe";
 const args = process.argv.slice(2);
 const json = args.includes("--json");
 const svgPath = args.find((a) => !a.startsWith("--"));
@@ -95,12 +97,17 @@ ${svg}
 </script>`;
 const htmlPath = path.join(dir, "probe.html");
 writeFileSync(htmlPath, html);
-const r = spawnSync(browser.path, [
+const r = await dumpDom(browser.path, [
   "--headless=new", "--disable-gpu", "--hide-scrollbars",
   `--user-data-dir=${path.join(dir, "profile")}`,
   "--no-first-run", "--no-default-browser-check",
   "--dump-dom", "--virtual-time-budget=4000", "--timeout=8000", pathToFileURL(htmlPath).href,
-], { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, timeout: 30000 });
+], { timeoutMs: 30000 });
+if (r.reason === "timeout" || r.reason === "spawn-error") {
+  rmSync(dir, { recursive: true, force: true });
+  console.error(`${PROBE_NAME}: browser probe did not finish (${r.reason}) — fail-closed`);
+  process.exit(1);
+}
 rmSync(dir, { recursive: true, force: true });
 const m = (r.stdout || "").match(/<pre id="probe-out">([\s\S]*?)<\/pre>/);
 if (!m || !m[1].trim()) { console.error("font-probe: probe output not found (browser JS did not run)"); process.exit(1); }

--- a/skills/svg-infographic/scripts/generate.mjs
+++ b/skills/svg-infographic/scripts/generate.mjs
@@ -13,14 +13,14 @@
 //   node generate.mjs build  --typepack <id> --case <case> --locale ko|en --out <svg> --receipt <json>
 //   node generate.mjs verify --receipt <json> [--svg <svg>] [--pair <other-locale-receipt>]
 // exit: 0 ok · 1 error · 2 usage · 3 needs-split(비성공, degrade receipt 기록) · 7 preflight
-import { readFileSync, writeFileSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, rmSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { preflight, guardPackagePath, provenance, SKILL_LOCATOR } from "./preflight-lib.mjs";
-import { parseYaml } from "./skin.mjs";
+import { parseYaml, derivePanelFloor, deriveAlignInventory, serializeAlignInventory, deriveMatrixPlacement } from "./skin.mjs";
 import { estimateWidth } from "./check-svg.mjs";
 import { planChannels, routeEdges, pathData, auditTopology, alignRows, ROUTE_DEFAULTS } from "./route-orthogonal.mjs";
 
@@ -56,15 +56,20 @@ function loadCase(tid, caseId) {
 // geometry 판정은 manifest fit params에서 계산한다(문서 상수 재복사 금지)
 function computeFit(tp, sc) {
   const prm = tp.fit.params;
+  // 같은 구성의 footprint가 선언한 extra(축 라벨 등)를 함께 반영한다 — validator와 같은 수치를 쓴다.
+  const fp = (Array.isArray(tp.fit.footprint) ? tp.fit.footprint : []).find((f) =>
+    Number(f.count) === Number(sc.count) && f.layout === sc.layout
+    && String(f.cols ?? "") === String(sc.cols ?? "") && String(f.floor ?? "base") === String(sc.floor ?? "base"));
+  const ex = { w: Number(fp?.extraW ?? 0), h: Number(fp?.extraH ?? 0) };
   const fl = sc.floor && sc.floor !== "base" ? sc.floor : null;
   const iw = Number(fl ? prm[`${fl}ItemMinW`] : prm.itemMinW);
   const ih = Number(fl ? prm[`${fl}ItemMinH`] : prm.itemMinH);
   const gx = Number(prm.gapX ?? 0), gy = Number(prm.gapY ?? 0), n = Number(sc.count);
-  if (sc.layout === "row") return { w: n * iw + (n - 1) * gx, h: ih };
-  if (sc.layout === "column") return { w: iw, h: n * ih + (n - 1) * gy };
+  if (sc.layout === "row") return { w: n * iw + (n - 1) * gx + ex.w, h: ih + ex.h };
+  if (sc.layout === "column") return { w: iw + ex.w, h: n * ih + (n - 1) * gy + ex.h };
   if (sc.layout === "grid") {
     const cols = Number(sc.cols), rows = Math.ceil(n / cols);
-    return { w: cols * iw + (cols - 1) * gx, h: rows * ih + (rows - 1) * gy };
+    return { w: cols * iw + (cols - 1) * gx + ex.w, h: rows * ih + (rows - 1) * gy + ex.h };
   }
   if (sc.layout === "zones") {
     const npz = Number(prm.maxNodesPerZone), pad = Number(prm.zonePad), band = Number(prm.zoneLabelBand), zg = Number(prm.zoneGap);
@@ -592,6 +597,175 @@ function renderNestedScope(input, loc, cb, sc, tp) {
       attempts: [], diagnostics: [], demoted: [], routes: [] } };
 }
 
+
+// ---------- before-after (좌우 mirrored — 정렬이 대응을 나른다) ----------
+function renderBeforeAfter(input, loc, cb, sc, tp) {
+  const panels = input.panels, slots = input.slots, delta = input.delta ?? [];
+  const P = tp.fit?.params ?? {};
+  const gutter = Number(P.gapX ?? 32), pad = Number(P.panelPad ?? 16), rowGap = Number(P.slotGap ?? 10);
+  const slotMinH = Number(P.slotMinH ?? 38);
+  const panelW = (cb.w - gutter) / 2;
+  const textW = panelW - 2 * pad - 24;
+  const wrapAll = (lc) => slots.map((st) => panels.map((p) =>
+    wrapLines(String(st[p.id]?.[lc] ?? ""), textW, 13, false, 2)));
+  if (["ko", "en"].some((lc) => wrapAll(lc).some((r) => r.some((x) => x.overflow)))) {
+    console.error("generate: a slot line exceeds the §2 budget at this layout"); process.exit(1);
+  }
+  // 행은 반복 항목이다 — 한 높이를 공유한다(양쪽 패널·두 locale 중 가장 긴 것이 정한다).
+  // 그래야 같은 slot이 같은 y에 오고, 반복 항목 크기 계약도 성립한다.
+  const rowUnit = Math.max(slotMinH, ...["ko", "en"].flatMap((lc) =>
+    wrapAll(lc).flat().map((r) => r.lines.length * 17 + 20)));
+  const rowH = slots.map(() => rowUnit);
+  const headH = Number(P.panelHeaderH ?? 34);
+  const bodyH = rowH.reduce((a, b) => a + b, 0) + (slots.length - 1) * rowGap;
+  // floor 산식은 skin.mjs의 derivePanelFloor가 소유한다 — validator와 같은 함수를 쓴다.
+  const f = derivePanelFloor(P);
+  if (!f.declared || f.missing?.length) {
+    console.error(`generate: before-after needs the floor components (${(f.missing ?? []).join(", ") || "panelPad, panelHeaderH, slotMinH, slotGap, minSlots"}) in fit.params`);
+    process.exit(1);
+  }
+  const floorH = f.value;
+  if (Number(P.itemMinH) !== floorH) {
+    console.error(`generate: declared panel floor ${P.itemMinH} != derived ${floorH} (${f.formula})`);
+    process.exit(1);
+  }
+  const panelH = Math.max(floorH, headH + pad + bodyH + pad);
+  const consumed = [], containers = [], nodeArt = [], labels = [];
+  const laid = wrapAll(loc);
+  panels.forEach((p, pi) => {
+    const px = cb.x + pi * (panelW + gutter);
+    consumed.push(p.id);
+    containers.push(`  <g data-comp-entity="${p.id}" data-entity="${p.id}" data-layout-role="panel">
+    <rect x="${r1(px)}" y="${r1(cb.y)}" width="${r1(panelW)}" height="${r1(panelH)}" rx="14" fill="${pi === 0 ? "#F4F8FC" : "#EFF5EC"}" stroke="#DEE0E2" stroke-width="1" data-fill-role="surface-tint" data-stroke-role="rule" data-layout-container="${p.id}" data-min-pad="${pad}" data-reserve-top="${headH}" data-layout-count="${slots.length}" data-symmetry="x"/>
+    <text x="${r1(px + pad)}" y="${r1(cb.y + headH / 2 + 3)}" font-size="13" font-weight="700" fill="#636A75" data-fill-role="muted" dominant-baseline="central">${esc(p.title[loc])}</text>
+  </g>`);
+    let y = cb.y + headH + pad;
+    slots.forEach((st, si) => {
+      const t = laid[si][pi];
+      const changed = st.change === "changed";
+      // 같은 slot은 두 패널에서 같은 행 id를 공유한다 — 정렬이 곧 대응이다.
+      nodeArt.push(`  <g data-comp-entity="${p.id}-${st.id}">
+    <rect x="${r1(px + pad)}" y="${r1(y)}" width="${r1(panelW - 2 * pad)}" height="${r1(rowH[si])}" rx="9" fill="#FFFFFF" stroke="${changed && pi === 1 ? "#9BC3A5" : "#DEE0E2"}" stroke-width="1" data-fill-role="surface" data-stroke-role="rule" data-layout-parent="${p.id}" data-layout-item="${p.id}-rows" data-align-row="slot-${st.id}" data-align-row-count="${panels.length}"/>
+    <text font-size="13" fill="#252B35" data-fill-role="ink" dominant-baseline="central">${tspans(t.lines, px + pad + 12, y + rowH[si] / 2 - (t.lines.length - 1) * 8.5, 17)}</text>
+  </g>`);
+      y += rowH[si] + rowGap;
+    });
+    containers.push(`  <g data-layout-group="${p.id}-rows" data-distribution="equal-gap" data-axis="y" data-group-count="${slots.length}"></g>`);
+  });
+  let bottom = cb.y + panelH;
+  if (delta.length) {
+    const dy = bottom + 22;
+    labels.push(`  <g data-layout-role="delta-strip">` + delta.map((d, i) =>
+      `<text data-entity="${d.id}" x="${r1(cb.x)}" y="${r1(dy + i * 20)}" font-size="12.5" fill="#636A75" data-fill-role="muted" dominant-baseline="central">${esc("· " + d.text[loc])}</text>`).join("") + `</g>`);
+    for (const d of delta) consumed.push(d.id);
+    bottom = dy + (delta.length - 1) * 20 + 12;
+  }
+  const inv = serializeAlignInventory(deriveAlignInventory("before-after", input, sc));
+  return { body: [`  <g data-layer="containers" data-align-inventory="${inv}">`, ...containers, `  </g>`,
+      `  <g data-layer="connectors"></g>`, `  <g data-layer="nodes">`, ...nodeArt, `  </g>`,
+      `  <g data-layer="annotations">`, ...labels, `  </g>`].join("\n"),
+    consumed, bounds: { x: cb.x, y: cb.y, w: cb.w, h: bottom - cb.y },
+    routing: { degradeLevel: 0, ladder: [], problems: [], hops: 0, legend: false, alignment: [],
+      attempts: [], diagnostics: [], demoted: [], routes: [] } };
+}
+
+// ---------- decision-matrix (축은 밖, 셀은 격자) ----------
+// 축은 **ordinal category direction**이다 — 수치 간격도, chart scale도 아니다.
+// 따라서 tick·숫자·gridline은 없고, 방향(위/오른쪽이 높음)만 표시한다.
+// 축은 connector가 아니다: data-route-* 를 쓰지 않으므로 routing audit 대상이 아니고,
+// direction marker는 primary connector arrow보다 가늘게(우선순위가 낮게) 파생한다.
+const AXIS_SHAFT = 1.5;                         // primary connector 2.5 / secondary 2.2보다 얇다
+const AXIS_HEAD = r1(4.5 * AXIS_SHAFT);         // marker 크기는 connector와 **같은 산식**에서 파생한다
+function renderDecisionMatrix(input, loc, cb, sc, tp) {
+  const cells = input.cells, ax = input.axes;
+  const pl = deriveMatrixPlacement(input);
+  const cols = pl.cols, rows = pl.rows;
+  if (Number(sc.cols) !== cols) { console.error(`generate: scenario declares cols ${sc.cols} but axes.x declares ${cols} tiers`); process.exit(1); }
+  const P = tp.fit?.params ?? {};
+  const gx = Number(P.gapX ?? 16), gy = Number(P.gapY ?? 16);
+  const padY = Number(P.cellPadY ?? 14);
+  const pad = 12, axisGap = 12, endLabel = 11;
+  const endOf = (a, which) => (which === "high" ? pl[a === "x" ? "xTiers" : "yTiers"].at(-1) : pl[a === "x" ? "xTiers" : "yTiers"][0]);
+  // 축 라벨 열 폭은 **실제 문안**(두 locale 최대)에서 파생한다 — 고정 상수면 KO에서 넘친다.
+  const axisTextW = Math.max(...["ko", "en"].flatMap((lc) =>
+    ["low", "high"].map((w) => estimateWidth(String(endOf("y", w).label[lc]), endLabel, true, 0))));
+  // 예약 = [라벨][라벨↔축선 간격][축선↔격자 간격]. 축선이 격자에도 라벨에도 닿지 않는다.
+  const axisCol = Math.max(48, axisTextW + 8 + axisGap + 4);
+  const axisRow = axisGap + 22;
+  // 격자 폭은 **예약(축 라벨 열)과 container pad를 뺀 실제 폭**에서 계산한다 —
+  // 경계에 정확히 닿는 것도 통과가 아니므로 양쪽 pad를 실제로 비운다.
+  const gridW = cb.w - axisCol - 2 * pad;
+  const cw = (gridW - (cols - 1) * gx) / cols;
+  const x0 = cb.x + axisCol + pad, y0 = cb.y + pad;
+  // cell 높이는 canvas가 아니라 **내용**이 정한다. 두 locale 최대 line-box + 상하 padding이며
+  // 남는 자리를 채우려고 늘리지 않는다(남는 것은 residual 계약이 선언한다).
+  const wrapped = new Map();
+  let ch = 0;
+  for (const c of cells) {
+    for (const lc of ["ko", "en"]) {
+      const nameL = wrapLines(cellName(c, pl, lc), cw - 2 * pad, 14, true, 2);
+      const traitL = wrapLines(c.trait[lc], cw - 2 * pad, 12, false, 2);
+      if (nameL.overflow || traitL.overflow) { console.error(`generate: cell "${c.id}" text exceeds the §2 budget (${lc})`); process.exit(1); }
+      wrapped.set(`${c.id}|${lc}`, { nameL, traitL });
+      ch = Math.max(ch, padY + nameL.lines.length * 18 + 6 + traitL.lines.length * 16 + padY);
+    }
+  }
+  const gridH = rows * ch + (rows - 1) * gy;
+  const consumed = [], containers = [], nodeArt = [], labels = [];
+  // 격자 전체를 하나의 container로 두고, 축 라벨 구간을 **가로·세로 예약**으로 선언한다.
+  containers.push(`  <rect data-layout-container="matrix" x="${r1(cb.x)}" y="${r1(cb.y)}" width="${r1(cb.w)}" height="${r1(gridH + 2 * pad)}" fill="none" stroke="none" data-min-pad="${pad}" data-reserve-left="${axisCol}" data-reserve-top="0" data-layout-count="${cells.length}"/>`);
+  const inRow = (r) => pl.cells.filter((c) => c.row === r).length;
+  const inCol = (c) => pl.cells.filter((x) => x.col === c).length;
+  for (let r = 0; r < rows; r++)
+    if (inRow(r) === cols)   // 완전한 행만 등간격 group을 선언한다(빈 칸이 있으면 열 정렬이 지배한다)
+      containers.push(`  <g data-layout-group="matrix-row-${r}" data-distribution="equal-gap" data-axis="x" data-group-count="${cols}"></g>`);
+  cells.forEach((c, i) => {
+    const p = pl.cells[i];
+    const cx = x0 + p.col * (cw + gx), cy = y0 + p.row * (ch + gy);
+    consumed.push(c.id);
+    const rowCount = inRow(p.row), colCount = inCol(p.col);
+    const { nameL, traitL } = wrapped.get(`${c.id}|${loc}`);
+    nodeArt.push(`  <g data-comp-entity="${c.id}" data-entity="${c.id}" data-cell-x="${esc(c.x)}" data-cell-y="${esc(c.y)}">
+    <rect x="${r1(cx)}" y="${r1(cy)}" width="${r1(cw)}" height="${r1(ch)}" rx="12" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1" data-fill-role="surface" data-stroke-role="rule" data-layout-parent="matrix"${rowCount === cols ? ` data-layout-item="matrix-row-${p.row}"` : ""}${rowCount >= 2 ? ` data-align-row="matrix-r${p.row}" data-align-row-count="${rowCount}"` : ""}${colCount >= 2 ? ` data-align-col="matrix-c${p.col}" data-align-col-count="${colCount}"` : ""}/>
+    <text font-size="14" font-weight="700" fill="#252B35" data-fill-role="ink" dominant-baseline="central">${tspans(nameL.lines, cx + pad, cy + padY + 9, 18)}</text>
+    <text font-size="12" fill="#636A75" data-fill-role="muted" dominant-baseline="central">${tspans(traitL.lines, cx + pad, cy + padY + 9 + nameL.lines.length * 18 + 6, 16)}</text>
+  </g>`);
+  });
+  // 축은 패널 **밖**에 둔다(spec §5): 세로축은 격자 왼쪽, 가로축은 격자 아래.
+  const gridBottom = y0 + gridH, gridRight = x0 + gridW;
+  const ayX = r1(x0 - axisGap), axY = r1(gridBottom + axisGap);
+  const A = `fill="none" data-stroke-role="muted" stroke="#636A75" stroke-width="${AXIS_SHAFT}" stroke-linecap="round" stroke-linejoin="round"`;
+  const h = AXIS_HEAD / 2;
+  labels.push(`  <g data-layout-role="axis" data-axis-kind="ordinal-direction">
+    <path data-axis="y" data-axis-orientation="vertical" data-axis-positive="up" d="M${ayX} ${r1(gridBottom)} V${r1(y0)}" ${A}/>
+    <path data-axis-marker="y" d="M${r1(ayX - h)} ${r1(y0 + AXIS_HEAD)} L${ayX} ${r1(y0)} L${r1(ayX + h)} ${r1(y0 + AXIS_HEAD)}" ${A}/>
+    <path data-axis="x" data-axis-orientation="horizontal" data-axis-positive="right" d="M${r1(x0)} ${axY} H${r1(gridRight)}" ${A}/>
+    <path data-axis-marker="x" d="M${r1(gridRight - AXIS_HEAD)} ${r1(Number(axY) - h)} L${r1(gridRight)} ${axY} L${r1(gridRight - AXIS_HEAD)} ${r1(Number(axY) + h)}" ${A}/>
+    <text data-axis-end="y:high" x="${r1(ayX - 8)}" y="${r1(y0 + 8)}" font-size="${endLabel}" font-weight="700" fill="#636A75" data-fill-role="muted" text-anchor="end" dominant-baseline="central">${esc(endOf("y", "high").label[loc])}</text>
+    <text data-axis-end="y:low" x="${r1(ayX - 8)}" y="${r1(gridBottom - 8)}" font-size="${endLabel}" font-weight="700" fill="#636A75" data-fill-role="muted" text-anchor="end" dominant-baseline="central">${esc(endOf("y", "low").label[loc])}</text>
+    <text data-axis-end="x:low" x="${r1(x0)}" y="${r1(Number(axY) + 14)}" font-size="${endLabel}" font-weight="700" fill="#636A75" data-fill-role="muted" dominant-baseline="central">${esc(endOf("x", "low").label[loc])}</text>
+    <text data-axis-end="x:high" x="${r1(gridRight)}" y="${r1(Number(axY) + 14)}" font-size="${endLabel}" font-weight="700" fill="#636A75" data-fill-role="muted" text-anchor="end" dominant-baseline="central">${esc(endOf("x", "high").label[loc])}</text>
+  </g>`);
+  const inv = serializeAlignInventory(deriveAlignInventory("decision-matrix", input, sc));
+  return { body: [`  <g data-layer="containers" data-align-inventory="${inv}">`, ...containers, `  </g>`,
+      `  <g data-layer="connectors"></g>`, `  <g data-layer="nodes">`, ...nodeArt, `  </g>`,
+      `  <g data-layer="annotations">`, ...labels, `  </g>`].join("\n"),
+    consumed, bounds: { x: cb.x, y: cb.y, w: cb.w, h: gridH + 2 * pad + axisRow },
+    matrix: { kind: "ordinal-direction", cols, rows, cellH: r1(ch), cellW: r1(cw),
+      axes: { x: { positive: "right", tiers: pl.xTiers.map((t) => t.id) },
+        y: { positive: "up", tiers: pl.yTiers.map((t) => t.id) } },
+      placement: pl.cells.map((c) => ({ id: c.id, x: c.x, y: c.y, row: c.row, col: c.col,
+        alignRow: inRow(c.row) >= 2 ? `matrix-r${c.row}` : null, alignCol: inCol(c.col) >= 2 ? `matrix-c${c.col}` : null })) },
+    routing: { degradeLevel: 0, ladder: [], problems: [], hops: 0, legend: false, alignment: [],
+      attempts: [], diagnostics: [], demoted: [], routes: [] } };
+}
+// name은 선택이다 — 없으면 두 축 tier label에서 파생한다(순서가 모호한 "낮음-높음"을 쓰지 않는다).
+function cellName(c, pl, lc) {
+  if (c.name) return c.name[lc];
+  const yt = pl.yTiers.find((t) => t.id === c.y), xt = pl.xTiers.find((t) => t.id === c.x);
+  return `${yt.label[lc]} · ${xt.label[lc]}`;
+}
+
 // ---------- font delivery (portable = 사용 glyph subset embed) ----------
 // 계약: portable은 대상 환경의 설치 글꼴에 의존하지 않는다. subset 도구가 없거나 glyph가
 // 빠지면 **full embed로도, system fallback으로도 조용히 넘어가지 않고 실패한다**.
@@ -608,7 +782,10 @@ function subsetFace(facePath, chars, tool, style, weight, alias, rfn) {
   // acceptance artifact를 만들 수 없다.
   const python = process.env.SVGINFO_PYTHON ?? tool.command ?? "python3";
   const wrapper = guardPackagePath(path.join(here, "..", String(tool.wrapper)), "font subset wrapper");
-  const tmp = path.join(tmpdir(), `svginfo-subset-${weight}-${createHash("sha256").update(chars).digest("hex").slice(0, 12)}.woff2`);
+  // 경로는 **호출마다 새로** 만든다. 내용으로 이름을 지으면 같은 글자 집합을 동시에 subset하는
+  // 두 build가 같은 파일을 쓰고 서로의 것을 지운다(작업 디렉터리는 공유 tmp다).
+  const work = mkdtempSync(path.join(tmpdir(), "svginfo-subset-"));
+  const tmp = path.join(work, `face-${weight}.woff2`);
   const textFile = tmp + ".txt";
   writeFileSync(textFile, chars);
   const args = [wrapper, "--face", facePath, "--text-file", textFile, "--out", tmp,
@@ -616,20 +793,23 @@ function subsetFace(facePath, chars, tool, style, weight, alias, rfn) {
     "--expect-fonttools", String(tool.version), "--expect-brotli", String(tool.brotli),
     ...rfn.flatMap((n) => ["--rfn", String(n)])];
   const r = spawnSync(python, args, { encoding: "utf8" });
+  const done = () => rmSync(work, { recursive: true, force: true });
   rmSync(textFile, { force: true });
   if (r.error?.code === "ENOENT") {
+    done();
     console.error(`generate: portable delivery needs the pinned toolchain (${tool.name} ${tool.version} + brotli ${tool.brotli}) run through ${tool.wrapper}.\n  It is a build-only dependency: point SVGINFO_PYTHON at an interpreter that has it, or generate with --font-delivery system (environment-dependent, not acceptance-grade).`);
     process.exit(4);
   }
   if (r.status !== 0) {
+    done();
     console.error(`generate: subsetting failed (exit ${r.status})\n${(r.stdout ?? "") + (r.stderr ?? "")}`.trimEnd());
     process.exit(4);
   }
   let receipt;
-  try { receipt = JSON.parse(r.stdout); } catch { console.error("generate: subset wrapper did not return JSON"); process.exit(4); }
-  if (receipt.rfnGuard !== "clean") { console.error("generate: subset wrapper did not certify the reserved-name guard"); process.exit(4); }
+  try { receipt = JSON.parse(r.stdout); } catch { done(); console.error("generate: subset wrapper did not return JSON"); process.exit(4); }
+  if (receipt.rfnGuard !== "clean") { done(); console.error("generate: subset wrapper did not certify the reserved-name guard"); process.exit(4); }
   const buf = readFileSync(tmp);
-  rmSync(tmp, { force: true });
+  done();
   return { buf, receipt };
 }
 
@@ -688,6 +868,8 @@ function build(argv) {
     : tid === "approval-gate" ? renderApprovalGate(input, loc, cbox, sc, tp)
     : tid === "layer-stack" ? renderLayerStack(input, loc, cbox, sc, tp)
     : tid === "nested-scope" ? renderNestedScope(input, loc, cbox, sc, tp)
+    : tid === "before-after" ? renderBeforeAfter(input, loc, cbox, sc, tp)
+    : tid === "decision-matrix" ? renderDecisionMatrix(input, loc, cbox, sc, tp)
     : (console.error(`generate: no renderer registered for "${tid}"`), process.exit(2));
   let pf = spawnJson([skinCli, "pageframe", preset, "--json"], "skin.mjs pageframe");
   if (pf.regions.fluid) {
@@ -700,7 +882,7 @@ function build(argv) {
   const geometry = need.w <= cb.w && need.h <= cb.h ? "fits" : "needs-split";
   const expected = sc.geometry_expected ?? "fits";
   const base = { schemaVersion: 1, command: "generate", typepack: tid, case: sc.id, locale: loc,
-    preset, presetDeclared: tp.presets.includes(preset), presetPreferred: tp.preferred_preset ?? null,
+    preset, cols: sc.cols ?? null, presetDeclared: tp.presets.includes(preset), presetPreferred: tp.preferred_preset ?? null,
     presetsSupported: tp.presets ?? [], audition: Boolean(override) && !tp.presets.includes(preset), layout: sc.layout, count: Number(sc.count), inputDigest,
     geometry, geometryExpected: expected, routingExpected: sc.routing_expected ?? null,
     footprint: { w: r1(need.w), h: r1(need.h) }, contentBox: { w: cb.w, h: cb.h } };
@@ -718,6 +900,18 @@ function build(argv) {
   }
 
   const R = render(cb);
+  // fit 예측은 **최소 합법 문법의 floor**다. 내용이 그 floor를 넘겨 자란 배치가 실제로
+  // contentBox를 벗어나면, 낙관적인 예측이 통과시킨 것을 여기서 다시 거부한다.
+  if (R.bounds.h > cb.h + 1) {
+    const degrade = { ...base, status: "needs-split", artifact: null, consumed: [],
+      degrade: { reason: `measured layout is ${r1(R.bounds.h)}px tall against contentBox ${cb.h}px — the declared fit floor (${r1(need.h)}px) is a lower bound and the content grew past it`,
+                 ladder: "spec §6 — reduce optional content, select a declared variant, then split the page" },
+      provenance: provenance({ producer: { kind: "generator", generatorDigest: sha(readFileSync(fileURLToPath(import.meta.url))) },
+        inputs: [{ role: "typepack-input", digest: inputDigest }] }) };
+    writeFileSync(rcp, JSON.stringify(degrade, null, 1) + "\n");
+    console.log(`generate ${tid}/${sc.id}/${loc} — needs-split (measured overflow); degrade receipt written`);
+    process.exit(3);
+  }
   const routingExpected = sc.routing_expected ?? null;
   if (routingExpected === "needs-split" && !R.needsSplit) {
     console.error(`generate: scenario declares routing_expected needs-split but the router found a legal layout — update the declaration`);
@@ -781,6 +975,7 @@ ${R.body}
       alias: embedded.alias ?? null, glyphs: embedded.chars ?? 0, faces: embedded.faces,
       tool: embedded.tool ?? null, wrapperDigest: embedded.wrapperDigest ?? null, identity: embedded.identity ?? [] },
     routing: R.routing ?? null,
+    matrix: R.matrix ?? null,
     residual, residualDisposition: decl,
     provenance: provenance({ producer: { kind: "generator", generatorDigest: sha(readFileSync(fileURLToPath(import.meta.url))) },
       inputs: [{ role: "typepack-input", digest: inputDigest }] }) };
@@ -796,6 +991,8 @@ function semanticIds(input, tid) {
   if (tid === "process-flow") for (const st of input.steps ?? []) ids.push(st.id);
   if (tid === "layer-stack") for (const L of input.layers ?? []) { ids.push(L.id); for (const c of L.items ?? []) ids.push(c.id); }
   if (tid === "nested-scope") for (const rg of input.rings ?? []) ids.push(rg.id);
+  if (tid === "before-after") { for (const p of input.panels ?? []) ids.push(p.id); for (const d of input.delta ?? []) ids.push(d.id); }
+  if (tid === "decision-matrix") for (const c of input.cells ?? []) ids.push(c.id);
   if (tid === "approval-gate") {
     for (const nd of input.nodes ?? []) ids.push(nd.id);
     if (input.gate?.id) ids.push(input.gate.id);
@@ -806,6 +1003,90 @@ function semanticIds(input, tid) {
     if (input.boundary) ids.push("boundary");
   }
   return ids;
+}
+// decision-matrix 감사: **receipt를 믿지 않고** 원본 입력에서 기대 배치를 다시 계산하고,
+// 축 기하는 기록된 path에서 직접 읽는다. 축은 ordinal direction이므로 눈금·수치는 검사 대상이 아니다.
+function auditMatrixAxes(svg, input, loc) {
+  const errs = [], pl = deriveMatrixPlacement(input);
+  const attr = (s, k) => (s.match(new RegExp(`\\b${k}="([^"]*)"`)) ?? [])[1];
+  const numAttr = (s, k) => Number(attr(s, k));
+  // --- 1. cell 기하: 산출물에서 직접 읽는다 ---
+  const cells = [];
+  for (const m of svg.matchAll(/<g[^>]*data-entity="([^"]+)"[^>]*data-cell-x="([^"]*)"[^>]*data-cell-y="([^"]*)"[^>]*>\s*<rect([^>]*)\/>/g))
+    cells.push({ id: m[1], x: m[2], y: m[3], rx: numAttr(m[4], "x"), ry: numAttr(m[4], "y"),
+      rw: numAttr(m[4], "width"), rh: numAttr(m[4], "height") });
+  if (cells.length !== pl.cells.length) {
+    errs.push(`E-GEN-MATRIX artifact carries ${cells.length} placed cell(s) but the input declares ${pl.cells.length}`);
+    return errs;
+  }
+  const expOf = (id) => pl.cells.find((p) => p.id === id);
+  for (const c of cells) {
+    const e = expOf(c.id);
+    if (!e) { errs.push(`E-GEN-MATRIX artifact cell "${c.id}" is absent from the input`); continue; }
+    if (c.x !== e.x || c.y !== e.y)
+      errs.push(`E-GEN-MATRIX cell "${c.id}" carries axis values (${c.x}, ${c.y}) but the input declares (${e.x}, ${e.y})`);
+  }
+  if (errs.length) return errs;
+  // 자리는 좌표 상수가 아니라 **순서**로 증명한다 — 빈 칸이 있어도 성립하고, 뒤집히면 걸린다.
+  const sgn = (n) => (Math.abs(n) < 0.5 ? 0 : Math.sign(n));
+  for (let i = 0; i < cells.length; i++) for (let j = i + 1; j < cells.length; j++) {
+    const a = cells[i], b = cells[j], ea = expOf(a.id), eb = expOf(b.id);
+    for (const [axis, want, got, unit] of [
+      ["column", Math.sign(ea.col - eb.col), sgn(a.rx - b.rx), "x"],
+      ["row", Math.sign(ea.row - eb.row), sgn(a.ry - b.ry), "y"],
+    ]) if (want !== got)
+      errs.push(`E-GEN-MATRIX-PLACE cells "${a.id}" (${ea.x}, ${ea.y}) and "${b.id}" (${eb.x}, ${eb.y}) must differ in ${axis} by ${want} but their drawn ${unit} differs by ${got} — the axis value decides the position, not the declaration order`);
+  }
+  // --- 2. 축 기하: 존재·방향·positive 끝 ---
+  const axisPaths = [...svg.matchAll(/<path([^>]*data-axis="[xy]"[^>]*)\/>/g)].map((m) => m[1]);
+  const markers = [...svg.matchAll(/<path([^>]*data-axis-marker="[xy]"[^>]*)\/>/g)].map((m) => m[1]);
+  for (const a of [...axisPaths, ...markers])
+    if (/data-route-(id|from|to|kind)=/.test(a)) errs.push("E-GEN-AXIS an ordinal axis must not be classified as a connector (data-route-*)");
+  for (const which of ["x", "y"]) {
+    const line = axisPaths.filter((a) => attr(a, "data-axis") === which);
+    const mk = markers.filter((a) => attr(a, "data-axis-marker") === which);
+    if (line.length !== 1 || mk.length !== 1) {
+      errs.push(`E-GEN-AXIS the ${which} axis must be drawn exactly once with one direction marker (found ${line.length} line(s), ${mk.length} marker(s))`);
+      continue;
+    }
+    const d = attr(line[0], "d"), pts = [...d.matchAll(/-?[\d.]+/g)].map(Number);
+    const orient = attr(line[0], "data-axis-orientation"), pos = attr(line[0], "data-axis-positive");
+    const apex = [...attr(mk[0], "d").matchAll(/L(-?[\d.]+) (-?[\d.]+)/g)].map((m) => [Number(m[1]), Number(m[2])])[0];
+    if (which === "y") {
+      if (orient !== "vertical" || pts.length !== 3) { errs.push(`E-GEN-AXIS the y axis must be a single vertical run (orientation "${orient}")`); continue; }
+      const [ax, y1, y2] = pts, top = Math.min(y1, y2), bot = Math.max(y1, y2);
+      if (pos !== "up") errs.push(`E-GEN-AXIS the y axis declares positive "${pos}" — an ordinal y axis grows upward`);
+      if (Math.abs(apex[1] - top) > 1 || Math.abs(apex[0] - ax) > 1)
+        errs.push(`E-GEN-AXIS-DIR the y direction marker sits at ${r1(apex[1])} but the positive (up) end is ${r1(top)} — the marker must mark the high end`);
+      if (ax >= Math.min(...cells.map((c) => c.rx)) - 1) errs.push("E-GEN-AXIS the y axis intrudes into the grid — it must be drawn outside the cells");
+      if (bot < Math.max(...cells.map((c) => c.ry + c.rh)) - 1) errs.push("E-GEN-AXIS the y axis does not span the grid it labels");
+    } else {
+      if (orient !== "horizontal" || pts.length !== 3) { errs.push(`E-GEN-AXIS the x axis must be a single horizontal run (orientation "${orient}")`); continue; }
+      const [x1, ay, x2] = pts, right = Math.max(x1, x2);
+      if (pos !== "right") errs.push(`E-GEN-AXIS the x axis declares positive "${pos}" — an ordinal x axis grows rightward`);
+      if (Math.abs(apex[0] - right) > 1 || Math.abs(apex[1] - ay) > 1)
+        errs.push(`E-GEN-AXIS-DIR the x direction marker sits at ${r1(apex[0])} but the positive (right) end is ${r1(right)} — the marker must mark the high end`);
+      if (ay <= Math.max(...cells.map((c) => c.ry + c.rh)) + 1) errs.push("E-GEN-AXIS the x axis intrudes into the grid — it must be drawn outside the cells");
+    }
+  }
+  // --- 3. 끝점 label이 실제 방향과 같은 뜻인지 ---
+  const ends = new Map();
+  for (const m of svg.matchAll(/<text([^>]*data-axis-end="([^"]+)"[^>]*)>([^<]*)</g))
+    ends.set(m[2], { x: numAttr(m[1], "x"), y: numAttr(m[1], "y"), text: m[3] });
+  for (const k of ["y:high", "y:low", "x:high", "x:low"]) if (!ends.has(k)) errs.push(`E-GEN-AXIS endpoint label "${k}" is missing — both ends of both axes must be labelled`);
+  if (ends.size === 4) {
+    if (!(ends.get("y:high").y < ends.get("y:low").y))
+      errs.push("E-GEN-AXIS-DIR the y high label is not above the low label — the label order contradicts the axis direction");
+    if (!(ends.get("x:high").x > ends.get("x:low").x))
+      errs.push("E-GEN-AXIS-DIR the x high label is not right of the low label — the label order contradicts the axis direction");
+    for (const [k, tiers] of [["y", pl.yTiers], ["x", pl.xTiers]])
+      for (const [end, t] of [["high", tiers.at(-1)], ["low", tiers[0]]]) {
+        const want = esc(String(t.label[loc]));
+        if (ends.get(`${k}:${end}`).text !== want)
+          errs.push(`E-GEN-AXIS the ${k} ${end} label reads "${ends.get(`${k}:${end}`).text}" but the ${end} tier of that axis is "${want}"`);
+      }
+  }
+  return errs;
 }
 function verify(argv) {
   const opt = (n, d = null) => { const i = argv.indexOf(`--${n}`); return i >= 0 ? argv[i + 1] : d; };
@@ -835,6 +1116,14 @@ function verify(argv) {
       const inSvg = new Set([...svg.matchAll(/data-entity="([^"]+)"/g)].map((m) => m[1]));
       for (const i of ids) if (!inSvg.has(i) && i !== "boundary") errors.push(`E-GEN-CONSUME artifact is missing entity "${i}"`);
       for (const i of inSvg) if (!ids.includes(i) && i !== "legend") errors.push(`E-GEN-INVENT artifact carries invented entity "${i}"`);
+      // 정렬 inventory도 산출물을 믿지 않는다 — 원본 입력에서 다시 파생해 대조한다.
+      const expectedInv = serializeAlignInventory(deriveAlignInventory(rcp.typepack, input, { cols: rcp.cols ?? undefined }));
+      const gotInv = (svg.match(/data-align-inventory="([^"]*)"/) ?? [])[1];
+      if (expectedInv && gotInv === undefined)
+        errors.push("E-GEN-ALIGN artifact declares no alignment inventory but the input implies one");
+      else if (expectedInv !== (gotInv ?? ""))
+        errors.push(`E-GEN-ALIGN alignment inventory recomputed from the input does not match the artifact\n    input:    ${expectedInv}\n    artifact: ${gotInv ?? "(none)"}`);
+      if (rcp.typepack === "decision-matrix") for (const e of auditMatrixAxes(svg, input, rcp.locale)) errors.push(e);
       // 배선은 산출물에서 다시 잰다 — receipt가 아니라 기록된 path가 근거다
       const audit = auditTopology(svg);
       for (const e of audit.errors) errors.push(`E-GEN-ROUTE ${e}`);

--- a/skills/svg-infographic/scripts/generate.test.mjs
+++ b/skills/svg-infographic/scripts/generate.test.mjs
@@ -229,3 +229,111 @@ test("G-12: connector 없는 산출물의 layer 순서를 흐트러뜨리면 ver
   assert.match(r.out, /A-LAYER-ORDER/);
   drop(pkg);
 });
+
+test("G-13: SVG inventory까지 함께 지워도 입력에서 다시 계산한 verify가 잡는다", () => {
+  const pkg = pkgCopy();
+  const b = build(pkg, "before-after", "canonical", "ko");
+  assert.equal(b.code, 0, b.out);
+  assert.equal(runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]).code, 0);
+  // group annotation과 inventory 항목을 **함께** 제거한다 — 산출물 내부는 자기 일관적이다
+  const svg = readFileSync(b.svg, "utf8");
+  const stripped = svg
+    .replace(/data-align-inventory="[^"]*"/, 'data-align-inventory="row:slot-deploy=2"')
+    .replace(/ data-align-row="slot-rollback" data-align-row-count="2"/g, "");
+  writeFileSync(b.svg, stripped);
+  const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /E-GEN-ALIGN/);
+  drop(pkg);
+});
+
+test("G-14: 불완전 격자에서 participant가 1인 축은 group을 만들지 않는다", () => {
+  const pkg = pkgCopy();
+  // 3열에 셀 9개는 완전 격자 — 모든 행·열이 3이다
+  const b = build(pkg, "decision-matrix", "stress-cardinality", "ko");
+  assert.equal(b.code, 0, b.out);
+  const svg = readFileSync(b.svg, "utf8");
+  const inv = (svg.match(/data-align-inventory="([^"]*)"/) ?? [])[1];
+  assert.ok(inv && !/=1(;|$)/.test(inv), `singleton group must not appear in the inventory: ${inv}`);
+  drop(pkg);
+});
+
+// --- decision-matrix: 축 방향과 cell 배치는 축 값에서 파생돼야 한다 -----------------
+// 배열 순서로 자리를 정하면 "낮음" 행이 위로 올라가도 아무 gate가 울리지 않았다.
+// 아래 3종은 그 회귀를 각각 다른 층위에서 고정한다.
+
+test("G-15: 축 값이 자리를 정한다 — high/low 행을 뒤집으면 verify가 거부한다", () => {
+  const pkg = pkgCopy();
+  const b = build(pkg, "decision-matrix", "canonical", "ko");
+  assert.equal(b.code, 0, b.out);
+  assert.equal(runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]).code, 0);
+  // 두 행의 y좌표만 맞바꾼다 — 라벨도 축도 그대로라 산출물만 보면 멀쩡하다.
+  const svg = readFileSync(b.svg, "utf8");
+  const ys = [...svg.matchAll(/<rect x="[\d.]+" y="([\d.]+)"[^>]*data-align-row="matrix-r(\d)"/g)];
+  const top = ys.find((m) => m[2] === "0")[1], bot = ys.find((m) => m[2] === "1")[1];
+  writeFileSync(b.svg, svg.replace(new RegExp(`y="${top}"`, "g"), 'y="__T__')
+    .replace(new RegExp(`y="${bot}"`, "g"), `y="${top}"`).replace(/y="__T__/g, `y="${bot}"`));
+  const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /E-GEN-MATRIX-PLACE/);
+  drop(pkg);
+});
+
+test("G-16: 축 방향 marker가 반대 끝에 있으면 거부한다", () => {
+  const pkg = pkgCopy();
+  const b = build(pkg, "decision-matrix", "canonical", "ko");
+  const svg = readFileSync(b.svg, "utf8");
+  // y축 marker를 아래 끝으로 옮긴다 — 선도 라벨도 그대로다.
+  const line = svg.match(/<path data-axis="y"[^>]*d="M([\d.]+) ([\d.]+) V([\d.]+)"/);
+  const [, ax, bot, top] = line;
+  const moved = svg.replace(/<path data-axis-marker="y" d="[^"]*"/,
+    `<path data-axis-marker="y" d="M${Number(ax) - 3.4} ${Number(bot) - 6.8} L${ax} ${bot} L${Number(ax) + 3.4} ${Number(bot) - 6.8}"`);
+  assert.notEqual(moved, svg);
+  void top;
+  writeFileSync(b.svg, moved);
+  const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /E-GEN-AXIS-DIR/);
+  drop(pkg);
+});
+
+test("G-17: 축 방향과 라벨을 함께 뒤집어도 cell 배치가 어긋나면 거부한다", () => {
+  const pkg = pkgCopy();
+  const b = build(pkg, "decision-matrix", "canonical", "ko");
+  const svg = readFileSync(b.svg, "utf8");
+  // 산출물만 보면 **완전히 자기 일관적**이 되도록 전부 뒤집는다: positive=down,
+  // marker를 아래 끝으로, 두 끝 라벨 교환, 그리고 cell 행까지 교환.
+  // "y는 위로 자란다"는 계약과 원본 축 값이 없으면 이 산출물은 통과해버린다.
+  const line = svg.match(/<path data-axis="y"[^>]*d="M([\d.]+) ([\d.]+) V([\d.]+)"/);
+  const [, ax, bot] = line;
+  const hi = svg.match(/<text data-axis-end="y:high"[^>]*>([^<]*)</)[1];
+  const lo = svg.match(/<text data-axis-end="y:low"[^>]*>([^<]*)</)[1];
+  const ys = [...svg.matchAll(/<rect x="[\d.]+" y="([\d.]+)"[^>]*data-align-row="matrix-r(\d)"/g)];
+  const top = ys.find((m) => m[2] === "0")[1], low = ys.find((m) => m[2] === "1")[1];
+  const f = svg.replace('data-axis-positive="up"', 'data-axis-positive="down"')
+    .replace(/<path data-axis-marker="y" d="[^"]*"/,
+      `<path data-axis-marker="y" d="M${Number(ax) - 3.4} ${Number(bot) - 6.8} L${ax} ${bot} L${Number(ax) + 3.4} ${Number(bot) - 6.8}"`)
+    .replace(/(<text data-axis-end="y:high"[^>]*>)[^<]*</, `$1${lo}<`)
+    .replace(/(<text data-axis-end="y:low"[^>]*>)[^<]*</, `$1${hi}<`)
+    .replace(new RegExp(`y="${top}"`, "g"), 'y="__T__')
+    .replace(new RegExp(`y="${low}"`, "g"), `y="${top}"`)
+    .replace(/y="__T__/g, `y="${low}"`);
+  writeFileSync(b.svg, f);
+  const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+  assert.notEqual(r.code, 0, r.out);
+  // 두 층위가 함께 걸린다: 축 방향 계약(위가 positive)과 입력 축 값이 정한 실제 자리.
+  assert.match(r.out, /E-GEN-AXIS/);
+  assert.match(r.out, /E-GEN-MATRIX-PLACE/);
+  drop(pkg);
+});
+
+test("G-18: ordinal 축은 connector가 아니다 — routing audit 대상이 되지 않는다", () => {
+  const pkg = pkgCopy();
+  const b = build(pkg, "decision-matrix", "canonical", "ko");
+  const svg = readFileSync(b.svg, "utf8");
+  const axisBlock = svg.slice(svg.indexOf('data-layout-role="axis"'));
+  assert.ok(!/data-route-(id|from|to|kind)=/.test(axisBlock), "axis must not carry connector classification");
+  assert.ok(!/marker-end="url\(#ah-/.test(axisBlock), "axis must not reuse the connector arrowhead marker");
+  assert.equal(runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]).code, 0);
+  drop(pkg);
+});

--- a/skills/svg-infographic/scripts/layout-fixtures/ln-align-col-drift.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/ln-align-col-drift.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 220" width="420" height="220">
+  <!-- 같은 column인데 폭이 20px 다르다 -->
+  <rect data-align-col="col-a" data-align-col-count="2" x="20" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-align-col="col-a" data-align-col-count="2" x="20" y="120" width="150" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+</svg>

--- a/skills/svg-infographic/scripts/layout-fixtures/ln-align-count-forged.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/ln-align-count-forged.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 120" width="420" height="120">
+  <!-- 참여자끼리 기대 수가 다르다(위조·불일치) -->
+  <rect data-align-row="slot-1" data-align-row-count="2" x="20" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-align-row="slot-1" data-align-row-count="3" x="230" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+</svg>

--- a/skills/svg-infographic/scripts/layout-fixtures/ln-align-inventory-col-gone.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/ln-align-inventory-col-gone.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 220" width="420" height="220">
+  <!-- column group 하나가 통째로 사라졌다 -->
+  <g data-align-inventory="col:matrix-c0=2;col:matrix-c1=2;row:matrix-r0=2;row:matrix-r1=2">
+    <rect data-align-row="matrix-r0" data-align-row-count="2" data-align-col="matrix-c0" data-align-col-count="2" x="20" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect data-align-row="matrix-r0" data-align-row-count="2" x="230" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect data-align-row="matrix-r1" data-align-row-count="2" data-align-col="matrix-c0" data-align-col-count="2" x="20" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect data-align-row="matrix-r1" data-align-row-count="2" x="230" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  </g>
+</svg>

--- a/skills/svg-infographic/scripts/layout-fixtures/ln-align-inventory-group-gone.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/ln-align-inventory-group-gone.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 220" width="420" height="220">
+  <!-- mirrored row 양쪽의 annotation을 모두 제거했다 — inventory가 그 group의 부재를 안다 -->
+  <g data-align-inventory="row:slot-1=2;row:slot-2=2">
+    <rect data-align-row="slot-1" data-align-row-count="2" x="20" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect data-align-row="slot-1" data-align-row-count="2" x="230" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect x="20" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect x="230" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  </g>
+</svg>

--- a/skills/svg-infographic/scripts/layout-fixtures/ln-align-inventory-row-gone.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/ln-align-inventory-row-gone.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 220" width="420" height="220">
+  <!-- 격자의 row group 하나가 통째로 사라졌다 -->
+  <g data-align-inventory="col:matrix-c0=2;col:matrix-c1=2;row:matrix-r0=2;row:matrix-r1=2">
+    <rect data-align-row="matrix-r0" data-align-row-count="2" data-align-col="matrix-c0" data-align-col-count="2" x="20" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect data-align-row="matrix-r0" data-align-row-count="2" data-align-col="matrix-c1" data-align-col-count="2" x="230" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect data-align-col="matrix-c0" data-align-col-count="2" x="20" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect data-align-col="matrix-c1" data-align-col-count="2" x="230" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  </g>
+</svg>

--- a/skills/svg-infographic/scripts/layout-fixtures/ln-align-inventory-unexpected.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/ln-align-inventory-unexpected.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 220" width="420" height="220">
+  <!-- inventory에 없는 group이 산출물에 추가됐다 -->
+  <g data-align-inventory="row:slot-1=2">
+    <rect data-align-row="slot-1" data-align-row-count="2" x="20" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect data-align-row="slot-1" data-align-row-count="2" x="230" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect data-align-row="slot-9" data-align-row-count="2" x="20" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+    <rect data-align-row="slot-9" data-align-row-count="2" x="230" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  </g>
+</svg>

--- a/skills/svg-infographic/scripts/layout-fixtures/ln-align-missing-cell.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/ln-align-missing-cell.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 220" width="420" height="220">
+  <!-- 2×2 격자에서 셀 하나의 col annotation이 빠졌다 -->
+  <rect data-align-col="col-a" data-align-col-count="2" x="20" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-align-col="col-a" data-align-col-count="2" x="20" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-align-col="col-b" data-align-col-count="2" x="230" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect x="230" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+</svg>

--- a/skills/svg-infographic/scripts/layout-fixtures/ln-align-missing-mirror.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/ln-align-missing-mirror.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 120" width="420" height="120">
+  <!-- 오른쪽 패널의 annotation이 빠졌다 — 남은 하나만으로 통과하면 안 된다 -->
+  <rect data-align-row="slot-1" data-align-row-count="2" x="20" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect x="230" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+</svg>

--- a/skills/svg-infographic/scripts/layout-fixtures/ln-align-row-drift.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/ln-align-row-drift.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 120" width="420" height="120">
+  <!-- 같은 row인데 y가 6px 어긋났다 -->
+  <rect data-align-row="slot-1" data-align-row-count="2" x="20" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-align-row="slot-1" data-align-row-count="2" x="230" y="26" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+</svg>

--- a/skills/svg-infographic/scripts/layout-fixtures/ln-align-singleton.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/ln-align-singleton.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 120" width="420" height="120">
+  <!-- 혼자짜리 alignment group은 아무것도 주장하지 않는다 -->
+  <rect data-align-row="lonely" data-align-row-count="1" x="20" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+</svg>

--- a/skills/svg-infographic/scripts/layout-fixtures/lp-align-grid.svg
+++ b/skills/svg-infographic/scripts/layout-fixtures/lp-align-grid.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 220" width="420" height="220">
+  <!-- mirrored row 2개 + 2×2 격자: 정렬과 참여 수가 모두 선언된 정상형 -->
+  <rect data-align-row="slot-1" data-align-row-count="2" x="20" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-align-row="slot-1" data-align-row-count="2" x="230" y="20" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-align-row="slot-2" data-align-row-count="2" data-align-col="col-a" data-align-col-count="2" x="20" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-align-row="slot-2" data-align-row-count="2" data-align-col="col-b" data-align-col-count="2" x="230" y="120" width="170" height="60" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1"/>
+  <rect data-align-col="col-a" data-align-col-count="2" x="20" y="20" width="170" height="60" fill="none" stroke="none"/>
+  <rect data-align-col="col-b" data-align-col-count="2" x="230" y="20" width="170" height="60" fill="none" stroke="none"/>
+</svg>

--- a/skills/svg-infographic/scripts/measure-text.mjs
+++ b/skills/svg-infographic/scripts/measure-text.mjs
@@ -7,13 +7,14 @@ import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { createHash } from "node:crypto";
-import { spawnSync } from "node:child_process";
 import { pathToFileURL, fileURLToPath } from "node:url";
-import { resolveBrowser } from "./render.mjs";
+import { resolveBrowser, dumpDom } from "./render.mjs";
 import { preflight } from "./preflight-lib.mjs";
 
 preflight({ entrypointUrl: import.meta.url });
 
+
+const PROBE_NAME = "measure-text";
 const args = process.argv.slice(2);
 const svgPath = args.find((a) => !a.startsWith("--"));
 if (!svgPath) { console.error("usage: measure-text.mjs <svg> [--json]"); process.exit(2); }
@@ -53,12 +54,17 @@ ${svg}
 </script>`;
 const htmlPath = path.join(dir, "m.html");
 writeFileSync(htmlPath, html);
-const r = spawnSync(browser.path, [
+const r = await dumpDom(browser.path, [
   "--headless=new", "--disable-gpu", "--hide-scrollbars",
   `--user-data-dir=${path.join(dir, "profile")}`,
   "--no-first-run", "--no-default-browser-check",
   "--dump-dom", "--virtual-time-budget=4000", "--timeout=8000", pathToFileURL(htmlPath).href,
-], { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, timeout: 30000 });
+], { timeoutMs: 30000 });
+if (r.reason === "timeout" || r.reason === "spawn-error") {
+  rmSync(dir, { recursive: true, force: true });
+  console.error(`${PROBE_NAME}: browser probe did not finish (${r.reason}) — fail-closed`);
+  process.exit(1);
+}
 rmSync(dir, { recursive: true, force: true });
 const m = (r.stdout || "").match(/<pre id="mt-out">([\s\S]*?)<\/pre>/);
 if (!m || !m[1].trim()) { console.error("measure-text: probe output not found"); process.exit(1); }

--- a/skills/svg-infographic/scripts/render.mjs
+++ b/skills/svg-infographic/scripts/render.mjs
@@ -268,6 +268,40 @@ async function runBrowserForScreenshot(executable, flags, shotPath, timeoutMs) {
 // profile handles a moment after the child exits, so EBUSY/EPERM/ENOTEMPTY
 // gets a bounded retry. A final failure is reported as an ASCII diagnostic
 // and never changes the render exit code.
+// --- DOM dump lifecycle ---------------------------------------------------
+// spawnSync의 timeout은 이 경로를 bound하지 못한다: Chromium은 결과를 낸 뒤에도
+// 계속 살아 있을 수 있고(render.mjs가 문서화한 동작), 보조 프로세스가 stdout pipe를
+// 붙잡고 있으면 부모의 동기 read가 timeout 뒤에도 계속 막힌다. 실제로 60초로 선언된
+// 호출이 549초를 쓰고 실패했다.
+// 그래서 render.mjs와 같은 계약을 쓴다: 자체 process group으로 띄우고, **필요한 산출물이
+// 나오는 즉시** 우리 자식을 종료하며, wall clock을 hard bound한다. 재시도는 하지 않는다.
+export async function dumpDom(exePath, argv, { timeoutMs = 30000, maxBytes = 64 * 1024 * 1024 } = {}) {
+  return await new Promise((resolve) => {
+    let child;
+    try { child = spawn(exePath, argv, { stdio: ["ignore", "pipe", "pipe"], detached: true }); }
+    catch { return resolve({ stdout: "", stderr: "", reason: "spawn-error" }); }
+    let stdout = "", stderr = "", bytes = 0, settled = false;
+    const stop = (reason) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      // 우리 자식과 그 보조 프로세스만 정리한다 — 사용자의 브라우저는 다른 group이다.
+      try { process.kill(-child.pid, "SIGKILL"); } catch { try { child.kill("SIGKILL"); } catch { /* 이미 종료 */ } }
+      resolve({ stdout, stderr, reason });
+    };
+    const timer = setTimeout(() => stop("timeout"), timeoutMs);
+    child.stdout.on("data", (b) => {
+      bytes += b.length;
+      if (bytes <= maxBytes) stdout += b;
+      // 원하는 것은 dump 전체가 아니라 probe 출력이다. 그것이 보이면 더 기다리지 않는다.
+      if (/<\/pre>/.test(stdout)) stop("done");
+    });
+    child.stderr.on("data", (b) => { stderr += b; });
+    child.on("error", () => stop("spawn-error"));
+    child.on("close", () => stop("exit"));
+  });
+}
+
 export async function cleanupWithRetry(path, { rmFn = rmSync, retries = 5, delayMs = 300, delayFn = delay } = {}) {
   for (let attempt = 0; ; attempt++) {
     try {

--- a/skills/svg-infographic/scripts/run-tests.sh
+++ b/skills/svg-infographic/scripts/run-tests.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# svg-infographic 공식 회귀 실행 경로.
+#
+# 왜 runner가 필요한가: suite 중 일부는 headless browser를 띄운다(render·measure-text 경유).
+# 이들을 동시에 돌리면 wall-clock timeout이 걸린 단계가 자원 경합에 노출돼 결과가 비결정적이 된다.
+# 그래서 **browser 비의존 suite는 병렬, browser 의존 suite는 직렬**을 계약으로 고정한다.
+#
+# 계약:
+#   - 재시도하지 않는다. 실패는 실패로 보고한다.
+#   - suite마다 전체 출력을 로그로 남긴다 — 실패 항목을 사후에 특정할 수 있어야 한다.
+#   - 한 suite라도 실패하면 non-zero로 끝난다.
+#
+# 사용: bash scripts/run-tests.sh [--log-dir <dir>]
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+log_dir=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --log-dir) log_dir="$2"; shift 2 ;;
+    *) echo "usage: run-tests.sh [--log-dir <dir>]" >&2; exit 2 ;;
+  esac
+done
+[ -n "$log_dir" ] || log_dir="$(mktemp -d "${TMPDIR:-/tmp}/svginfo-tests-XXXXXX")"
+mkdir -p "$log_dir"
+
+# browser를 띄우지 않는다 — 동시에 돌려도 서로 간섭하지 않는다.
+parallel_suites=(skin preflight check-svg check-layout route-orthogonal)
+# headless browser를 띄운다 — 반드시 한 번에 하나씩.
+serial_suites=(font-probe render compose generate)
+
+status=0
+declare -a failed=()
+
+run_suite() {
+  local s="$1"
+  node "$here/$s.test.mjs" >"$log_dir/$s.log" 2>&1
+  echo "$?" >"$log_dir/$s.exit"
+}
+
+report() {
+  local s="$1" code pass fail
+  code="$(cat "$log_dir/$s.exit" 2>/dev/null || echo "?")"
+  pass="$(grep -oE '^# pass [0-9]+' "$log_dir/$s.log" 2>/dev/null | tail -1 | grep -oE '[0-9]+')"
+  fail="$(grep -oE '^# fail [0-9]+' "$log_dir/$s.log" 2>/dev/null | tail -1 | grep -oE '[0-9]+')"
+  printf '  %-16s pass %-4s fail %-4s exit %s\n' "$s" "${pass:-?}" "${fail:-?}" "$code"
+  if [ "$code" != "0" ]; then
+    status=1
+    failed+=("$s")
+    grep -E '^not ok' "$log_dir/$s.log" | head -10 | sed 's/^/      /'
+  fi
+}
+
+echo "svg-infographic regression — logs in $log_dir"
+echo "parallel (no browser):"
+for s in "${parallel_suites[@]}"; do run_suite "$s" & done
+wait
+for s in "${parallel_suites[@]}"; do report "$s"; done
+
+echo "serial (browser-dependent — one at a time by contract):"
+for s in "${serial_suites[@]}"; do run_suite "$s"; report "$s"; done
+
+if [ "$status" != "0" ]; then
+  echo "FAILED: ${failed[*]}"
+  echo "full output per suite: $log_dir/<suite>.log"
+else
+  echo "all suites green"
+fi
+exit "$status"

--- a/skills/svg-infographic/scripts/skin.mjs
+++ b/skills/svg-infographic/scripts/skin.mjs
@@ -291,6 +291,61 @@ function loadTypography(errors, overridePath = null) {
   return { doc, digest };
 }
 
+
+// --- derived geometry floors -------------------------------------------------
+// 수치 SSoT는 manifest params이고, **산식의 소유자는 이 helper 하나**다.
+// spec은 기호식만 설명하고, validator와 renderer는 이 함수를 함께 쓴다.
+export const PANEL_FLOOR_COMPONENTS = ["panelPad", "panelHeaderH", "slotMinH", "slotGap", "minSlots"];
+export function derivePanelFloor(params = {}) {
+  if (!PANEL_FLOOR_COMPONENTS.some((k) => params[k] !== undefined)) return { declared: false };
+  const missing = PANEL_FLOOR_COMPONENTS.filter((k) => !Number.isFinite(Number(params[k])));
+  if (missing.length) return { declared: true, missing };
+  const n = Number(params.minSlots);
+  const value = 2 * Number(params.panelPad) + Number(params.panelHeaderH)
+    + n * Number(params.slotMinH) + (n - 1) * Number(params.slotGap);
+  return { declared: true, missing: [], value,
+    formula: "2×panelPad + panelHeaderH + minSlots×slotMinH + (minSlots−1)×slotGap" };
+}
+
+
+// --- alignment inventory -----------------------------------------------------
+// 정렬 group이 **통째로 빠지면** participant annotation만으로는 알 수 없다.
+// 그래서 기대 group 목록을 입력 cardinality에서 따로 파생하고, 산출물이 그것을 선언하게 한다.
+// 규칙: 참여자가 2 미만인 축은 정렬 관계가 없으므로 **group을 만들지 않는다**
+//       (불완전 격자도 지원하되 singleton group은 존재 자체가 없다 — 모순을 남기지 않는다).
+// decision-matrix: 자리는 배열 순서가 아니라 **축 값**이 정한다.
+// x tier는 낮음→높음이 왼→오, y tier는 낮음→높음이 아래→위이므로 row는 뒤집어 센다.
+export function deriveMatrixPlacement(input) {
+  const xt = input.axes?.x?.tiers ?? [], yt = input.axes?.y?.tiers ?? [];
+  const cols = xt.length, rows = yt.length;
+  const cells = (input.cells ?? []).map((c) => {
+    const col = xt.findIndex((t) => t.id === c.x), yi = yt.findIndex((t) => t.id === c.y);
+    return { id: c.id, x: c.x, y: c.y, col, row: yi < 0 ? -1 : rows - 1 - yi };
+  });
+  return { cols, rows, xTiers: xt, yTiers: yt, cells };
+}
+export function deriveAlignInventory(typepack, input, scenario = {}) {
+  const out = [];
+  if (typepack === "before-after") {
+    const n = (input.panels ?? []).length;
+    for (const st of input.slots ?? []) if (n >= 2) out.push({ axis: "row", id: `slot-${st.id}`, count: n });
+  } else if (typepack === "decision-matrix") {
+    const pl = deriveMatrixPlacement(input);
+    for (let r = 0; r < pl.rows; r++) {
+      const n = pl.cells.filter((c) => c.row === r).length;
+      if (n >= 2) out.push({ axis: "row", id: `matrix-r${r}`, count: n });
+    }
+    for (let c = 0; c < pl.cols; c++) {
+      const n = pl.cells.filter((x) => x.col === c).length;
+      if (n >= 2) out.push({ axis: "col", id: `matrix-c${c}`, count: n });
+    }
+    void scenario;
+  }
+  return out.sort((a, b) => (a.axis + a.id < b.axis + b.id ? -1 : 1));
+}
+export const serializeAlignInventory = (inv) =>
+  inv.map((g) => `${g.axis}:${g.id}=${g.count}`).join(";");
+
 // --- font delivery policy ------------------------------------------------------
 // 글꼴 정체성은 typography SSoT가, **전달 방식**은 이 profile이 소유한다.
 export function loadDelivery(errors, typo = null) {
@@ -700,8 +755,11 @@ const INPUT_SCHEMA = {
   },
   "decision-matrix": {
     root: ["axes", "cells"], collection: "cells",
-    entity: { required: { name: B(16, 24), trait: B(30, 44) }, optional: { action: B(20, 30), examples: "examples" } },
-    limits: { maxExamples: 2, exampleBudget: B(20, 30) },
+    // 위치가 곧 주장이므로 cell은 **어느 축 값에 속하는지**를 선언한다(x/y = tier id).
+    // name은 선택이다 — 없으면 두 축 tier label에서 파생해 "낮음-높음" 같은 모호한 문안을 없앤다.
+    entity: { required: { x: "tier", y: "tier", trait: B(30, 44) },
+      optional: { name: B(16, 24), action: B(20, 30), examples: "examples" } },
+    limits: { maxExamples: 2, exampleBudget: B(20, 30), tiers: [2, 3] },
   },
 };
 
@@ -758,6 +816,7 @@ export function validateInputPayload(doc, tid, declaredCount, report) {
     else if (ids.has(e.id)) report(`duplicate ${sc.collection} entity id "${e.id}"`);
     else ids.add(e.id);
     for (const [f, budget] of Object.entries(req)) {
+      if (budget === "tier") continue;      // 축 tier 참조는 타입별 validator가 소유
       if (budget === "status") { if (!["done", "current", "future"].includes(e[f])) report(`entity "${e.id}" status must be done|current|future`); continue; }
       if (budget === "card") {
         if (e[f] === undefined) { report(`entity "${e.id}" is missing its required milestone card`); continue; }
@@ -908,10 +967,36 @@ export function validateInputPayload(doc, tid, declaredCount, report) {
       const ax = doc.axes;
       if (!ax || typeof ax !== "object") { report("decision payload requires axes"); return; }
       exactKeys(ax, ["x", "y"], "axes", report);
+      const [tlo, thi] = sc.limits.tiers;
+      const tierIds = {};
       for (const a of ["x", "y"]) {
-        exactKeys(ax[a], ["low", "high"], `axes.${a}`, report);
-        for (const end of ["low", "high"]) localized(ax[a]?.[end], B(14, 20), `axes.${a}.${end}`, report);
+        if (ax[a] && "low" in ax[a]) { report(`axes.${a} still uses the low/high form — declare ordered "tiers" instead so cell placement can be derived from the axis value`); continue; }
+        exactKeys(ax[a], ["tiers"], `axes.${a}`, report);
+        const t = ax[a]?.tiers;
+        if (!Array.isArray(t) || t.length < tlo || t.length > thi) { report(`axes.${a}.tiers must hold ${tlo}–${thi} ordered steps (low → high)`); continue; }
+        const seen = new Set();
+        for (const s of t) {
+          exactKeys(s, ["id", "label"], `axes.${a} tier "${s?.id}"`, report);
+          if (!s?.id || !/^[a-z0-9][a-z0-9-]*$/.test(String(s.id))) report(`axes.${a} tier id "${s?.id}" must be kebab-case`);
+          else if (seen.has(s.id)) report(`axes.${a} declares duplicate tier id "${s.id}"`);
+          else seen.add(s.id);
+          localized(s?.label, B(14, 20), `axes.${a} tier "${s?.id}" label`, report);
+        }
+        tierIds[a] = seen;
       }
+      // cell은 배열 순서가 아니라 축 값으로 자리를 갖는다 — 같은 칸을 두 번 주장할 수 없다.
+      const taken = new Map();
+      for (const c of list) {
+        for (const a of ["x", "y"]) {
+          if (!tierIds[a]) continue;
+          if (!tierIds[a].has(c?.[a])) report(`cell "${c?.id}" ${a} "${c?.[a]}" is not a declared axes.${a} tier`);
+        }
+        const key = `${c?.x}|${c?.y}`;
+        if (taken.has(key)) report(`cells "${taken.get(key)}" and "${c?.id}" both claim the same (x=${c?.x}, y=${c?.y}) position`);
+        else taken.set(key, c?.id);
+      }
+      if (tierIds.x && tierIds.y && list.length > tierIds.x.size * tierIds.y.size)
+        report(`${list.length} cells exceed the ${tierIds.x.size}×${tierIds.y.size} positions the axes declare`);
       if (list.every((c) => c.action !== undefined && (c.examples ?? []).length === sc.limits.maxExamples)) observed.add("optionals-max");
     },
   };
@@ -1488,6 +1573,13 @@ function main() {
           // 승격할 수 없으므로 거부한다.
           errors.push(`manifest: ${id}: fit.floor_basis "rendered" requires the CP2B floor_evidence contract (preset/locale stress fixtures with digests) — it cannot be self-declared`);
         const card = fit.cardinality ?? {};
+        // floor 산식은 derivePanelFloor가 소유한다(renderer도 같은 함수를 쓴다).
+        {
+          const f = derivePanelFloor(fit.params ?? {});
+          if (f.declared && f.missing?.length) errors.push(`manifest: ${id}: derived floor needs ${f.missing.join(", ")}`);
+          else if (f.declared && Number(fit.params.itemMinH) !== f.value)
+            errors.push(`manifest: ${id}: itemMinH ${fit.params.itemMinH} != derived floor ${f.value} (${f.formula})`);
+        }
         for (const k of ["min", "canonical", "max"]) if (!posInt(card[k])) errors.push(`manifest: ${id}: fit.cardinality.${k} must be a positive integer (got ${card[k]})`);
         if (Number(card.min) > Number(card.canonical) || Number(card.canonical) > Number(card.max))
           errors.push(`manifest: ${id}: fit.cardinality must satisfy min <= canonical <= max`);
@@ -1602,7 +1694,13 @@ function main() {
           if (Array.isArray(p.presets) && !p.presets.includes(c.preset)) errors.push(`manifest: ${id}: inputs.${cse} preset "${c.preset}" is not declared`);
           if (!posInt(c.count)) errors.push(`manifest: ${id}: inputs.${cse} count must be a positive integer`);
           // 기하 판정: 선언된 배치를 계산해 live contentBox와 대조하고 expected와 맞춘다
-          const got = computeFit ? computeFit({ count: c.count, layout: c.layout, cols: c.cols, floor: c.floor }) : null;
+          // 같은 구성의 footprint가 선언한 extra(축 라벨 등)를 함께 반영한다 —
+          // 시나리오 판정과 footprint 판정이 다른 수치를 쓰면 두 계약이 갈린다.
+          const fpMatch = (Array.isArray(p.fit?.footprint) ? p.fit.footprint : []).find((f) =>
+            Number(f.count) === Number(c.count) && f.layout === c.layout
+            && String(f.cols ?? "") === String(c.cols ?? "") && String(f.floor ?? "base") === String(c.floor ?? "base"));
+          const got = computeFit ? computeFit({ count: c.count, layout: c.layout, cols: c.cols, floor: c.floor,
+            extraW: fpMatch?.extraW, extraH: fpMatch?.extraH }) : null;
           const pfi = pageframeFor(c.preset);
           let computed = null;
           if (got && pfi) {


### PR DESCRIPTION
## 요약

CP2B Wave 1 batch 3A. `before-after`와 `decision-matrix` 두 TypePack을 등록하면서, 시각 검수에서 드러난 계약 결손을 구현 수정으로 닫았다.

## decision-matrix — 자리·높이·축

- **자리를 축 값에서 파생한다.** 배열 순서로 채우던 구조에서 `axes.{x,y}.tiers[]`(낮음→높음) + cell의 `x`/`y` tier 참조로 바꿨다. x는 왼→오, y는 **아래→위**다. 이전에는 3×3 상단 행이 "낮음"이라 축 라벨과 cell 의미가 반대였고, 그 관계를 보는 gate가 없었다.
- cell `name`은 선택이며 없으면 두 tier label에서 파생한다 — "낮음-높음"처럼 축 순서가 모호한 문안을 입력이 지어내지 않는다.
- **cell 높이는 내용이 정한다.** 두 locale 최대 line-box + 상하 padding에서 유도하고 canvas를 채우려고 늘리지 않는다. `itemMinH`도 임의 상수(150)에서 최소 합법 cell의 geometry floor(68)로 다시 유도했다.
- **ordinal axis를 그린다.** spec §5는 이미 "axis arrows drawn outside the panels"를 요구했으나 구현은 끝점 라벨 4개만 두고 있었다(축이라 이름 붙인 group에 축이 없었다). 격자 왼쪽 세로 keyline + 아래 가로 keyline, positive 끝에만 direction marker. **ordinal category direction이며 chart axis가 아니다** — tick·숫자·gridline으로 확장하지 않는다. connector와 구분한다: `data-route-*` 미사용, routing audit 비대상, marker는 connector와 같은 산식에서 더 얇게 파생.

## 정렬 계약 (design-kernel §7d 신설)

container를 가로지르는 정렬 주장을 기계로 증명한다. 정렬 group은 멤버가 빠져도 남은 것끼리는 맞아서 통과하므로, 완결성을 두 층위로 강제한다 — group마다 참여 수 선언, artifact마다 `data-align-inventory` 1:1 대조. `generate verify`는 artifact를 믿지 않고 **원본 입력에서 inventory와 기대 배치를 다시 계산**한다.

불완전 격자는 예외가 아니다: 둘 이상이 실제로 주장하는 곳에만 띠를 선언하고, 선언된 곳은 완전해야 한다. 빈 칸에 자리표시자를 넣지 않는다.

## browser probe lifecycle

`compose`의 간헐 실패 원인을 확정했다. 직렬 실행에서 재현됐으므로 자원 경합이 아니다 — 선언된 60초 timeout이 **549초** 호출을 bound하지 못했다. Chromium은 결과를 낸 뒤에도 살아 있을 수 있고(`render.mjs`가 이미 문서화한 동작) 보조 프로세스가 stdout pipe를 잡으면 부모의 동기 read가 계속 막힌다. `measure-text.mjs`·`font-probe.mjs`를 `render.mjs`의 lifecycle 계약(`dumpDom`)으로 통일했다: 자체 process group, 필요한 출력이 나오면 즉시 종료, wall clock hard bound, fail-closed. **재시도 없음.**

함께: portable subset 임시 경로가 내용 해시로 결정적이라 동시 build가 서로의 파일을 지우던 격리 결함을 `mkdtemp`로 고쳤다.

## 공식 회귀 경로

`scripts/run-tests.sh` — browser 비의존 suite는 병렬, browser 의존 suite는 직렬을 계약으로 고정하고 suite별 전체 출력을 남긴다.

```
skin 118 · preflight 29 · check-svg 70 · check-layout 47 · route-orthogonal 28
font-probe 6 · render 23 · compose 51 · generate 19
all suites green (exit 0)
```

## 판정

- 3×3은 `presentation-16x9` + 잔여 358px 선언을 유지한다. fluid 부족분은 67.9px이고, gutter에서 회수할 수 있는 상한이 정확히 0.0이라 경계에 닿는다. cell 최소폭을 짧은 payload만 보고 낮추지 않고, fluid 폭 가변 확장도 하지 않는다.
- 성긴 격자를 가리키는 vocabulary는 추가하지 않고 후보로 둔다. 특정 칸이 비었다는 사실 자체가 의미를 가질 때 모호한 flag가 아니라 input에서 명시하고 validator가 검증하는 별도 계약으로 다룬다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)