### PR TITLE
feat(svg-infographic): CP2B batch 3B — roadmap-timeline을 등록한다

### DIFF
--- a/skills/svg-infographic/references/types/inputs/roadmap-timeline.canonical.yaml
+++ b/skills/svg-infographic/references/types/inputs/roadmap-timeline.canonical.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: roadmap-timeline
 case: canonical
-preset: social-4x5
+preset: document-compact
 layout: row
 count: 4
 prompt_ko: "롤아웃을 4개 단계로 마일스톤 카드와 함께 보여줘. 4:5."
@@ -48,6 +48,7 @@ phases:
         ko: "운영 안정화"
         en: "Ops stabilised"
 now_marker:
+  after_phase: "phase-2"
   label:
     ko: "지금"
     en: "Now"

--- a/skills/svg-infographic/references/types/inputs/roadmap-timeline.stress-body.yaml
+++ b/skills/svg-infographic/references/types/inputs/roadmap-timeline.stress-body.yaml
@@ -1,12 +1,12 @@
 schema_version: 1
 kind: typepack-input
 typepack: roadmap-timeline
-case: stress-degrade
+case: stress-body
 preset: document-compact
 layout: row
-count: 5
-prompt_ko: "롤아웃 5단계를 4:5에 배치해줘(경계 초과 확인용)."
-prompt_en: "Five phases on 4:5 to exercise the degrade path."
+count: 4
+prompt_ko: "롤아웃을 4개 단계로 마일스톤 카드와 함께 보여줘. 4:5."
+prompt_en: "Four rollout phases with milestone cards. 4:5."
 title:
   ko: "롤아웃은 단계로 진행한다"
   en: "The rollout proceeds in phases"
@@ -20,24 +20,33 @@ phases:
       title:
         ko: "기준선 확정"
         en: "Baseline agreed"
+      body:
+        ko: "파일럿 결과를 기준선으로 확정했다"
+        en: "Baseline fixed from the pilot result"
   - id: "phase-2"
     label:
       ko: "시범"
       en: "Pilot"
-    status: "done"
+    status: "current"
     card:
       title:
         ko: "시범 팀 적용"
         en: "Pilot team live"
+      body:
+        ko: "두 팀이 실제 업무에서 사용 중이다"
+        en: "Two teams now use it in real work"
   - id: "phase-3"
     label:
       ko: "확대"
       en: "Expand"
-    status: "current"
+    status: "future"
     card:
       title:
         ko: "전사 확대"
         en: "Org-wide rollout"
+      body:
+        ko: "전 조직 순차 적용을 준비한다"
+        en: "Preparing a staged org-wide rollout"
   - id: "phase-4"
     label:
       ko: "안정화"
@@ -47,17 +56,11 @@ phases:
       title:
         ko: "운영 안정화"
         en: "Ops stabilised"
-  - id: "phase-5"
-    label:
-      ko: "이관"
-      en: "Hand over"
-    status: "future"
-    card:
-      title:
-        ko: "팀 이관"
-        en: "Handed to team"
+      body:
+        ko: "운영 인계와 지표 감시를 마무리한다"
+        en: "Finishing handover and metric watch"
 now_marker:
-  after_phase: "phase-3"
+  after_phase: "phase-2"
   label:
     ko: "지금"
     en: "Now"

--- a/skills/svg-infographic/references/types/inputs/roadmap-timeline.stress-cardinality.yaml
+++ b/skills/svg-infographic/references/types/inputs/roadmap-timeline.stress-cardinality.yaml
@@ -57,6 +57,7 @@ phases:
         ko: "팀 이관"
         en: "Handed to team"
 now_marker:
+  after_phase: "phase-3"
   label:
     ko: "지금"
     en: "Now"

--- a/skills/svg-infographic/references/types/inputs/roadmap-timeline.stress-copy.yaml
+++ b/skills/svg-infographic/references/types/inputs/roadmap-timeline.stress-copy.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 kind: typepack-input
 typepack: roadmap-timeline
 case: stress-copy
-preset: social-4x5
+preset: presentation-16x9
 layout: row
 count: 4
 prompt_ko: "각 단계 라벨과 카드 문구를 경계까지 길게 써줘. 4:5."
@@ -48,6 +48,7 @@ phases:
         ko: "운영 지표 안정화"
         en: "Ops metrics stabilised"
 now_marker:
+  after_phase: "phase-2"
   label:
     ko: "지금"
     en: "Now"

--- a/skills/svg-infographic/references/types/inputs/roadmap-timeline.stress-tail-current.yaml
+++ b/skills/svg-infographic/references/types/inputs/roadmap-timeline.stress-tail-current.yaml
@@ -1,15 +1,15 @@
 schema_version: 1
 kind: typepack-input
 typepack: roadmap-timeline
-case: stress-degrade
+case: stress-tail-current
 preset: document-compact
 layout: row
-count: 5
-prompt_ko: "롤아웃 5단계를 4:5에 배치해줘(경계 초과 확인용)."
-prompt_en: "Five phases on 4:5 to exercise the degrade path."
+count: 4
+prompt_ko: "마지막 단계를 진행 중인 롤아웃을 보여줘. 4:5."
+prompt_en: "A rollout whose final phase is under way. 4:5."
 title:
-  ko: "롤아웃은 단계로 진행한다"
-  en: "The rollout proceeds in phases"
+  ko: "마지막 단계를 진행하고 있다"
+  en: "The final phase is under way"
 phases:
   - id: "phase-1"
     label:
@@ -33,7 +33,7 @@ phases:
     label:
       ko: "확대"
       en: "Expand"
-    status: "current"
+    status: "done"
     card:
       title:
         ko: "전사 확대"
@@ -42,22 +42,8 @@ phases:
     label:
       ko: "안정화"
       en: "Stabilise"
-    status: "future"
+    status: "current"
     card:
       title:
         ko: "운영 안정화"
         en: "Ops stabilised"
-  - id: "phase-5"
-    label:
-      ko: "이관"
-      en: "Hand over"
-    status: "future"
-    card:
-      title:
-        ko: "팀 이관"
-        en: "Handed to team"
-now_marker:
-  after_phase: "phase-3"
-  label:
-    ko: "지금"
-    en: "Now"

--- a/skills/svg-infographic/references/types/manifest.yaml
+++ b/skills/svg-infographic/references/types/manifest.yaml
@@ -509,9 +509,10 @@ typepacks:
     profile: constrained-layout
     support: experimental
     spec: types/specs/roadmap-timeline.md
-    presets: [social-4x5, presentation-16x9]
-    # 이 batch에서 아직 판형을 재평가하지 않았다 — 현재 기본값을 기록한다.
-    preferred_preset: social-4x5
+    presets: [document-compact, social-4x5, presentation-16x9]
+    # 구조적으로 얇은 band라 고정 판형을 채우지 못한다(장면별 실측 잔여 80~87%) — 기본은 fluid.
+    # 폭이 모자란 구성만 더 넓은 16:9로 옮긴다.
+    preferred_preset: document-compact
     orientations: [portrait, landscape]
     verifier: null
     receipt_schema: null
@@ -525,25 +526,42 @@ typepacks:
     migration_origin: legacy
     legacy_section: "Roadmap / timeline"
     inputs:
-      canonical: { id: roadmap-timeline-canonical, path: types/inputs/roadmap-timeline.canonical.yaml, preset: social-4x5, layout: row, count: 4 }
+      canonical: { id: roadmap-timeline-canonical, path: types/inputs/roadmap-timeline.canonical.yaml, preset: document-compact, layout: row, count: 4 }
       stress:
         - id: roadmap-timeline-stress-cardinality
           path: types/inputs/roadmap-timeline.stress-cardinality.yaml
           preset: presentation-16x9
           layout: row
           count: 5
+          residual_disposition: { bottom: 501, reason: "timeline은 구조적으로 얇은 band다. 5 phase는 폭 때문에 16:9를 써야 하고 band를 canvas 높이에 맞춰 늘리지 않으므로 남는 세로 여백이다." }
           geometry_expected: fits
           covers: [cardinality-max, status-and-marker]
-        - id: roadmap-timeline-stress-copy
-          path: types/inputs/roadmap-timeline.stress-copy.yaml
-          preset: social-4x5
+        - id: roadmap-timeline-stress-body
+          path: types/inputs/roadmap-timeline.stress-body.yaml
+          preset: document-compact
           layout: row
           count: 4
+          geometry_expected: fits
+          covers: [status-and-marker]
+        - id: roadmap-timeline-stress-tail-current
+          path: types/inputs/roadmap-timeline.stress-tail-current.yaml
+          preset: document-compact
+          layout: row
+          count: 4
+          geometry_expected: fits
+          covers: [terminal-current]
+        - id: roadmap-timeline-stress-copy
+          path: types/inputs/roadmap-timeline.stress-copy.yaml
+          # 긴 title이 card 폭을 키워 fluid 폭을 넘는다 — 이 구성만 더 넓은 판형을 쓴다.
+          preset: presentation-16x9
+          layout: row
+          count: 4
+          residual_disposition: { bottom: 501, reason: "긴 title 때문에 폭이 되는 판형이 16:9뿐이다. band 높이는 내용이 정하고 canvas를 채우려고 늘리지 않는다." }
           geometry_expected: fits
           covers: [copy-boundary-candidate, status-and-marker]
         - id: roadmap-timeline-stress-degrade
           path: types/inputs/roadmap-timeline.stress-degrade.yaml
-          preset: social-4x5
+          preset: document-compact
           layout: row
           count: 5
           geometry_expected: needs-split
@@ -551,10 +569,17 @@ typepacks:
     fit:
       floor_basis: geometry
       cardinality: { min: 3, canonical: 4, max: 5 }
-      params: { itemMinW: 132, itemMinH: 112, gapX: 20, gapY: 20 }
+      # 두 수치 모두 **최소 합법 문법**에서 유도한다(임의 상수가 아니다).
+      #   itemMinW = card 폭 floor. 실제 폭은 두 locale 최장 title에서 나오고 이 값이 하한이다.
+      #   itemMinH = label 띠 + dot + 간격 + body 없는 card = (9+5+10+8) + 12 + 9 + (12+18+12) = 95
+      #   extraW   = 축 양 끝 여백 2 × outerClearance = 28. 끝 card가 content box 안에 들어오는 조건이다.
+      params: { itemMinW: 132, itemMinH: 95, gapX: 20, gapY: 20 }
       footprint:
-        - { count: 5, layout: row, extraW: 48, extraH: 56, w: 788, h: 168 }
+        - { count: 4, layout: row, extraW: 28, extraH: 0, w: 616, h: 95 }
+        - { count: 5, layout: row, extraW: 28, extraH: 0, w: 768, h: 95 }
       feasibility:
+        # 5 phase는 768px가 필요해 616px 폭(fluid·4:5)을 넘는다 — 폭이 되는 것은 16:9뿐이다.
+        - { preset: document-compact, orientation: portrait, count: 5, layout: row, result: needs-split }
         - { preset: social-4x5, orientation: portrait, count: 5, layout: row, result: needs-split }
         - { preset: presentation-16x9, orientation: landscape, count: 5, layout: row, result: fits }
   - id: decision-matrix

--- a/skills/svg-infographic/references/types/specs/roadmap-timeline.md
+++ b/skills/svg-infographic/references/types/specs/roadmap-timeline.md
@@ -26,11 +26,14 @@ Phases or milestones over time.
 | `phases[].card` | one per phase | title ≤ 1 line, body ≤ 2 lines |
 | `phases[].status` | done / current / future | — |
 | `now_marker` | optional | pill label ≤ 1 line |
+| `now_marker.after_phase` | required when `now_marker` is present | must name the `current` phase |
 
 ## 3. Semantic model and invariants
 
 - Entities are **ordered phases**; position encodes order only, and intervals are uniform by construction.
-- Invariants: exactly one phase may be `current`; phase labels are preferred over exact dates; the axis is continuous across all phases.
+- Invariants: exactly one phase may be `current`; **statuses read `done* → current → future*` in declaration order** (one-current alone would admit `future → done → current`); the axis is continuous across all phases.
+- **Position is input, never inference.** Phase order fixes phase position; the now marker's position comes from `now_marker.after_phase`, which must name the `current` phase. The value is redundant with `status` on purpose — a marker moved without moving `current` becomes an error instead of a silent contradiction. If the `current` phase is last there is no interval after it, so a `now_marker` is refused: drop it from the input rather than asking the renderer to hide a declared label.
+- **No dates.** This TypePack carries no date, duration, tick, numeric scale or dependency. Such fields are refused at the input, not silently ignored.
 - **No duration claim**: even spacing must never be read as equal length, and the subtitle says so when dates are shown.
 
 ## 4. Intrinsic fit and variant contract
@@ -56,21 +59,24 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
 
 - Axis as a soft thick line or chevron band; phase dots/chevrons in phase colours.
 - One milestone card per phase under the axis, or alternating above/below.
-- Status shifts saturation: done = muted, current = emphasis toolkit, future = outline.
+- Status is distinguishable **without colour**, and every state marker is **opaque**: `done` = status fill · `current` = background underlay + status fill + outer ring · `future` = background fill + outline. "Outlined" never means transparent — a hollow dot lets the axis rail show through and reads as sitting behind the line. The fill comes from the background **role**, never a hardcoded colour, so it follows the skin into dark mode. The ring must be visibly clear of the dot (radius floor and stroke floor are re-measured on the final SVG, not declared).
+- Paint order is a DOM contract: **axis → marker underlay → dot/ring → label**. The axis is a background rail, so it belongs to the container layer; drawing it after the markers puts the rail on top of them. The accessible status wording per locale is fixed by this spec, so the generator never invents it: `done` = 완료 / Done · `current` = 진행 중 / In progress · `future` = 예정 / Planned.
+- The phase label sits on the **opposite side of the axis from its milestone card**, so alternating layout never buries a label under a card.
+- Even spacing derives from the card that must fit: `endInset = cardVisualW/2 + outerClearance` and `step = (contentW − 2 × endInset) / (n − 1)`, where `cardVisualW` is the resolved maximum over both locales. A constant end inset lets the outermost card leave the content box.
 - The "now" marker is a dashed vertical line with a small pill label; it crosses the axis but no card.
 
 ## 6. Degrade ladder
 
-1. Drop card bodies (title-only milestones).
-2. Alternate cards above/below the axis.
-3. Merge adjacent phases, recording the merge.
-4. Return `needs-split`.
+1. Alternate cards above/below the axis.
+2. Return `needs-split`.
+
+Two steps that a reader might expect are **deliberately absent**. *Dropping card bodies* is not a step: height never binds in this type (a body adds ~36px against a content box of 700+), so dropping it cannot rescue a layout — a body over the §2 budget is an input error, not something to degrade away. *Merging adjacent phases* is not a step either: merging changes the author's meaning, and no input yet declares which phases may merge or what label survives.
 
 ## 7. Verifier, receipt and fixture contract
 
-- **Machine verifier**: none (`verifier: null`) — because the type makes **no** proportional claim. A dated timeline that claimed real intervals would need the data-accuracy annex and a verifier before `core`.
-- Checks: intervals mathematically even; alternating cards clear of axis labels; the now marker crosses no card; phase count 3–5.
-- **Receipt**: phases in order with status, the computed interval, and any merge.
+- **Machine verifier**: no separate data-accuracy verifier (`verifier: null`) — the type makes no proportional claim. Structure is still machine-checked: the generation entrypoint runs an ordinal audit that recomputes geometry from the input and compares it against the written SVG.
+- Checks: the axis appears before every state marker in DOM order; each marker carries a background-role underlay covering its full extent (ring included for `current`); `future` is background-filled with an outline rather than transparent; intervals recomputed from the input and matched within 0.5px; declaration order = DOM order = left-to-right order; dot shape matches status and the current ring is visibly clear; the axis is drawn once, horizontal, and spans the first and last phase; the marker sits where `after_phase` puts it and its **whole visual bounds** (pill + stem) clear every card, phase label and the content box; the outermost card stays inside the content box, re-measured on the final SVG.
+- **Receipt**: `timeline receipt v1` — `schemaVersion`, `kind: "ordinal"`, axis (`x0`, `x1`, `endInset`, `step`), `phases[]` (`id`, `index`, `status`, `x`), and `marker` as a union of `null` or `{ afterPhase, x, labelConsumed }`. Undeclared fields are refused. One shared validator serves both the producer and the verifier, and the verifier recomputes every coordinate from the input rather than trusting the receipt.
 - **Fixtures**: positive per preset + a baseline-red with label-width spacing. Required before `core`.
 
 ## 8. Reading order, accessibility and locale
@@ -82,6 +88,12 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
 ## 9. Anti-patterns and known failures
 
 - Spacing phases by label width instead of the computed interval.
+- A now marker whose position the renderer inferred rather than the input declaring it.
+- Statuses that contradict time order (`future` before `done`).
+- A constant axis end inset that pushes the outermost milestone card out of the content box.
+- `done` and `current` differing by colour alone.
+- A transparent `future` dot with the axis rail visible through it.
+- The axis painted over the state markers.
 - Even spacing presented as if it were a real duration scale.
 - Two phases marked `current`.
 - A "now" marker drawn over a milestone card.

--- a/skills/svg-infographic/scripts/generate.mjs
+++ b/skills/svg-infographic/scripts/generate.mjs
@@ -669,6 +669,158 @@ function renderBeforeAfter(input, loc, cb, sc, tp) {
       attempts: [], diagnostics: [], demoted: [], routes: [] } };
 }
 
+// ---------- timeline receipt v1 (producer와 verifier가 함께 쓴다) ----------
+// R0B-F1: shape를 여기서 못 박는다. 선언에 없는 field는 전부 거부하고, marker는 null과
+// 객체의 union이며 섞일 수 없다.
+function validateTimelineReceiptV1(t, expect) {
+  const e = [];
+  const num = (v, w) => { if (typeof v !== "number" || !Number.isFinite(v)) e.push(`E-TL-SCHEMA ${w} must be a finite number (got ${JSON.stringify(v)})`); };
+  const keys = (o, allow, w) => {
+    for (const k of Object.keys(o ?? {})) if (!allow.includes(k)) e.push(`E-TL-SCHEMA ${w} carries undeclared field "${k}"`);
+    for (const k of allow) if (!(k in (o ?? {}))) e.push(`E-TL-SCHEMA ${w} is missing required field "${k}"`);
+  };
+  if (!t || typeof t !== "object") { e.push("E-TL-SCHEMA timeline receipt is absent"); return e; }
+  keys(t, ["schemaVersion", "kind", "axis", "phases", "marker"], "timeline");
+  if (t.schemaVersion !== 1) e.push(`E-TL-SCHEMA schemaVersion must be 1 (got ${JSON.stringify(t.schemaVersion)})`);
+  if (t.kind !== "ordinal") e.push(`E-TL-SCHEMA kind must be "ordinal" — this type makes no proportional claim (got ${JSON.stringify(t.kind)})`);
+  keys(t.axis, ["x0", "x1", "endInset", "step"], "timeline.axis");
+  for (const k of ["x0", "x1", "endInset", "step"]) num(t.axis?.[k], `timeline.axis.${k}`);
+  if (!Array.isArray(t.phases)) e.push("E-TL-SCHEMA timeline.phases must be an array");
+  else {
+    if (expect && t.phases.length !== expect.phaseCount)
+      e.push(`E-TL-SCHEMA timeline.phases holds ${t.phases.length} entries but the input declares ${expect.phaseCount} phases`);
+    t.phases.forEach((p, i) => {
+      keys(p, ["id", "index", "status", "x"], `timeline.phases[${i}]`);
+      if (typeof p.id !== "string") e.push(`E-TL-SCHEMA timeline.phases[${i}].id must be a string`);
+      if (p.index !== i) e.push(`E-TL-SCHEMA timeline.phases[${i}].index must equal its position (got ${JSON.stringify(p.index)})`);
+      if (!["done", "current", "future"].includes(p.status)) e.push(`E-TL-SCHEMA timeline.phases[${i}].status must be done|current|future`);
+      num(p.x, `timeline.phases[${i}].x`);
+    });
+  }
+  // marker는 union이다 — 없거나(null), 있으면 세 field를 모두 갖는다.
+  if (t.marker !== null) {
+    if (!t.marker || typeof t.marker !== "object") e.push("E-TL-SCHEMA timeline.marker must be null or an object");
+    else {
+      keys(t.marker, ["afterPhase", "x", "labelConsumed"], "timeline.marker");
+      if (typeof t.marker.afterPhase !== "string") e.push("E-TL-SCHEMA timeline.marker.afterPhase must be a phase id");
+      num(t.marker.x, "timeline.marker.x");
+      if (t.marker.labelConsumed !== true) e.push("E-TL-SCHEMA timeline.marker.labelConsumed must be true — a declared label that is not drawn is a dropped input");
+    }
+  }
+  if (expect) {
+    const hasMarker = t.marker !== null;
+    if (hasMarker !== expect.hasMarker)
+      e.push(`E-TL-SCHEMA timeline.marker is ${hasMarker ? "present" : "null"} but the input ${expect.hasMarker ? "declares" : "declares no"} now_marker`);
+  }
+  return e;
+}
+
+// ---------- roadmap-timeline (ordinal 축 — 위치는 순서만 뜻한다) ----------
+// 이 타입은 **기간 비례를 주장하지 않는다**. 간격은 균등이고 날짜 domain은 입력에 없다.
+// marker 위치도 renderer가 추론하지 않고 입력의 after_phase가 정한다.
+const TL = { pad: 12, cardTitle: 13, cardBody: 11, dotR: 9, ringGap: 5, ringStroke: 1.8,
+  axisH: 6, labelGap: 12, outerClearance: 14, pillH: 22, pillPad: 10, stem: 46, bandPad: 10 };
+function timelineGeometry(input, cb, tp) {
+  const ph = input.phases, n = ph.length;
+  const P = tp.fit?.params ?? {};
+  // card 폭은 **내용**이 정한다. §2가 title 1줄을 요구하므로 두 locale 최장 title이 폭의 하한이고,
+  // endInset은 그 폭에서 유도한다 — 상수로 두면 끝 card가 content box를 넘는다.
+  const cardW = Math.max(Number(P.itemMinW ?? 132), ...["ko", "en"].flatMap((lc) =>
+    ph.map((p) => estimateWidth(String(p.card.title[lc]), TL.cardTitle, true, 0) + 2 * TL.pad)));
+  const endInset = cardW / 2 + TL.outerClearance;
+  const step = n > 1 ? (cb.w - 2 * endInset) / (n - 1) : 0;
+  const xs = ph.map((_, i) => cb.x + endInset + i * step);
+  const curIdx = ph.findIndex((p) => p.status === "current");
+  const markerX = input.now_marker ? (xs[curIdx] + xs[curIdx + 1]) / 2 : null;
+  return { n, cardW, endInset, step, xs, curIdx, markerX, gapX: Number(P.gapX ?? 20) };
+}
+function renderRoadmapTimeline(input, loc, cb, sc, tp) {
+  const ph = input.phases;
+  const g = timelineGeometry(input, cb, tp);
+  const fail = (reason, ladder) => ({ needsSplit: true, timelineReason: reason,
+    routing: { degradeLevel: 0, ladder: ladder ?? [], problems: [reason], hops: 0, legend: false,
+      alignment: [], attempts: [], diagnostics: [], demoted: [], routes: [], unrouted: [], edgeCount: 0 } });
+  // 등간격이 card를 겹치게 하면 자리를 옮겨서 푸는 게 아니라 비성공으로 끝낸다.
+  if (g.n > 1 && g.step < g.cardW + g.gapX)
+    return fail(`even spacing gives ${r1(g.step)}px between phase centres but a card needs ${r1(g.cardW + g.gapX)}px — the interval is computed, never widened by label`);
+  const alt = g.n >= 5;                       // §6 ladder 2단계: 상하 교대
+  const bodies = ph.map((p) => (p.card.body ? ["ko", "en"].map((lc) =>
+    wrapLines(String(p.card.body[lc]), g.cardW - 2 * TL.pad, TL.cardBody, false, 2)) : null));
+  // body가 예산을 넘는 것은 배치 문제가 아니라 **입력이 §2를 어긴 것**이다. degrade로 삼키지 않는다.
+  // (body drop을 ladder에 두지 않는 이유는 spec §6에 적혀 있다 — 이 타입에서 높이는 제약이 아니다.)
+  if (bodies.some((b) => b?.some((x) => x.overflow))) {
+    console.error("generate: a milestone body exceeds the §2 two-line budget at the computed card width");
+    process.exit(1);
+  }
+  const bodyLines = Math.max(0, ...bodies.map((b) => (b ? Math.max(...b.map((x) => x.lines.length)) : 0)));
+  const cardH = TL.pad + 18 + (bodyLines ? 6 + bodyLines * 15 : 0) + TL.pad;
+  // label은 card 반대편에 둔다 — 교대 배치에서 위쪽 card가 label을 덮기 때문이다.
+  const labelH = TL.dotR + TL.ringGap + 10 + 8;
+  const cardSide = TL.labelGap + TL.dotR + cardH;
+  const markerTop = input.now_marker ? TL.stem + TL.pillH : 0;
+  const above = Math.max(markerTop, labelH, alt ? cardSide : 0);
+  // band는 container 안쪽에 놓는다 — 경계에 닿는 것도 통과가 아니므로 실제 여백을 비운다.
+  const axisY = cb.y + TL.bandPad + above;
+  const consumed = [], containers = [], nodeArt = [], labels = [];
+  const STATUS_TEXT = { ko: { done: "완료", current: "진행 중", future: "예정" },
+    en: { done: "Done", current: "In progress", future: "Planned" } };
+  const axisX0 = cb.x + g.endInset - 14, axisX1 = cb.x + cb.w - g.endInset + 14;
+  const bottom = axisY + Math.max(cardSide, alt ? labelH : 0) + TL.bandPad;
+  containers.push(`  <rect data-layout-container="timeline" x="${r1(cb.x)}" y="${r1(cb.y)}" width="${r1(cb.w)}" height="${r1(bottom - cb.y)}" fill="none" stroke="none" data-min-pad="10" data-layout-count="${g.n}"/>`);
+  // 축은 dot·card가 올라앉는 **배경 rail**이다. annotations에 두면 node를 덮으므로
+  // paint layer 계약(containers → connectors → nodes → annotations)의 앞쪽에 둔다.
+  containers.push(`  <g data-layout-role="axis" data-axis-kind="ordinal-direction">
+    <rect data-axis="x" data-axis-orientation="horizontal" data-axis-positive="right" x="${r1(axisX0)}" y="${r1(axisY - TL.axisH / 2)}" width="${r1(axisX1 - axisX0)}" height="${TL.axisH}" rx="${TL.axisH / 2}" fill="#DEE0E2" data-fill-role="rule"/>
+  </g>`);
+  ph.forEach((p, i) => {
+    consumed.push(p.id);
+    const x = g.xs[i], up = alt && i % 2 === 1;
+    const cy = up ? axisY - TL.labelGap - TL.dotR - cardH : axisY + TL.labelGap + TL.dotR;
+    const b = bodies[i] ? bodies[i][loc === "ko" ? 0 : 1] : null;
+    // 상태는 색만이 아니라 **형태**로도 구분된다: done 채움 · current 채움+ring · future 윤곽.
+    // 그리고 state marker는 **불투명**해야 한다 — 비어 있으면 뒤의 축 rail이 비쳐 dot이
+    // 선에 걸린 것처럼 보인다. 배경은 하드코딩하지 않고 canvas role로 칠한다(dark에서도 맞는다).
+    const cy0 = r1(axisY), cxs = r1(x);
+    const under = (rad) => `<circle data-dot-underlay="${p.status}" cx="${cxs}" cy="${cy0}" r="${r1(rad)}" fill="#F7F7F5" data-fill-role="canvas"/>`;
+    const dot = p.status === "future"
+      ? `${under(TL.dotR)}<circle cx="${cxs}" cy="${cy0}" r="${TL.dotR}" fill="#F7F7F5" data-fill-role="canvas" stroke="#636A75" stroke-width="1.8" data-stroke-role="muted" data-dot-status="future"/>`
+      : p.status === "done"
+        ? `${under(TL.dotR)}<circle cx="${cxs}" cy="${cy0}" r="${TL.dotR}" fill="#636A75" data-fill-role="muted" data-dot-status="done"/>`
+        : `${under(TL.dotR + TL.ringGap + TL.ringStroke / 2)}<circle cx="${cxs}" cy="${cy0}" r="${TL.dotR}" fill="#2E6DA4" data-fill-role="focus" data-dot-status="current"/><circle data-dot-ring="current" cx="${cxs}" cy="${cy0}" r="${r1(TL.dotR + TL.ringGap)}" fill="none" stroke="#2E6DA4" stroke-width="${TL.ringStroke}" data-stroke-role="focus"/>`;
+    nodeArt.push(`  <g data-comp-entity="${p.id}" data-entity="${p.id}" data-phase-status="${p.status}" data-phase-index="${i}">
+    <title>${esc(STATUS_TEXT[loc][p.status])}</title>
+    ${dot}
+    <text x="${r1(x)}" y="${r1(axisY + (up ? 1 : -1) * (TL.dotR + TL.ringGap + 10))}" font-size="12" font-weight="700" fill="#252B35" data-fill-role="ink" text-anchor="middle" dominant-baseline="central" data-phase-label="${p.id}">${esc(p.label[loc])}</text>
+    <rect x="${r1(x - g.cardW / 2)}" y="${r1(cy)}" width="${r1(g.cardW)}" height="${r1(cardH)}" rx="12" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1" data-fill-role="surface" data-stroke-role="rule" data-layout-parent="timeline" data-phase-card="${p.id}"/>
+    <text x="${r1(x - g.cardW / 2 + TL.pad)}" y="${r1(cy + TL.pad + 8)}" font-size="${TL.cardTitle}" font-weight="700" fill="#252B35" data-fill-role="ink" dominant-baseline="central">${esc(p.card.title[loc])}</text>${
+      b ? `\n    <text font-size="${TL.cardBody}" fill="#636A75" data-fill-role="muted" dominant-baseline="central">${tspans(b.lines, x - g.cardW / 2 + TL.pad, cy + TL.pad + 8 + 14, 15)}</text>` : ""}
+  </g>`);
+  });
+  if (input.now_marker) {
+    // pill 폭은 두 locale 최대값으로 고정한다 — 언어에 따라 기하가 갈리지 않는다.
+    const pw = Math.max(...["ko", "en"].map((lc) =>
+      estimateWidth(String(input.now_marker.label[lc]), 12, true, 0))) + 2 * TL.pillPad;
+    const mx = g.markerX;
+    labels.push(`  <g data-marker="now" data-marker-after="${esc(input.now_marker.after_phase)}">
+    <path data-marker-stem="now" d="M${r1(mx)} ${r1(axisY - TL.stem)} V${r1(axisY + TL.stem)}" fill="none" stroke="#2E6DA4" stroke-width="1.5" stroke-dasharray="5 4" data-stroke-role="focus"/>
+    <rect data-marker-pill="now" x="${r1(mx - pw / 2)}" y="${r1(axisY - TL.stem - TL.pillH)}" width="${r1(pw)}" height="${TL.pillH}" rx="${TL.pillH / 2}" fill="#2E6DA4" data-fill-role="focus"/>
+    <text x="${r1(mx)}" y="${r1(axisY - TL.stem - TL.pillH / 2)}" font-size="12" font-weight="700" fill="#FFFFFF" data-fill-role="on-focus" text-anchor="middle" dominant-baseline="central">${esc(String(input.now_marker.label[loc]))}</text>
+  </g>`);
+  }
+  return { body: [`  <g data-layer="containers">`, ...containers, `  </g>`,
+      `  <g data-layer="connectors"></g>`, `  <g data-layer="nodes">`, ...nodeArt, `  </g>`,
+      `  <g data-layer="annotations">`, ...labels, `  </g>`].join("\n"),
+    consumed, bounds: { x: cb.x, y: cb.y, w: cb.w, h: bottom - cb.y },
+    timeline: { schemaVersion: 1, kind: "ordinal",
+      axis: { x0: r1(axisX0), x1: r1(axisX1), endInset: r1(g.endInset), step: r1(g.step) },
+      phases: ph.map((p, i) => ({ id: p.id, index: i, status: p.status, x: r1(g.xs[i]) })),
+      marker: input.now_marker
+        ? { afterPhase: input.now_marker.after_phase, x: r1(g.markerX), labelConsumed: true }
+        : null },
+    routing: { degradeLevel: 0, ladder: [], problems: [], hops: 0, legend: false, alignment: [],
+      attempts: [], diagnostics: [], demoted: [], routes: [] } };
+}
+
 // ---------- decision-matrix (축은 밖, 셀은 격자) ----------
 // 축은 **ordinal category direction**이다 — 수치 간격도, chart scale도 아니다.
 // 따라서 tick·숫자·gridline은 없고, 방향(위/오른쪽이 높음)만 표시한다.
@@ -870,12 +1022,15 @@ function build(argv) {
     : tid === "nested-scope" ? renderNestedScope(input, loc, cbox, sc, tp)
     : tid === "before-after" ? renderBeforeAfter(input, loc, cbox, sc, tp)
     : tid === "decision-matrix" ? renderDecisionMatrix(input, loc, cbox, sc, tp)
+    : tid === "roadmap-timeline" ? renderRoadmapTimeline(input, loc, cbox, sc, tp)
     : (console.error(`generate: no renderer registered for "${tid}"`), process.exit(2));
   let pf = spawnJson([skinCli, "pageframe", preset, "--json"], "skin.mjs pageframe");
   if (pf.regions.fluid) {
     // fluid 캔버스는 내용 높이를 따라간다 — 블록을 먼저 재고 그 높이로 프레임을 다시 만든다.
     const probe = render({ ...pf.regions.contentBox, h: 100000 });
-    pf = spawnJson([skinCli, "pageframe", preset, "--content-height", String(Math.ceil(probe.bounds.h)), "--json"], "skin.mjs pageframe");
+    // 배치가 성립하지 않으면 잴 높이도 없다 — 프레임은 그대로 두고 아래 needs-split 경로가 판정한다.
+    if (probe.bounds)
+      pf = spawnJson([skinCli, "pageframe", preset, "--content-height", String(Math.ceil(probe.bounds.h)), "--json"], "skin.mjs pageframe");
   }
   const cb = pf.regions.contentBox;
   const need = computeFit(tp, sc);
@@ -900,18 +1055,6 @@ function build(argv) {
   }
 
   const R = render(cb);
-  // fit 예측은 **최소 합법 문법의 floor**다. 내용이 그 floor를 넘겨 자란 배치가 실제로
-  // contentBox를 벗어나면, 낙관적인 예측이 통과시킨 것을 여기서 다시 거부한다.
-  if (R.bounds.h > cb.h + 1) {
-    const degrade = { ...base, status: "needs-split", artifact: null, consumed: [],
-      degrade: { reason: `measured layout is ${r1(R.bounds.h)}px tall against contentBox ${cb.h}px — the declared fit floor (${r1(need.h)}px) is a lower bound and the content grew past it`,
-                 ladder: "spec §6 — reduce optional content, select a declared variant, then split the page" },
-      provenance: provenance({ producer: { kind: "generator", generatorDigest: sha(readFileSync(fileURLToPath(import.meta.url))) },
-        inputs: [{ role: "typepack-input", digest: inputDigest }] }) };
-    writeFileSync(rcp, JSON.stringify(degrade, null, 1) + "\n");
-    console.log(`generate ${tid}/${sc.id}/${loc} — needs-split (measured overflow); degrade receipt written`);
-    process.exit(3);
-  }
   const routingExpected = sc.routing_expected ?? null;
   if (routingExpected === "needs-split" && !R.needsSplit) {
     console.error(`generate: scenario declares routing_expected needs-split but the router found a legal layout — update the declaration`);
@@ -923,13 +1066,29 @@ function build(argv) {
   }
   if (R.needsSplit) {
     const degrade = { ...base, status: "needs-split", artifact: null, consumed: [],
-      degrade: { reason: `routing: the bounded router found no legal route for ${R.routing.unrouted?.length ?? "?"} of ${R.routing.edgeCount ?? "?"} edges under the current layout constraints (${(R.routing.unrouted ?? []).join(", ")}); this is a search result within the declared candidate shapes, not a proof that no layout exists`,
-                 ladder: "spec §6 — " + R.routing.ladder.map((l) => `${l.step}) ${l.action}${l.applied ? " ✓" : " ✗"}`).join(" · ") },
+      degrade: { reason: R.timelineReason
+                   ? `layout: ${R.timelineReason}`
+                   : `routing: the bounded router found no legal route for ${R.routing.unrouted?.length ?? "?"} of ${R.routing.edgeCount ?? "?"} edges under the current layout constraints (${(R.routing.unrouted ?? []).join(", ")}); this is a search result within the declared candidate shapes, not a proof that no layout exists`,
+                 ladder: R.timelineReason
+                   ? "spec §6 — 1) alternating layout · 2) needs-split. body drop is not a step (height never binds in this type) and adjacent-phase merge is not supported (merging changes the author's meaning)"
+                   : "spec §6 — " + R.routing.ladder.map((l) => `${l.step}) ${l.action}${l.applied ? " ✓" : " ✗"}`).join(" · ") },
       routing: R.routing,
       provenance: provenance({ producer: { kind: "generator", generatorDigest: sha(readFileSync(fileURLToPath(import.meta.url))) },
         inputs: [{ role: "typepack-input", digest: inputDigest }] }) };
     writeFileSync(rcp, JSON.stringify(degrade, null, 1) + "\n");
     console.log(`generate ${tid}/${sc.id}/${loc} — needs-split (routing); degrade receipt written`);
+    process.exit(3);
+  }
+  // fit 예측은 **최소 합법 문법의 floor**다. 내용이 그 floor를 넘겨 자란 배치가 실제로
+  // contentBox를 벗어나면, 낙관적인 예측이 통과시킨 것을 여기서 다시 거부한다.
+  if (R.bounds.h > cb.h + 1) {
+    const degrade = { ...base, status: "needs-split", artifact: null, consumed: [],
+      degrade: { reason: `measured layout is ${r1(R.bounds.h)}px tall against contentBox ${cb.h}px — the declared fit floor (${r1(need.h)}px) is a lower bound and the content grew past it`,
+                 ladder: "spec §6 — reduce optional content, select a declared variant, then split the page" },
+      provenance: provenance({ producer: { kind: "generator", generatorDigest: sha(readFileSync(fileURLToPath(import.meta.url))) },
+        inputs: [{ role: "typepack-input", digest: inputDigest }] }) };
+    writeFileSync(rcp, JSON.stringify(degrade, null, 1) + "\n");
+    console.log(`generate ${tid}/${sc.id}/${loc} — needs-split (measured overflow); degrade receipt written`);
     process.exit(3);
   }
   const canvasH = pf.regions.fluid ? pf.regions.documentHeight : pf.canvas.height;
@@ -976,6 +1135,7 @@ ${R.body}
       tool: embedded.tool ?? null, wrapperDigest: embedded.wrapperDigest ?? null, identity: embedded.identity ?? [] },
     routing: R.routing ?? null,
     matrix: R.matrix ?? null,
+    timeline: R.timeline ?? null,
     residual, residualDisposition: decl,
     provenance: provenance({ producer: { kind: "generator", generatorDigest: sha(readFileSync(fileURLToPath(import.meta.url))) },
       inputs: [{ role: "typepack-input", digest: inputDigest }] }) };
@@ -993,6 +1153,8 @@ function semanticIds(input, tid) {
   if (tid === "nested-scope") for (const rg of input.rings ?? []) ids.push(rg.id);
   if (tid === "before-after") { for (const p of input.panels ?? []) ids.push(p.id); for (const d of input.delta ?? []) ids.push(d.id); }
   if (tid === "decision-matrix") for (const c of input.cells ?? []) ids.push(c.id);
+  // phase만 semantic entity다 — card·dot·marker는 phase에 귀속된 participant이고 독립 ID가 없다.
+  if (tid === "roadmap-timeline") for (const p of input.phases ?? []) ids.push(p.id);
   if (tid === "approval-gate") {
     for (const nd of input.nodes ?? []) ids.push(nd.id);
     if (input.gate?.id) ids.push(input.gate.id);
@@ -1088,13 +1250,140 @@ function auditMatrixAxes(svg, input, loc) {
   }
   return errs;
 }
+// roadmap-timeline 감사: receipt를 정답으로 쓰지 않고 **입력과 preset에서 다시 계산**한 뒤
+// 기록된 SVG 좌표와 대조한다. 축은 ordinal이므로 눈금·수치는 검사 대상이 아니다.
+function auditTimeline(svg, input, rcp, tp) {
+  const errs = [];
+  const attr = (s, k) => (s.match(new RegExp(`\\b${k}="([^"]*)"`)) ?? [])[1];
+  const num = (s, k) => Number(attr(s, k));
+  // 날짜 domain은 이 타입에 없다(C-01) — 입력이 들고 오면 거부한다.
+  const dateish = ["date", "start", "end", "duration", "dates"];
+  for (const p of input.phases ?? [])
+    for (const k of dateish) if (k in p) errs.push(`E-TL-DOMAIN phase "${p.id}" carries "${k}" — this TypePack spaces phases evenly and makes no proportional-duration claim`);
+  // 기대 기하: preset contentBox와 입력에서 다시 계산한다.
+  const pf = spawnJson([skinCli, "pageframe", rcp.preset, "--json"], "skin.mjs pageframe");
+  const cb = pf.regions.contentBox;
+  const g = timelineGeometry(input, cb, tp);
+  const dots = [...svg.matchAll(/<g[^>]*data-entity="([^"]+)"[^>]*data-phase-status="([^"]*)"[^>]*data-phase-index="(\d+)"[^>]*>([\s\S]*?)<\/g>/g)]
+    .map((m) => ({ id: m[1], status: m[2], index: Number(m[3]), block: m[4], at: m.index }));
+  if (dots.length !== (input.phases ?? []).length) {
+    errs.push(`E-TL-PHASE artifact carries ${dots.length} phase group(s) but the input declares ${input.phases.length}`);
+    return errs;
+  }
+  const firstCircle = (b) => (b.match(/<circle[^>]*data-dot-status="[^"]*"[^>]*\/>/) ?? [])[0] ?? "";
+  dots.forEach((d, i) => {
+    const want = input.phases[i];
+    if (d.id !== want.id || d.index !== i)
+      errs.push(`E-TL-ORDER artifact phase #${i} is "${d.id}"(index ${d.index}) but the input declares "${want.id}" — declaration order is the reading order`);
+    if (d.status !== want.status) errs.push(`E-TL-PHASE "${d.id}" status "${d.status}" != input "${want.status}"`);
+    const c = firstCircle(d.block);
+    const cx = num(c, "cx");
+    if (Math.abs(cx - g.xs[i]) > 0.5)
+      errs.push(`E-TL-POSITION "${d.id}" sits at x=${r1(cx)} but the even interval recomputed from the input puts it at ${r1(g.xs[i])} — the interval is computed, never widened by label`);
+    // 상태는 색이 아니라 **형태**로도 구분돼야 한다 — ring이 실제로 보이는지까지 본다.
+    const dr = num(c, "r"), fillRole = attr(c, "data-fill-role");
+    const ring = (d.block.match(/<circle[^>]*data-dot-ring="current"[^>]*\/>/) ?? [])[0];
+    const underlay = (d.block.match(/<circle[^>]*data-dot-underlay="[^"]*"[^>]*\/>/) ?? [])[0];
+    // state marker는 불투명해야 한다 — 비어 있으면 뒤의 축 rail이 비친다.
+    if (attr(c, "fill") === "none")
+      errs.push(`E-TL-SHAPE "${d.id}" dot has no fill — the axis rail shows through and the marker reads as sitting behind the line`);
+    if (want.status === "future") {
+      // future는 "빈 원"이지만 **투명**한 것이 아니다: 배경 role로 채우고 윤곽선을 둔다.
+      if (fillRole !== "canvas") errs.push(`E-TL-SHAPE "${d.id}" is future so its dot must be filled with the background role (got "${fillRole ?? "none"}")`);
+      if (!attr(c, "data-stroke-role")) errs.push(`E-TL-SHAPE "${d.id}" is future but carries no outline`);
+    } else if (fillRole === "canvas") {
+      errs.push(`E-TL-SHAPE "${d.id}" is ${want.status} but its dot is filled with the background role — it would read as future`);
+    }
+    if (!underlay) errs.push(`E-TL-SHAPE "${d.id}" carries no background underlay — the axis rail must be hidden under the whole marker`);
+    else {
+      const ur = num(underlay, "r"), needR = want.status === "current" ? dr + 4 : dr;
+      if (attr(underlay, "data-fill-role") !== "canvas") errs.push(`E-TL-SHAPE "${d.id}" underlay must use the background role, not a hardcoded colour`);
+      if (!(ur >= needR - 0.01)) errs.push(`E-TL-SHAPE "${d.id}" underlay radius ${ur} does not cover the marker (needs ${r1(needR)})`);
+      if (Math.abs(num(underlay, "cx") - cx) > 0.5) errs.push(`E-TL-SHAPE "${d.id}" underlay is not centred on its dot`);
+    }
+    if (want.status === "current") {
+      if (!ring) errs.push(`E-TL-SHAPE "${d.id}" is current but carries no ring — done and current would differ by colour alone`);
+      else {
+        const rr = num(ring, "r"), rs = num(ring, "stroke-width");
+        if (Math.abs(num(ring, "cx") - cx) > 0.5 || Math.abs(num(ring, "cy") - num(c, "cy")) > 0.5)
+          errs.push(`E-TL-SHAPE "${d.id}" ring is not concentric with its dot`);
+        if (!(rr >= dr + 4)) errs.push(`E-TL-SHAPE "${d.id}" ring radius ${rr} leaves no visible gap over the ${dr}px dot (floor ${dr + 4})`);
+        if (!(rs >= 1.2)) errs.push(`E-TL-SHAPE "${d.id}" ring stroke ${rs} is below the visible floor 1.2`);
+        if (attr(ring, "fill") !== "none") errs.push(`E-TL-SHAPE "${d.id}" ring must not be filled`);
+      }
+    } else if (ring) errs.push(`E-TL-SHAPE "${d.id}" is ${want.status} but carries the current ring`);
+  });
+  if (errs.length) return errs;
+  // x는 좌→우로 단조여야 한다(DOM 순서와 함께 본다).
+  for (let i = 1; i < dots.length; i++) {
+    const a = num(firstCircle(dots[i - 1].block), "cx"), b = num(firstCircle(dots[i].block), "cx");
+    if (!(b > a)) errs.push(`E-TL-ORDER phase #${i} is not right of #${i - 1} — later must read as further right`);
+    if (!(dots[i].at > dots[i - 1].at)) errs.push(`E-TL-ORDER DOM order does not follow the declared phase order`);
+  }
+  // 축: 정확히 하나, 수평, 첫·마지막 dot을 감싼다.
+  const axes = [...svg.matchAll(/<rect[^>]*data-axis="x"[^>]*\/>/g)].map((m) => m[0]);
+  if (axes.length !== 1) errs.push(`E-TL-AXIS the ordinal axis must be drawn exactly once (found ${axes.length})`);
+  else {
+    const ax = axes[0], x0 = num(ax, "x"), w = num(ax, "width");
+    if (attr(ax, "data-axis-orientation") !== "horizontal" || attr(ax, "data-axis-positive") !== "right")
+      errs.push("E-TL-AXIS the ordinal axis must be horizontal with positive to the right");
+    if (!(x0 <= g.xs[0] && x0 + w >= g.xs.at(-1)))
+      errs.push(`E-TL-AXIS the axis spans ${r1(x0)}–${r1(x0 + w)} and does not contain the first/last phase (${r1(g.xs[0])}, ${r1(g.xs.at(-1))})`);
+    if (/data-route-(id|from|to|kind)=/.test(ax)) errs.push("E-TL-AXIS an ordinal axis must not be classified as a connector");
+    // paint order는 DOM 순서다: axis → underlay → dot/ring → label.
+    const axAt = svg.indexOf(ax);
+    const firstMarker = svg.search(/<circle[^>]*data-dot-(underlay|status)=/);
+    if (axAt > firstMarker)
+      errs.push("E-TL-LAYER the axis is painted after a state marker — the rail must sit behind every dot");
+  }
+  // marker: 입력이 위치를 말한다. 그리고 pill까지 포함한 **전체**가 아무것도 침범하지 않는다.
+  const stem = (svg.match(/<path[^>]*data-marker-stem="now"[^>]*\/>/) ?? [])[0];
+  const pill = (svg.match(/<rect[^>]*data-marker-pill="now"[^>]*\/>/) ?? [])[0];
+  if (!input.now_marker) {
+    if (stem || pill) errs.push("E-TL-MARKER the artifact draws a now marker the input does not declare");
+  } else if (!stem || !pill) {
+    errs.push("E-TL-MARKER the input declares a now_marker but the artifact does not draw it — a declared label must be consumed, not hidden");
+  } else {
+    const mx = Number((attr(stem, "d").match(/M([\d.-]+)/) ?? [])[1]);
+    if (Math.abs(mx - g.markerX) > 0.5)
+      errs.push(`E-TL-MARKER the marker sits at x=${r1(mx)} but after_phase "${input.now_marker.after_phase}" recomputed from the input puts it at ${r1(g.markerX)}`);
+    const mb = { x: num(pill, "x"), y: num(pill, "y"), w: num(pill, "width"), h: num(pill, "height") };
+    const hit = (b) => !(mb.x + mb.w <= b.x || b.x + b.w <= mb.x || mb.y + mb.h <= b.y || b.y + b.h <= mb.y);
+    for (const m of svg.matchAll(/<rect[^>]*data-phase-card="([^"]+)"[^>]*\/>/g)) {
+      const b = { x: num(m[0], "x"), y: num(m[0], "y"), w: num(m[0], "width"), h: num(m[0], "height") };
+      if (hit(b)) errs.push(`E-TL-MARKER the marker pill overlaps milestone card "${m[1]}" — the marker crosses the axis, never a card`);
+    }
+    for (const m of svg.matchAll(/<text[^>]*data-phase-label="([^"]+)"[^>]*>/g)) {
+      const lx = num(m[0], "x"), ly = num(m[0], "y");
+      if (lx >= mb.x && lx <= mb.x + mb.w && ly >= mb.y - 8 && ly <= mb.y + mb.h + 8)
+        errs.push(`E-TL-MARKER the marker pill covers phase label "${m[1]}"`);
+    }
+    if (mb.x < cb.x || mb.x + mb.w > cb.x + cb.w) errs.push("E-TL-MARKER the marker pill leaves the content box");
+  }
+  // 끝 card가 content box 안에 있는지 최종 SVG에서 재측정한다(예측식이 아니라 실측).
+  const cards = [...svg.matchAll(/<rect[^>]*data-phase-card="([^"]+)"[^>]*\/>/g)]
+    .map((m) => ({ id: m[1], x: num(m[0], "x"), w: num(m[0], "width") }));
+  for (const c of cards)
+    if (c.x < cb.x - 0.5 || c.x + c.w > cb.x + cb.w + 0.5)
+      errs.push(`E-TL-CONTAIN milestone card "${c.id}" spans ${r1(c.x)}–${r1(c.x + c.w)} outside the content box ${cb.x}–${cb.x + cb.w}`);
+  // receipt는 정답이 아니라 대조 대상이다.
+  for (const e of validateTimelineReceiptV1(rcp.timeline, { phaseCount: input.phases.length, hasMarker: Boolean(input.now_marker) })) errs.push(e);
+  if (rcp.timeline?.phases) rcp.timeline.phases.forEach((p, i) => {
+    if (typeof p.x === "number" && Math.abs(p.x - g.xs[i]) > 0.5)
+      errs.push(`E-TL-SCHEMA receipt phase "${p.id}" x=${p.x} != ${r1(g.xs[i])} recomputed from the input`);
+  });
+  if (rcp.timeline?.marker && g.markerX != null && Math.abs(rcp.timeline.marker.x - g.markerX) > 0.5)
+    errs.push(`E-TL-SCHEMA receipt marker x=${rcp.timeline.marker.x} != ${r1(g.markerX)} recomputed from the input`);
+  return errs;
+}
+
 function verify(argv) {
   const opt = (n, d = null) => { const i = argv.indexOf(`--${n}`); return i >= 0 ? argv[i + 1] : d; };
   const rcpP = opt("receipt"), svgP = opt("svg"), pairP = opt("pair");
   if (!rcpP) { console.error("usage: generate.mjs verify --receipt <json> [--svg <svg>] [--pair <receipt>]"); process.exit(2); }
   const rcp = JSON.parse(readFileSync(rcpP, "utf8"));
   const errors = [];
-  const { input, inputDigest } = loadCase(rcp.typepack, String(rcp.case).replace(`${rcp.typepack}-`, ""));
+  const { input, inputDigest, tp: caseTp } = loadCase(rcp.typepack, String(rcp.case).replace(`${rcp.typepack}-`, ""));
   if (rcp.inputDigest !== inputDigest) errors.push(`E-GEN-INPUT receipt inputDigest != recomputed (${inputDigest.slice(0, 20)}…)`);
   if (rcp.geometry !== rcp.geometryExpected) errors.push(`E-GEN-GEOMETRY receipt geometry "${rcp.geometry}" != declared "${rcp.geometryExpected}"`);
   if (rcp.routingExpected) {
@@ -1124,6 +1413,7 @@ function verify(argv) {
       else if (expectedInv !== (gotInv ?? ""))
         errors.push(`E-GEN-ALIGN alignment inventory recomputed from the input does not match the artifact\n    input:    ${expectedInv}\n    artifact: ${gotInv ?? "(none)"}`);
       if (rcp.typepack === "decision-matrix") for (const e of auditMatrixAxes(svg, input, rcp.locale)) errors.push(e);
+      if (rcp.typepack === "roadmap-timeline") for (const e of auditTimeline(svg, input, rcp, caseTp)) errors.push(e);
       // 배선은 산출물에서 다시 잰다 — receipt가 아니라 기록된 path가 근거다
       const audit = auditTopology(svg);
       for (const e of audit.errors) errors.push(`E-GEN-ROUTE ${e}`);

--- a/skills/svg-infographic/scripts/generate.test.mjs
+++ b/skills/svg-infographic/scripts/generate.test.mjs
@@ -337,3 +337,161 @@ test("G-18: ordinal 축은 connector가 아니다 — routing audit 대상이 �
   assert.equal(runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]).code, 0);
   drop(pkg);
 });
+
+// --- roadmap-timeline: 위치는 입력이 정하고, 상태는 색 없이도 구분된다 -----------------
+// 이 타입의 뜻은 "순서"다. 그래서 좌표·순서·marker 위치를 모두 **원본 입력에서 재계산해** 대조한다.
+
+const skinManifest = (pkg) => {
+  const r = spawnSync(process.execPath, [path.join(pkg, "scripts", "skin.mjs"), "manifest"],
+    { encoding: "utf8", cwd: path.join(pkg, "scripts") });
+  return { code: r.status, out: r.stdout + r.stderr };
+};
+const tlEdit = (pkg, tid, fn) => {
+  const f = path.join(pkg, "references", "types", "inputs", `roadmap-timeline.${tid}.yaml`);
+  writeFileSync(f, fn(readFileSync(f, "utf8")));
+};
+
+test("G-19: 등간격은 계산값이다 — 한 phase만 옮기면 verify가 거부한다", () => {
+  const pkg = pkgCopy();
+  const b = build(pkg, "roadmap-timeline", "canonical", "ko");
+  assert.equal(b.code, 0, b.out);
+  assert.equal(runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]).code, 0);
+  const svg = readFileSync(b.svg, "utf8");
+  // phase 하나를 통째로 옮긴다(underlay·dot·ring·label 전부) — 자기 일관적인 이동이다.
+  const grp = svg.match(/<g data-comp-entity="phase-3"[\s\S]*?<\/g>/)[0];
+  const cx = Number(grp.match(/<circle[^>]*cx="([\d.]+)"/)[1]);
+  const moved = grp.replace(new RegExp(`cx="${cx}"`, "g"), `cx="${cx + 24}"`)
+    .replace(new RegExp(`x="${cx}"`, "g"), `x="${cx + 24}"`);
+  writeFileSync(b.svg, svg.replace(grp, moved));
+  const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /E-TL-POSITION/);
+  drop(pkg);
+});
+
+test("G-20: now marker 위치는 after_phase가 정한다 — 옮기면 거부한다", () => {
+  const pkg = pkgCopy();
+  const b = build(pkg, "roadmap-timeline", "canonical", "ko");
+  const svg = readFileSync(b.svg, "utf8");
+  const d = svg.match(/data-marker-stem="now" d="M([\d.]+)/)[1];
+  writeFileSync(b.svg, svg.replace(`d="M${d}`, `d="M${Number(d) + 20}`));
+  const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /E-TL-MARKER/);
+  drop(pkg);
+});
+
+test("G-21: after_phase가 없는 phase이거나 current가 아니면 입력에서 거부한다", () => {
+  for (const [mutate, why] of [
+    [(s) => s.replace('after_phase: "phase-2"', 'after_phase: "phase-9"'), /not an existing phase id/],
+    [(s) => s.replace('after_phase: "phase-2"', 'after_phase: "phase-3"'), /must name the phase whose status is "current"/],
+  ]) {
+    const pkg = pkgCopy();
+    tlEdit(pkg, "canonical", mutate);
+    const r = skinManifest(pkg);
+    assert.notEqual(r.code, 0, r.out);
+    assert.match(r.out, why);
+    drop(pkg);
+  }
+});
+
+test("G-22: 마지막 phase가 current인데 marker가 있으면 거부한다", () => {
+  const pkg = pkgCopy();
+  // tail-current 입력에 marker를 되돌려 넣는다 — 뒤에 놓을 ordinal interval이 없다.
+  const marker = ['now_marker:', '  after_phase: "phase-4"', '  label:', '    ko: "지금"', '    en: "Now"', ''].join("\n");
+  tlEdit(pkg, "stress-tail-current", (s) => s.trimEnd() + "\n" + marker);
+  const r = skinManifest(pkg);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /no ordinal interval follows it/);
+  drop(pkg);
+});
+
+test("G-23: status가 시간 순서와 모순이면 거부한다", () => {
+  const pkg = pkgCopy();
+  // done → future 로 바꿔 future 가 current 앞에 오게 만든다.
+  tlEdit(pkg, "canonical", (s) => s.replace('status: "done"', 'status: "future"'));
+  const r = skinManifest(pkg);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /done\* → current → future\*/);
+  drop(pkg);
+});
+
+test("G-24: 상태는 색만으로 구분되지 않는다 — ring이 안 보이면 거부한다", () => {
+  for (const [mutate, code] of [
+    [(s) => s.replace(/(data-dot-ring="current"[^>]*stroke-width=")[\d.]+/, "$10"), /ring stroke 0 is below the visible floor/],
+    [(s) => s.replace(/(<circle data-dot-ring="current" cx="[\d.]+" cy="[\d.]+" r=")[\d.]+/, "$19"), /leaves no visible gap/],
+    [(s) => s.replace(/<circle data-dot-ring="current"[^>]*\/>/, ""), /carries no ring/],
+  ]) {
+    const pkg = pkgCopy();
+    const b = build(pkg, "roadmap-timeline", "canonical", "ko");
+    writeFileSync(b.svg, mutate(readFileSync(b.svg, "utf8")));
+    const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+    assert.notEqual(r.code, 0, r.out);
+    assert.match(r.out, code);
+    drop(pkg);
+  }
+});
+
+test("G-25: timeline receipt는 exact schema다 — 누락·추가·타입·길이·union 모순을 거부한다", () => {
+  const muts = [
+    [(t) => { delete t.timeline.axis.step; }, /missing required field "step"/],
+    [(t) => { t.timeline.extra = 1; }, /undeclared field "extra"/],
+    [(t) => { t.timeline.axis.step = "wide"; }, /axis.step must be a finite number/],
+    [(t) => { t.timeline.phases[0].x = Infinity; }, /phases\[0\]\.x must be a finite number/],
+    [(t) => { t.timeline.phases.pop(); }, /holds 3 entries but the input declares 4/],
+    [(t) => { t.timeline.marker = null; }, /but the input declares now_marker/],
+    [(t) => { t.timeline.kind = "proportional"; }, /kind must be "ordinal"/],
+  ];
+  for (const [mutate, why] of muts) {
+    const pkg = pkgCopy();
+    const b = build(pkg, "roadmap-timeline", "canonical", "ko");
+    const t = JSON.parse(readFileSync(b.rcp, "utf8"));
+    mutate(t);
+    writeFileSync(b.rcp, JSON.stringify(t));
+    const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+    assert.notEqual(r.code, 0, `${why}\n${r.out}`);
+    assert.match(r.out, why);
+    drop(pkg);
+  }
+});
+
+test("G-26: 날짜 domain은 이 타입에 없다 — 입력이 들고 오면 거부한다", () => {
+  const pkg = pkgCopy();
+  const b = build(pkg, "roadmap-timeline", "canonical", "ko");
+  tlEdit(pkg, "canonical", (s) => s.replace('  - id: "phase-1"', '  - id: "phase-1"\n    date: "2026-01-01"'));
+  const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+  assert.notEqual(r.code, 0, r.out);
+  drop(pkg);
+});
+
+test("G-27: 축은 모든 state marker 뒤에 그려져야 한다 — 순서를 뒤집으면 거부한다", () => {
+  const pkg = pkgCopy();
+  const b = build(pkg, "roadmap-timeline", "canonical", "ko");
+  assert.equal(b.code, 0, b.out);
+  const svg = readFileSync(b.svg, "utf8");
+  // 축 rect를 dot 뒤로 옮긴다 — 좌표는 그대로라 기하 검사만으로는 잡히지 않는다.
+  const ax = svg.match(/<rect[^>]*data-axis="x"[^>]*\/>/)[0];
+  writeFileSync(b.svg, svg.replace(ax, "").replace("</svg>", `${ax}\n</svg>`));
+  const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /E-TL-LAYER/);
+  drop(pkg);
+});
+
+test("G-28: 투명한 future dot은 거부한다 — 축 rail이 비친다", () => {
+  for (const [mutate, why] of [
+    [(s) => s.replace(/(<circle cx="[\d.]+" cy="[\d.]+" r="[\d.]+" )fill="#F7F7F5" data-fill-role="canvas"( stroke="#636A75")/, '$1fill="none"$2'), /no fill — the axis rail shows through/],
+    [(s) => s.replace(/<circle[^>]*data-dot-underlay="future"[^>]*\/>/, ""), /carries no background underlay/],
+  ]) {
+    const pkg = pkgCopy();
+    const b = build(pkg, "roadmap-timeline", "canonical", "ko");
+    const before = readFileSync(b.svg, "utf8");
+    const after = mutate(before);
+    assert.notEqual(after, before, "fixture mutation did not apply");
+    writeFileSync(b.svg, after);
+    const r = runIn(pkg, ["verify", "--receipt", b.rcp, "--svg", b.svg]);
+    assert.notEqual(r.code, 0, r.out);
+    assert.match(r.out, why);
+    drop(pkg);
+  }
+});

--- a/skills/svg-infographic/scripts/skin.mjs
+++ b/skills/svg-infographic/scripts/skin.mjs
@@ -767,10 +767,10 @@ const INPUT_SCHEMA = {
 // 않으면 허위 coverage이므로 거부한다.
 const COVERS_VOCAB = ["cardinality-max", "copy-boundary-candidate", "optionals-max",
   "edge-density", "containment-depth", "mirrored-slots", "status-and-marker",
-  "gate-caption", "chips-max", "degrade-path"];
+  "gate-caption", "chips-max", "degrade-path", "terminal-current"];
 // audit 대상 축: 관측되면 반드시 선언돼야 한다(선언 ⊆ 관측 뿐 아니라 그 역도 성립).
 const AUDITABLE_COVERS = ["cardinality-max", "copy-boundary-candidate", "optionals-max",
-  "edge-density", "containment-depth", "mirrored-slots", "status-and-marker", "chips-max", "degrade-path"];
+  "edge-density", "containment-depth", "mirrored-slots", "status-and-marker", "chips-max", "degrade-path", "terminal-current"];
 
 function localized(v, budget, ctx, report, required = true) {
   if (v == null) { if (required) report(`${ctx} is missing`); return; }
@@ -959,9 +959,35 @@ export function validateInputPayload(doc, tid, declaredCount, report) {
     "roadmap-timeline": () => {
       const cur = list.filter((x) => x.status === "current").length;
       if (cur !== 1) report(`exactly one phase must be "current" (found ${cur})`);
-      if (doc.now_marker !== undefined) { exactKeys(doc.now_marker, ["label"], "now_marker", report); localized(doc.now_marker.label, B(12, 18), "now_marker label", report); }
+      // 축이 뜻하는 것은 순서다. "current 하나"만 보면 future → done → current 처럼
+      // 시간과 모순된 배열이 통과한다. 상태는 반드시 done* current future* 순이다.
+      const rank = { done: 0, current: 1, future: 2 };
+      let prev = -1, mono = true;
+      for (const p of list) {
+        const r = rank[p.status];
+        if (r === undefined || r < prev) { mono = false; break; }
+        prev = r;
+      }
+      if (!mono) report(`phase statuses must read done* → current → future* in declaration order (got ${list.map((p) => p.status).join(" → ")})`);
+      const curIdx = list.findIndex((p) => p.status === "current");
+      if (doc.now_marker !== undefined) {
+        exactKeys(doc.now_marker, ["label", "after_phase"], "now_marker", report);
+        localized(doc.now_marker.label, B(12, 18), "now_marker label", report);
+        // marker 위치는 입력이 말한다 — renderer가 추론하지 않는다. after_phase는 current와
+        // 같아야 하므로 값 자체는 중복이지만, marker만 옮기고 current를 두고 온 경우를
+        // **조용한 모순 대신 오류**로 만든다(검사되는 중복).
+        const ap = doc.now_marker.after_phase;
+        if (ap === undefined) report("now_marker requires after_phase — the marker position is input data, not something the generator may infer");
+        else if (!ids.has(ap)) report(`now_marker after_phase "${ap}" is not an existing phase id`);
+        else if (curIdx >= 0 && list[curIdx].id !== ap)
+          report(`now_marker after_phase "${ap}" must name the phase whose status is "current" (that is "${list[curIdx].id}")`);
+        else if (curIdx === list.length - 1)
+          report("the last phase is \"current\", so no ordinal interval follows it — drop now_marker from the input instead of asking the renderer to hide a declared label");
+      }
       const st = new Set(list.map((x) => x.status));
       if (st.has("done") && st.has("current") && st.has("future") && doc.now_marker !== undefined) observed.add("status-and-marker");
+      // C-06이 fail-closed로 다루는 조합의 **합법 쪽**이다: 마지막이 current인데 marker가 없다.
+      if (curIdx === list.length - 1 && doc.now_marker === undefined) observed.add("terminal-current");
     },
     "decision-matrix": () => {
       const ax = doc.axes;


### PR DESCRIPTION
## 요약

Wave 1의 마지막 TypePack. **구현 순서를 바꾼 첫 batch**다 — contract coverage table → wireframe → bounded R0/R0B → 구현. 설계 기록은 Toolstead `#161`에 있다.

효과는 실측으로 나타났다. 코드 이전에 가정 2건이 반증됐고(marker를 축 끝에 두면 label·dot과 충돌, 상수 endInset은 끝 card를 42px 밀어냄), R0/R0B가 계약 결손 9건을 더 잡았다.

## 축은 ordinal이다

spec §1·§3이 비례 주장을 부정하고 legacy 산출물도 정확히 등간격이다. 날짜·tick·duration·의존관계는 입력에서 거부하고, phase에 날짜 필드가 있으면 verify가 `E-TL-DOMAIN`으로 막는다.

## 자리는 입력이 정한다

| 대상 | 규칙 |
| --- | --- |
| phase | `step = (contentW − 2×endInset)/(n−1)`, `x_i = contentX0 + endInset + i×step` |
| endInset | `cardVisualW/2 + outerClearance` — 두 locale 최장 title이 정하는 card 폭에서 유도 |
| now_marker | `after_phase`(= current)와 다음 phase의 중점. renderer가 추론하지 않는다 |

`after_phase`는 `current`와 같아야 하므로 값 자체는 중복이다. 그럼에도 두는 이유는 **검사되는 중복**이기 때문이다 — marker만 옮기고 `current`를 두고 오면 조용한 모순 대신 오류가 난다.

verify는 receipt를 정답으로 쓰지 않고 **원본 입력과 preset contentBox에서 기하를 재계산해** 0.5px로 대조한다.

## 상태는 색 없이도 구분되고, marker는 불투명하다

`done` = status fill · `current` = 배경 underlay + status fill + outer ring · `future` = **배경 role fill + outline**. "빈 원"이 투명을 뜻하지 않는다 — 투명하면 뒤의 축 rail이 비쳐 dot이 선에 걸린 것처럼 보인다. 배경은 하드코딩이 아니라 canvas role이라 dark skin에서도 맞는다.

paint order는 DOM 계약이다: **axis → marker underlay → dot/ring → label**.

## 구현 중 gate·렌더가 잡은 결함 5건

| # | 결함 | 처리 |
| --- | --- | --- |
| 1 | 축 band가 dot 위에 그려져 dot이 잘렸다 | 축은 배경 rail → container layer |
| 2 | 교대 배치에서 위쪽 card가 phase label을 덮었다 | label을 card 반대편에 |
| 3 | container가 band에 딱 맞아 card stroke가 경계에 닿았다 | band를 안쪽 여백에 |
| 4 | fluid에서 예측 footprint(112) > 실제 최소 높이(95) → **거짓 needs-split** | 최소 합법 문법에서 재유도 |
| 5 | fluid probe가 needs-split 결과의 `bounds`를 읽어 크래시 | 배치가 없으면 프레임을 다시 만들지 않는다 |

## degrade ladder를 줄였다

`body drop`을 **제거**했다. body는 높이를 36px 늘리는데 content box는 652~712px라 어떤 합법 입력에서도 body가 실패를 만들지 못한다 — 즉 `before fail → body drop 후 pass` 전이가 성립하지 않는다. 이름만 남기지 않고 뺐고, 예산을 넘는 body는 degrade가 아니라 입력 오류다. 대신 body 렌더 경로가 미검증으로 남지 않게 `stress-body`를 positive 시나리오로 추가했다.

인접 phase 자동 병합도 넣지 않았다 — 병합은 저자 허가 없이 의미를 바꾼다.

## 회귀

```
skin 118 · preflight 29 · check-svg 70 · check-layout 47 · route-orthogonal 28
font-probe 6 · render 23 · compose 51 · generate 29
all suites green (exit 0)
```

negative fixture 10종(G-19~G-28): phase 이동 · marker 이동 · `after_phase` 미존재/비-current · 마지막 current+marker · status 시간 역전 · ring 비가시 3종 · receipt schema 7종 · 날짜 domain 유입 · axis paint order · 투명 future dot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)