### PR TITLE
docs(svg-infographic): TypePack spec 9종을 English canonical로 정규화한다

### DIFF
--- a/skills/svg-infographic/references/package-surface.yaml
+++ b/skills/svg-infographic/references/package-surface.yaml
@@ -14,7 +14,7 @@
 # evidence 또는 CI artifact로만 저장한다.
 
 schema_version: 1
-surface_revision: 9
+surface_revision: 10
 
 canonicalization:
   version: 1

--- a/skills/svg-infographic/references/types/specs/approval-gate.md
+++ b/skills/svg-infographic/references/types/specs/approval-gate.md
@@ -34,22 +34,22 @@ A simple request path with one approval gate.
 
 ## 4. Intrinsic fit and variant contract
 
-Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 region에 들어가는지
-판정하고, 들어가지 않으면 §6 ladder로 내려간다. 글자·간격을 줄여 억지로 맞추지 않는다.
+Fit is decided **before** layout: judge whether this type fits the region before attempting
+placement, and drop to the §6 ladder when it does not. Never shrink type or spacing to force a fit.
 
-**수식 변수는 이 문서가 아니라 manifest의 `fit` 블록이 소유한다**(`references/types/manifest.yaml`,
-해당 TypePack의 `fit.cardinality` / `fit.params` / `fit.footprint`). 문서에 상수를 다시
-적으면 두 벌이 어긋나므로, 여기서는 배치 종류와 판정 경계만 적는다.
+**The manifest's `fit` block owns the formula variables, not this document**
+(`references/types/manifest.yaml`, this TypePack's `fit.cardinality` / `fit.params` / `fit.footprint`). Restating constants here would
+let the two copies drift, so this section records only the arrangement and the decision boundary.
 
-- 배치: row + gate pill clearance
-- 근거 수준: manifest `fit.floor_basis`가 `geometry`인 동안 이 수치는 **기하 가정**이며
-  실제 렌더로 확인된 값이 아니다. CP2B의 stress render(getBBox·containment·PNG 검수)를
-  통과한 뒤에만 `rendered`로 승격한다.
-- 판정: `fit.footprint`가 params에서 계산되고, `fit.feasibility`가 **실제 PageFrame
-  contentBox**(preset별 live receipt)와 대조돼 `fits` 또는 `needs-split`으로 확정된다.
-  manifest validator가 두 계산을 모두 재수행하므로 선언만으로 통과할 수 없다.
-- 경계: **4:5 portrait에서 4노드는 성립하지 않는다**(needs-split). 4:5은 3노드가 상한이고,
-  16:9은 4노드까지 성립한다.
+- Arrangement: row + gate pill clearance
+- Evidence level: while the manifest's `fit.floor_basis` reads `geometry`, these numbers are a
+  **geometric assumption**, not a value confirmed by rendering. They are promoted to `rendered`
+  only after passing the CP2B stress render (getBBox, containment, PNG inspection).
+- Decision: `fit.footprint` is computed from the params, and `fit.feasibility` is settled as
+  `fits` or `needs-split` against the **live PageFrame contentBox** (a per-preset receipt). The
+  manifest validator recomputes both, so a declaration alone never passes.
+- Boundary: **4 nodes do not hold in 4:5 portrait** (needs-split). 4:5 tops out at 3 nodes;
+  16:9 holds 4.
 
 ## 5. Layout, encoding and connector rules
 

--- a/skills/svg-infographic/references/types/specs/before-after.md
+++ b/skills/svg-infographic/references/types/specs/before-after.md
@@ -34,35 +34,37 @@ Old versus new, side by side.
 
 ## 4. Intrinsic fit and variant contract
 
-Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 region에 들어가는지
-판정하고, 들어가지 않으면 §6 ladder로 내려간다. 글자·간격을 줄여 억지로 맞추지 않는다.
+Fit is decided **before** layout: judge whether this type fits the region before attempting
+placement, and drop to the §6 ladder when it does not. Never shrink type or spacing to force a fit.
 
-**수식 변수는 이 문서가 아니라 manifest의 `fit` 블록이 소유한다**(`references/types/manifest.yaml`,
-해당 TypePack의 `fit.cardinality` / `fit.params` / `fit.footprint`). 문서에 상수를 다시
-적으면 두 벌이 어긋나므로, 여기서는 배치 종류와 판정 경계만 적는다.
+**The manifest's `fit` block owns the formula variables, not this document**
+(`references/types/manifest.yaml`, this TypePack's `fit.cardinality` / `fit.params` / `fit.footprint`). Restating constants here would
+let the two copies drift, so this section records only the arrangement and the decision boundary.
 
-- 배치: row(패널 2개)
-- 근거 수준: manifest `fit.floor_basis`가 `geometry`인 동안 이 수치는 **기하 가정**이며
-  실제 렌더로 확인된 값이 아니다. CP2B의 stress render(getBBox·containment·PNG 검수)를
-  통과한 뒤에만 `rendered`로 승격한다.
-- 판정: `fit.footprint`가 params에서 계산되고, `fit.feasibility`가 **실제 PageFrame
-  contentBox**(preset별 live receipt)와 대조돼 `fits` 또는 `needs-split`으로 확정된다.
-  manifest validator가 두 계산을 모두 재수행하므로 선언만으로 통과할 수 없다.
-- 경계: 두 패널과 gutter가 두 preset에서 성립한다. 높이는 긴 쪽이 정하고 짧은 쪽을 **패딩**한다.
-- 패널 높이 floor는 상수가 아니라 **최소 합법 문법에서 유도한다**: 헤더 예약 + (최소 slot 수 ×
-  slot 높이) + slot 사이 간격 + 패널 안쪽 여백. 기호로 쓰면
-  `panelFloor = panelHeaderH + minSlots × slotMinH + (minSlots − 1) × slotGap + 2 × panelPad`이고,
-  변수 값은 모두 manifest `fit.params`가 소유한다. validator와 renderer가 **같은 derive helper**를
-  호출하므로 문서·검증·렌더가 갈라질 수 없다. floor를 맞추려고 canonical의 slot 수를 늘리거나
-  임의의 낮은 상수로 내리지 않는다.
+- Arrangement: row (2 panels)
+- Evidence level: while the manifest's `fit.floor_basis` reads `geometry`, these numbers are a
+  **geometric assumption**, not a value confirmed by rendering. They are promoted to `rendered`
+  only after passing the CP2B stress render (getBBox, containment, PNG inspection).
+- Decision: `fit.footprint` is computed from the params, and `fit.feasibility` is settled as
+  `fits` or `needs-split` against the **live PageFrame contentBox** (a per-preset receipt). The
+  manifest validator recomputes both, so a declaration alone never passes.
+- Boundary: both panels and the gutter hold in both presets. The taller panel sets the height and the
+  shorter one is **padded** to match.
+- The panel height floor is not a constant — it is **derived from the minimum legal syntax**: the header
+  reservation, plus (minimum slot count × slot height), plus the gaps between slots, plus the panel's
+  inner padding. Symbolically:
+  `panelFloor = panelHeaderH + minSlots × slotMinH + (minSlots − 1) × slotGap + 2 × panelPad`,
+  and the manifest `fit.params` owns every variable. The validator and the renderer call the **same
+  derive helper**, so the document, the check and the render cannot drift apart. Never raise the
+  canonical slot count to reach the floor, and never lower the floor to an arbitrary constant.
 
 ## 5. Layout, encoding and connector rules
 
 - Two equal-height, equal-width panels with a 32–48px gutter; optional centre arrow or migration chip between them; optional delta strip below.
-- Mirrored slots align to the same y in both panels. 이 대칭은 눈으로 판정하지 않는다: slot `i`는
-  두 패널에서 하나의 `data-align-row`에 속하고 참여 수 2를 선언하므로, 한쪽 slot이 어긋나거나
-  annotation이 빠지면 hard error가 된다(design-kernel §7d). 패널 헤더는 `data-reserve-top`으로
-  예약돼 대칭 판정에서 빠진다.
+- Mirrored slots align to the same y in both panels. This symmetry is not judged by eye: slot `i` joins
+  one `data-align-row` across both panels and declares a participant count of 2, so a slot that drifts —
+  or an annotation that goes missing — becomes a hard error (design-kernel §7d). The panel header is
+  reserved with `data-reserve-top` and is therefore excluded from the symmetry judgement.
 - A legend is required when three or more semantic colours appear.
 - No connectors between panel internals — the mirror alignment carries the correspondence.
 
@@ -76,7 +78,7 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
 ## 7. Verifier, receipt and fixture contract
 
 - **Machine verifier**: none (`verifier: null`).
-- Checks: panel heights and widths equal; mirrored slots share a y; gutter ≥ 24 with balanced outer margins; legend present when required. 앞의 두 항목은 `check-layout.mjs`의 alignment 계약이 기계로 판정하고, artifact의 `data-align-inventory`는 원본 input에서 다시 계산한 기대치와 대조된다.
+- Checks: panel heights and widths equal; mirrored slots share a y; gutter ≥ 24 with balanced outer margins; legend present when required. The first two are decided by machine through the alignment contract in `check-layout.mjs`, and the artifact's `data-align-inventory` is compared against an expectation recomputed from the original input.
 - **Receipt**: the mirrored slot list, per-slot change class, and the padding applied to the shorter panel.
 - **Fixtures**: positive per preset + a baseline-red with ragged panel ends. Required before `core`.
 
@@ -90,6 +92,6 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
 
 - Panels ending ragged because content differed.
 - Slots that do not mirror, so the eye cannot diff.
-- 한쪽 패널의 slot annotation만 남아 정렬 검사가 "남은 것끼리는 맞다"로 통과하는 경우.
+- Only one panel keeping its slot annotations, so the alignment check passes on "the survivors agree".
 - Colour-only change encoding with no legend and no text.
 - A third panel bolted on.

--- a/skills/svg-infographic/references/types/specs/cards-kpi-grid.md
+++ b/skills/svg-infographic/references/types/specs/cards-kpi-grid.md
@@ -49,23 +49,23 @@ promote the extras out of the grid — never shrink the card below the §4 floor
 
 ## 4. Intrinsic fit and variant contract
 
-Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 region에 들어가는지
-판정하고, 들어가지 않으면 §6 ladder로 내려간다. 글자·간격을 줄여 억지로 맞추지 않는다.
+Fit is decided **before** layout: judge whether this type fits the region before attempting
+placement, and drop to the §6 ladder when it does not. Never shrink type or spacing to force a fit.
 
-**수식 변수는 이 문서가 아니라 manifest의 `fit` 블록이 소유한다**(`references/types/manifest.yaml`,
-해당 TypePack의 `fit.cardinality` / `fit.params` / `fit.footprint`). 문서에 상수를 다시
-적으면 두 벌이 어긋나므로, 여기서는 배치 종류와 판정 경계만 적는다.
+**The manifest's `fit` block owns the formula variables, not this document**
+(`references/types/manifest.yaml`, this TypePack's `fit.cardinality` / `fit.params` / `fit.footprint`). Restating constants here would
+let the two copies drift, so this section records only the arrangement and the decision boundary.
 
-- 배치: row(n ≤ 4) / grid 2열(n = 5–6)
-- 근거 수준: manifest `fit.floor_basis`가 `geometry`인 동안 이 수치는 **기하 가정**이며
-  실제 렌더로 확인된 값이 아니다. CP2B의 stress render(getBBox·containment·PNG 검수)를
-  통과한 뒤에만 `rendered`로 승격한다.
-- 판정: `fit.footprint`가 params에서 계산되고, `fit.feasibility`가 **실제 PageFrame
-  contentBox**(preset별 live receipt)와 대조돼 `fits` 또는 `needs-split`으로 확정된다.
-  manifest validator가 두 계산을 모두 재수행하므로 선언만으로 통과할 수 없다.
-- 경계: base floor는 title 2줄 + body 2줄 + icon을 수용하는 크기이고, `compact` floor는 body를
-  버린 title-only 축약이다 — 두 floor는 manifest `fit.params`에서 이름으로 구분된다.
-  4:5에서는 6장 grid가 성립하고 compact 한 줄 배치는 성립하지 않는다(needs-split).
+- Arrangement: row (n ≤ 4) / 2-column grid (n = 5–6)
+- Evidence level: while the manifest's `fit.floor_basis` reads `geometry`, these numbers are a
+  **geometric assumption**, not a value confirmed by rendering. They are promoted to `rendered`
+  only after passing the CP2B stress render (getBBox, containment, PNG inspection).
+- Decision: `fit.footprint` is computed from the params, and `fit.feasibility` is settled as
+  `fits` or `needs-split` against the **live PageFrame contentBox** (a per-preset receipt). The
+  manifest validator recomputes both, so a declaration alone never passes.
+- Boundary: the base floor holds a 2-line title, a 2-line body and an icon; the `compact` floor
+  is the title-only reduction that drops the body — the two floors are distinguished by name in the
+  manifest `fit.params`. In 4:5 a 6-card grid holds while a compact single row does not (needs-split).
 
 ## 5. Layout, encoding and connector rules
 

--- a/skills/svg-infographic/references/types/specs/decision-matrix.md
+++ b/skills/svg-infographic/references/types/specs/decision-matrix.md
@@ -30,54 +30,58 @@ Options placed by two qualitative axes.
 
 ## 3. Semantic model and invariants
 
-- Entities are **cells** addressed by their axis position; position is the claim. 자리는 배열 순서가
-  아니라 cell이 선언한 **축 값**(`x`/`y` tier id)에서 파생한다: x tier는 낮음→높음이 왼→오,
-  y tier는 낮음→높음이 **아래→위**다. 같은 칸을 두 cell이 주장할 수 없고, 축 값과 어긋난 자리는
-  통과하지 못한다. cell `name`은 선택이며 없으면 두 축 tier label에서 파생한다 — "낮음-높음"처럼
-  어느 축이 먼저인지 알 수 없는 문안을 입력이 지어내지 않게 하기 위해서다.
+- Entities are **cells** addressed by their axis position; position is the claim. Placement derives from the
+  **axis value** each cell declares (`x` / `y` tier id), never from array order: x tiers run low→high
+  left→right, and y tiers run low→high **bottom→top**. 2 cells may not claim the same slot, and a
+  position that disagrees with its axis values does not pass. A cell `name` is optional; when absent it
+  derives from the two tier labels, so the input never has to invent copy like "Low-High" where the
+  axis order is unreadable.
 - Invariants: all cells are equal in size; both axes label **both** ends; every cell carries a name; at most one cell takes the emphasis toolkit.
 - Qualitative only — saturation may encode severity but no numeric scale is asserted.
 
 ## 4. Intrinsic fit and variant contract
 
-Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 region에 들어가는지
-판정하고, 들어가지 않으면 §6 ladder로 내려간다. 글자·간격을 줄여 억지로 맞추지 않는다.
+Fit is decided **before** layout: judge whether this type fits the region before attempting
+placement, and drop to the §6 ladder when it does not. Never shrink type or spacing to force a fit.
 
-**수식 변수는 이 문서가 아니라 manifest의 `fit` 블록이 소유한다**(`references/types/manifest.yaml`,
-해당 TypePack의 `fit.cardinality` / `fit.params` / `fit.footprint`). 문서에 상수를 다시
-적으면 두 벌이 어긋나므로, 여기서는 배치 종류와 판정 경계만 적는다.
+**The manifest's `fit` block owns the formula variables, not this document**
+(`references/types/manifest.yaml`, this TypePack's `fit.cardinality` / `fit.params` / `fit.footprint`). Restating constants here would
+let the two copies drift, so this section records only the arrangement and the decision boundary.
 
-- 배치: grid 2×2 / 3×3 + axis gutter
-- 근거 수준: manifest `fit.floor_basis`가 `geometry`인 동안 이 수치는 **기하 가정**이며
-  실제 렌더로 확인된 값이 아니다. CP2B의 stress render(getBBox·containment·PNG 검수)를
-  통과한 뒤에만 `rendered`로 승격한다.
-- 판정: `fit.footprint`가 params에서 계산되고, `fit.feasibility`가 **실제 PageFrame
-  contentBox**(preset별 live receipt)와 대조돼 `fits` 또는 `needs-split`으로 확정된다.
-  manifest validator가 두 계산을 모두 재수행하므로 선언만으로 통과할 수 없다.
-- 경계: 축 gutter를 제외한 뒤에도 2×2와 3×3이 두 preset에서 성립한다. corner decoration 간격은
-  cell floor에 포함된 예산이다.
-- 격자 폭은 frame 폭이 아니라 **예약을 뺀 나머지**에서 계산한다:
+- Arrangement: grid 2×2 / 3×3 + axis gutter
+- Evidence level: while the manifest's `fit.floor_basis` reads `geometry`, these numbers are a
+  **geometric assumption**, not a value confirmed by rendering. They are promoted to `rendered`
+  only after passing the CP2B stress render (getBBox, containment, PNG inspection).
+- Decision: `fit.footprint` is computed from the params, and `fit.feasibility` is settled as
+  `fits` or `needs-split` against the **live PageFrame contentBox** (a per-preset receipt). The
+  manifest validator recomputes both, so a declaration alone never passes.
+- Boundary: 2×2 and 3×3 hold in both presets even after the axis gutter is subtracted. The corner
+  decoration spacing is a budget already included in the cell floor.
+- Grid width is computed from **what remains after the reservation**, not from the frame width:
   `gridW = contentW − reserveLeft − 2 × pad`, `cellW = (gridW − (cols − 1) × gapX) ÷ cols`
-  (세로도 동형). 축 라벨 열은 `data-reserve-left`로 예약되며, 라벨 폭은 상수가 아니라 KO·EN 실제
-  문자열을 측정한 값의 최댓값이다. 이 예약을 빼지 않고 좌표를 잡으면 셀이 경계에 닿고, 경계에
-  정확히 닿는 경우도 통과가 아니라 hard error다.
+  (the vertical axis is symmetric). The axis label column is reserved with `data-reserve-left`, and the
+  label width is not a constant — it is the maximum of the measured KO and EN strings. Laying out
+  coordinates without subtracting this reservation makes cells touch the boundary, and touching it
+  exactly is a hard error rather than a pass.
 
 ## 5. Layout, encoding and connector rules
 
 - Four or nine equal panels with visible gutters; axis arrows drawn **outside** the panels; quadrant name labels inside their panel.
-- **Ordinal axis grammar (this TypePack only).** 격자 왼쪽에 세로 keyline, 아래에 가로 keyline을
-  그리고 positive 끝(위·오른쪽)에만 작은 direction marker를 둔다. 양끝 tier label이 각 축 끝점에
-  정렬하고, 축선은 예약 구간 안에서 격자와 label 어느 쪽에도 닿지 않는다(clearance는 계산값이며
-  고정 상수가 아니다). 이 축은 **ordinal category direction**이다 — 수치 간격을 나타내는 chart
-  axis가 아니므로 tick·숫자 눈금·gridline으로 확장하지 않는다. 축은 connector가 아니다:
-  `data-route-*`로 분류하지 않고 routing audit 대상도 아니며, direction marker는 primary
-  connector arrow보다 얇게(시각적 우선순위가 낮게) 같은 arrow scale 산식에서 파생한다.
-  2×2·3×3·불완전 격자가 모두 같은 문법을 쓰고 KO/EN이 같은 축 기하를 갖는다.
-- 셀은 행 id와 열 id를 **동시에** 갖는다(`data-align-row` + `data-align-col`, 각각 참여 수 선언).
-  위치가 곧 주장이므로 교차 정렬은 기계로 판정한다(design-kernel §7d).
-- 격자가 완전히 차지 않을 수 있다. 마지막 행이 부족하면 그 행은 등간격 group을 주장하지 않고
-  **열 정렬이 대신 지배**하며, 참여자가 하나뿐인 축은 group 자체를 만들지 않는다. 빈 칸을 채우는
-  자리표시자 셀은 만들지 않는다.
+- **Ordinal axis grammar (this TypePack only).** Draw a vertical keyline left of the grid and a
+  horizontal keyline below it, with a small direction marker only at the positive end (up, right). The
+  end tier labels align to each axis endpoint, and the axis line stays inside the reservation without
+  touching either the grid or a label (the clearance is computed, not a fixed constant). This axis is an
+  **ordinal category direction** — not a chart axis expressing numeric intervals — so it never grows
+  ticks, numeric scales or gridlines. The axis is not a connector: it carries no `data-route-*`
+  classification, is not subject to the routing audit, and its direction marker is derived from the same
+  arrow-scale formula as connectors but thinner, so it never outranks a primary connector arrow
+  visually. 2×2, 3×3 and incomplete grids all use the same grammar, and KO and EN share one axis geometry.
+- A cell carries a row id **and** a column id at once (`data-align-row` + `data-align-col`, each
+  declaring its participant count). Position is the claim, so cross alignment is decided by machine
+  (design-kernel §7d).
+- The grid may be incomplete. When the last row falls short it asserts no equal-gap group and **column
+  alignment governs instead**; an axis left with a single participant forms no group at all. No
+  placeholder cell is invented to fill a hole.
 - One colour family per cell; risk grids encode severity by saturation (low light → high saturated).
 - Corner decorations are placed by rule: badge top-left, status label on the same row right of the badge, icon top-right.
 - No connectors between cells.
@@ -92,22 +96,23 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
 ## 7. Verifier, receipt and fixture contract
 
 - **Machine verifier**: none (`verifier: null`).
-- Checks: cells exactly equal; both ends of both axes labelled; axis labels clear of panel corners; corner decorations meet the ≥ 20–24px separation. 셀 동일성과 행·열 교차 정렬은 `check-layout.mjs`가 판정하고, `data-align-inventory`는 원본 input에서 다시 계산한 기대치와 대조된다. **Corner crowding is this type's top failure — verify it against the exported PNG, not only the SVG source.**
-- Axis checks (기하까지 본다 — 라벨만 보면 축이 없어도 통과한다): 두 축이 각각 정확히 한 번 그려지고
-  orientation이 맞을 것 · positive 끝에 direction marker가 있을 것 · 끝점 label의 배치가 그 방향과
-  같은 뜻일 것 · 축이 grid/cell bounds를 침범하지 않을 것 · cell 자리가 입력 축 값에서 다시 계산한
-  기대 행·열과 일치할 것. 마지막 항목은 receipt가 아니라 **원본 입력**에서 재계산해 대조한다.
+- Checks: cells exactly equal; both ends of both axes labelled; axis labels clear of panel corners; corner decorations meet the ≥ 20–24px separation. Cell equality and row/column cross alignment are decided by `check-layout.mjs`, and `data-align-inventory` is compared against an expectation recomputed from the original input. **Corner crowding is this type's top failure — verify it against the exported PNG, not only the SVG source.**
+- Axis checks (geometry included — checking labels alone would pass an artifact with no axis at all):
+  each axis is drawn exactly once with the right orientation · a direction marker sits at the positive
+  end · the endpoint labels are placed consistently with that direction · the axis does not intrude into
+  the grid or cell bounds · each cell sits at the row and column recomputed from its input axis values.
+  That last item is compared against a recomputation from the **original input**, not from the receipt.
 - **Receipt**: cells with their axis position, the emphasised cell, and dropped optional content.
-  `matrix` 블록에 축 kind(`ordinal-direction`)·tier 순서·positive 방향과 cell별 축 값·행·열·정렬
-  group id를 기록한다.
+  The `matrix` block records the axis kind (`ordinal-direction`), tier order and positive direction,
+  plus each cell's axis values, row, column and alignment group ids.
 - **Fixtures**: positive per preset + a baseline-red with crowded corners. Required before `core`.
 
 ## 8. Reading order, accessibility and locale
 
-- Reading order는 선언값이며 DOM 순서와 일치해야 한다. **기본값은 DOM 친화적인 top-row-first**
-  (top-left → top-right → bottom-left → bottom-right)다. 축 의미상 아래 행부터 읽어야 하는
-  경우(예: 저위험 → 고위험 상승)에는 입력이 그 순서를 **명시적으로 선언**해야 하며, 암묵적
-  기본값으로 두지 않는다.
+- Reading order is a declared value and must match DOM order. **The default is the DOM-friendly
+  top-row-first** order (top-left → top-right → bottom-left → bottom-right). When the axis meaning
+  requires reading from the bottom row up (for example low risk → high risk), the input must
+  **declare that order explicitly** rather than leaving it to an implicit default.
 - Severity is never colour-only: the cell trait states it.
 - KO and EN budgets are per script; corner decorations are budgeted per script too.
 
@@ -116,9 +121,9 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
 - Corner crowding — the top failure; badge, status and icon collide at small sizes.
 - One axis labelled at only one end.
 - Cells resized to fit longer text.
-- 축 라벨 예약을 무시하고 frame 폭으로 격자를 계산해 셀이 경계에 닿는 경우.
-- 배열 순서대로 채워 "낮음" 행이 위로 올라가는 경우 — 축 라벨과 cell 의미가 반대가 된다.
-- 축 끝 label만 띄우고 축선·방향 marker를 생략해 2축 방향성이 읽히지 않는 경우.
-- cell을 canvas 높이에 맞춰 늘려 두 줄짜리 내용이 빈 세로 면적을 갖는 경우.
-- 격자를 네모나게 보이려고 빈 자리표시자 셀을 넣는 경우.
+- Computing the grid from the frame width, ignoring the axis label reservation, so cells touch the boundary.
+- Filling by array order so the "low" row lands on top — the axis labels and the cell meaning end up reversed.
+- Floating the axis end labels while omitting the axis lines and direction markers, leaving the two-axis direction unreadable.
+- Stretching cells to the canvas height so two lines of content sit in a large empty vertical area.
+- Inserting an empty placeholder cell to make the grid look rectangular.
 - Saturation read as a numeric severity score.

--- a/skills/svg-infographic/references/types/specs/layer-stack.md
+++ b/skills/svg-infographic/references/types/specs/layer-stack.md
@@ -45,24 +45,24 @@ the artifact rather than shrinking the band height.
 
 ## 4. Intrinsic fit and variant contract
 
-Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 region에 들어가는지
-판정하고, 들어가지 않으면 §6 ladder로 내려간다. 글자·간격을 줄여 억지로 맞추지 않는다.
+Fit is decided **before** layout: judge whether this type fits the region before attempting
+placement, and drop to the §6 ladder when it does not. Never shrink type or spacing to force a fit.
 
-**수식 변수는 이 문서가 아니라 manifest의 `fit` 블록이 소유한다**(`references/types/manifest.yaml`,
-해당 TypePack의 `fit.cardinality` / `fit.params` / `fit.footprint`). 문서에 상수를 다시
-적으면 두 벌이 어긋나므로, 여기서는 배치 종류와 판정 경계만 적는다.
+**The manifest's `fit` block owns the formula variables, not this document**
+(`references/types/manifest.yaml`, this TypePack's `fit.cardinality` / `fit.params` / `fit.footprint`). Restating constants here would
+let the two copies drift, so this section records only the arrangement and the decision boundary.
 
-- 배치: column
-- 근거 수준: manifest `fit.floor_basis`가 `geometry`인 동안 이 수치는 **기하 가정**이며
-  실제 렌더로 확인된 값이 아니다. CP2B의 stress render(getBBox·containment·PNG 검수)를
-  통과한 뒤에만 `rendered`로 승격한다.
-- 판정: `fit.footprint`가 params에서 계산되고, `fit.feasibility`가 **실제 PageFrame
-  contentBox**(preset별 live receipt)와 대조돼 `fits` 또는 `needs-split`으로 확정된다.
-  manifest validator가 두 계산을 모두 재수행하므로 선언만으로 통과할 수 없다.
-- 경계: **band 폭은 chip 예산이 정한다.** base floor는 label gutter + chip 2개(각 16 CJK)를
-  수용하고, chip 4개를 요구하는 `wide` floor는 **4:5에서 성립하지 않는다**(needs-split;
-  16:9은 성립). 4:5에서 chip 4개가 필요하면 chip 문구를 줄이거나 분리 페이지다.
-  clamp는 feasibility 판정 **이후**에만 적용한다.
+- Arrangement: column
+- Evidence level: while the manifest's `fit.floor_basis` reads `geometry`, these numbers are a
+  **geometric assumption**, not a value confirmed by rendering. They are promoted to `rendered`
+  only after passing the CP2B stress render (getBBox, containment, PNG inspection).
+- Decision: `fit.footprint` is computed from the params, and `fit.feasibility` is settled as
+  `fits` or `needs-split` against the **live PageFrame contentBox** (a per-preset receipt). The
+  manifest validator recomputes both, so a declaration alone never passes.
+- Boundary: **the chip budget sets the band width.** The base floor holds the label gutter plus 2
+  chips (16 CJK characters each); the `wide` floor that demands 4 chips **does not hold in 4:5**
+  (needs-split; 16:9 does). When 4:5 needs 4 chips, shorten the chip copy or split the page.
+  Clamping applies only **after** the feasibility decision.
 
 ## 5. Layout, encoding and connector rules
 

--- a/skills/svg-infographic/references/types/specs/nested-scope.md
+++ b/skills/svg-infographic/references/types/specs/nested-scope.md
@@ -36,22 +36,22 @@ Five or more rings is a degrade input (§6): merge rings or split the artifact.
 
 ## 4. Intrinsic fit and variant contract
 
-Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 region에 들어가는지
-판정하고, 들어가지 않으면 §6 ladder로 내려간다. 글자·간격을 줄여 억지로 맞추지 않는다.
+Fit is decided **before** layout: judge whether this type fits the region before attempting
+placement, and drop to the §6 ladder when it does not. Never shrink type or spacing to force a fit.
 
-**수식 변수는 이 문서가 아니라 manifest의 `fit` 블록이 소유한다**(`references/types/manifest.yaml`,
-해당 TypePack의 `fit.cardinality` / `fit.params` / `fit.footprint`). 문서에 상수를 다시
-적으면 두 벌이 어긋나므로, 여기서는 배치 종류와 판정 경계만 적는다.
+**The manifest's `fit` block owns the formula variables, not this document**
+(`references/types/manifest.yaml`, this TypePack's `fit.cardinality` / `fit.params` / `fit.footprint`). Restating constants here would
+let the two copies drift, so this section records only the arrangement and the decision boundary.
 
-- 배치: concentric
-- 근거 수준: manifest `fit.floor_basis`가 `geometry`인 동안 이 수치는 **기하 가정**이며
-  실제 렌더로 확인된 값이 아니다. CP2B의 stress render(getBBox·containment·PNG 검수)를
-  통과한 뒤에만 `rendered`로 승격한다.
-- 판정: `fit.footprint`가 params에서 계산되고, `fit.feasibility`가 **실제 PageFrame
-  contentBox**(preset별 live receipt)와 대조돼 `fits` 또는 `needs-split`으로 확정된다.
-  manifest validator가 두 계산을 모두 재수행하므로 선언만으로 통과할 수 없다.
-- 경계: core는 한 줄 최대 20 CJK label을 수용하는 크기이며 inset은 균등하다. 4겹까지 두
-  preset에서 성립한다.
+- Arrangement: concentric
+- Evidence level: while the manifest's `fit.floor_basis` reads `geometry`, these numbers are a
+  **geometric assumption**, not a value confirmed by rendering. They are promoted to `rendered`
+  only after passing the CP2B stress render (getBBox, containment, PNG inspection).
+- Decision: `fit.footprint` is computed from the params, and `fit.feasibility` is settled as
+  `fits` or `needs-split` against the **live PageFrame contentBox** (a per-preset receipt). The
+  manifest validator recomputes both, so a declaration alone never passes.
+- Boundary: the core holds a single-line label of up to 20 CJK characters and the insets are
+  uniform. 4 rings hold in both presets.
 
 ## 5. Layout, encoding and connector rules
 

--- a/skills/svg-infographic/references/types/specs/process-flow.md
+++ b/skills/svg-infographic/references/types/specs/process-flow.md
@@ -35,22 +35,22 @@ Ordered steps or handoffs.
 
 ## 4. Intrinsic fit and variant contract
 
-Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 region에 들어가는지
-판정하고, 들어가지 않으면 §6 ladder로 내려간다. 글자·간격을 줄여 억지로 맞추지 않는다.
+Fit is decided **before** layout: judge whether this type fits the region before attempting
+placement, and drop to the §6 ladder when it does not. Never shrink type or spacing to force a fit.
 
-**수식 변수는 이 문서가 아니라 manifest의 `fit` 블록이 소유한다**(`references/types/manifest.yaml`,
-해당 TypePack의 `fit.cardinality` / `fit.params` / `fit.footprint`). 문서에 상수를 다시
-적으면 두 벌이 어긋나므로, 여기서는 배치 종류와 판정 경계만 적는다.
+**The manifest's `fit` block owns the formula variables, not this document**
+(`references/types/manifest.yaml`, this TypePack's `fit.cardinality` / `fit.params` / `fit.footprint`). Restating constants here would
+let the two copies drift, so this section records only the arrangement and the decision boundary.
 
-- 배치: row(가로) / column(세로)
-- 근거 수준: manifest `fit.floor_basis`가 `geometry`인 동안 이 수치는 **기하 가정**이며
-  실제 렌더로 확인된 값이 아니다. CP2B의 stress render(getBBox·containment·PNG 검수)를
-  통과한 뒤에만 `rendered`로 승격한다.
-- 판정: `fit.footprint`가 params에서 계산되고, `fit.feasibility`가 **실제 PageFrame
-  contentBox**(preset별 live receipt)와 대조돼 `fits` 또는 `needs-split`으로 확정된다.
-  manifest validator가 두 계산을 모두 재수행하므로 선언만으로 통과할 수 없다.
-- 경계: **4:5 portrait에서 5단계는 가로로 성립하지 않는다** — 가로 압축이 아니라
-  top→bottom(column)으로 배치한다. 16:9은 가로 5단계가 성립한다.
+- Arrangement: row (horizontal) / column (vertical)
+- Evidence level: while the manifest's `fit.floor_basis` reads `geometry`, these numbers are a
+  **geometric assumption**, not a value confirmed by rendering. They are promoted to `rendered`
+  only after passing the CP2B stress render (getBBox, containment, PNG inspection).
+- Decision: `fit.footprint` is computed from the params, and `fit.feasibility` is settled as
+  `fits` or `needs-split` against the **live PageFrame contentBox** (a per-preset receipt). The
+  manifest validator recomputes both, so a declaration alone never passes.
+- Boundary: **5 steps do not hold horizontally in 4:5 portrait** — lay them out top-to-bottom
+  (column) rather than compressing the row. 16:9 holds 5 steps horizontally.
 
 ## 5. Layout, encoding and connector rules
 

--- a/skills/svg-infographic/references/types/specs/roadmap-timeline.md
+++ b/skills/svg-infographic/references/types/specs/roadmap-timeline.md
@@ -38,32 +38,40 @@ Phases or milestones over time.
 
 ## 4. Intrinsic fit and variant contract
 
-Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 region에 들어가는지
-판정하고, 들어가지 않으면 §6 ladder로 내려간다. 글자·간격을 줄여 억지로 맞추지 않는다.
+Fit is decided **before** layout: judge whether this type fits the region before attempting
+placement, and drop to the §6 ladder when it does not. Never shrink type or spacing to force a fit.
 
-**수식 변수는 이 문서가 아니라 manifest의 `fit` 블록이 소유한다**(`references/types/manifest.yaml`,
-해당 TypePack의 `fit.cardinality` / `fit.params` / `fit.footprint`). 문서에 상수를 다시
-적으면 두 벌이 어긋나므로, 여기서는 배치 종류와 판정 경계만 적는다.
+**The manifest's `fit` block owns the formula variables, not this document**
+(`references/types/manifest.yaml`, this TypePack's `fit.cardinality` / `fit.params` / `fit.footprint`). Restating constants here would
+let the two copies drift, so this section records only the arrangement and the decision boundary.
 
-- 배치: row(axis band 포함)
-- 근거 수준: manifest `fit.floor_basis`가 `geometry`인 동안 이 수치는 **기하 가정**이며
-  실제 렌더로 확인된 값이 아니다. CP2B의 stress render(getBBox·containment·PNG 검수)를
-  통과한 뒤에만 `rendered`로 승격한다.
-- 판정: `fit.footprint`가 params에서 계산되고, `fit.feasibility`가 **실제 PageFrame
-  contentBox**(preset별 live receipt)와 대조돼 `fits` 또는 `needs-split`으로 확정된다.
-  manifest validator가 두 계산을 모두 재수행하므로 선언만으로 통과할 수 없다.
-- 경계: **4:5 portrait에서 5 phase는 성립하지 않는다**(needs-split) — 4:5의 상한은 4 phase이고
-  16:9은 5 phase가 성립한다. 간격은 계산값이며 label 폭으로 띄우지 않는다.
+- Arrangement: row (including the axis band)
+- Evidence level: while the manifest's `fit.floor_basis` reads `geometry`, these numbers are a
+  **geometric assumption**, not a value confirmed by rendering. They are promoted to `rendered`
+  only after passing the CP2B stress render (getBBox, containment, PNG inspection).
+- Decision: `fit.footprint` is computed from the params, and `fit.feasibility` is settled as
+  `fits` or `needs-split` against the **live PageFrame contentBox** (a per-preset receipt). The
+  manifest validator recomputes both, so a declaration alone never passes.
+- Boundary: **5 phases do not hold in 4:5 portrait** (needs-split) — 4:5 tops out at 4 phases
+  and 16:9 holds 5. The interval is a computed value, never widened by label width.
 
 ## 5. Layout, encoding and connector rules
 
 - Axis as a soft thick line or chevron band; phase dots/chevrons in phase colours.
 - One milestone card per phase under the axis, or alternating above/below.
 - Status is distinguishable **without colour**, and every state marker is **opaque**: `done` = status fill · `current` = background underlay + status fill + outer ring · `future` = background fill + outline. "Outlined" never means transparent — a hollow dot lets the axis rail show through and reads as sitting behind the line. The fill comes from the background **role**, never a hardcoded colour, so it follows the skin into dark mode. The ring must be visibly clear of the dot (radius floor and stroke floor are re-measured on the final SVG, not declared).
-- Paint order is a DOM contract: **axis → marker underlay → dot/ring → label**. The axis is a background rail, so it belongs to the container layer; drawing it after the markers puts the rail on top of them. The accessible status wording per locale is fixed by this spec, so the generator never invents it: `done` = 완료 / Done · `current` = 진행 중 / In progress · `future` = 예정 / Planned.
+- Paint order is a DOM contract: **axis → marker underlay → dot/ring → label**. The axis is a background rail, so it belongs to the container layer; drawing it after the markers puts the rail on top of them. The accessible status wording per locale is fixed by this spec, so the generator never invents it — see the vocabulary table below.
 - The phase label sits on the **opposite side of the axis from its milestone card**, so alternating layout never buries a label under a card.
 - Even spacing derives from the card that must fit: `endInset = cardVisualW/2 + outerClearance` and `step = (contentW − 2 × endInset) / (n − 1)`, where `cardVisualW` is the resolved maximum over both locales. A constant end inset lets the outermost card leave the content box.
 - The "now" marker is a dashed vertical line with a small pill label; it crosses the axis but no card.
+
+**Accessible status vocabulary** (rendered copy, fixed by this spec — not prose):
+
+| `status` | en | ko |
+| --- | --- | --- |
+| `done` | Done | 완료 |
+| `current` | In progress | 진행 중 |
+| `future` | Planned | 예정 |
 
 ## 6. Degrade ladder
 

--- a/skills/svg-infographic/references/types/specs/topology-component.md
+++ b/skills/svg-infographic/references/types/specs/topology-component.md
@@ -23,7 +23,7 @@ Systems, components and their links inside zones.
 | Field | Cardinality | Budget |
 | --- | --- | --- |
 | `zones[].label` | 2–4 zones, entry → app → data | one line, ≤ 18 CJK / ≤ 28 Latin |
-| `zones[].nodes[]` | zone당 1–4개, **총 9개 이하**(두 상한이 동시에 적용된다) | name ≤ 2 lines, one icon |
+| `zones[].nodes[]` | 1–4 per zone, **9 in total or fewer** (both caps apply at once) | name ≤ 2 lines, one icon |
 | `edges[]` | ≤ 12 | optional label ≤ 1 line |
 | `boundary` | optional, one system boundary | label ≤ 1 line |
 
@@ -35,25 +35,25 @@ Systems, components and their links inside zones.
 
 ## 4. Intrinsic fit and variant contract
 
-Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 region에 들어가는지
-판정하고, 들어가지 않으면 §6 ladder로 내려간다. 글자·간격을 줄여 억지로 맞추지 않는다.
+Fit is decided **before** layout: judge whether this type fits the region before attempting
+placement, and drop to the §6 ladder when it does not. Never shrink type or spacing to force a fit.
 
-**수식 변수는 이 문서가 아니라 manifest의 `fit` 블록이 소유한다**(`references/types/manifest.yaml`,
-해당 TypePack의 `fit.cardinality` / `fit.params` / `fit.footprint`). 문서에 상수를 다시
-적으면 두 벌이 어긋나므로, 여기서는 배치 종류와 판정 경계만 적는다.
+**The manifest's `fit` block owns the formula variables, not this document**
+(`references/types/manifest.yaml`, this TypePack's `fit.cardinality` / `fit.params` / `fit.footprint`). Restating constants here would
+let the two copies drift, so this section records only the arrangement and the decision boundary.
 
-- 배치: grid(zone × zone당 node)
-- 근거 수준: manifest `fit.floor_basis`가 `geometry`인 동안 이 수치는 **기하 가정**이며
-  실제 렌더로 확인된 값이 아니다. CP2B의 stress render(getBBox·containment·PNG 검수)를
-  통과한 뒤에만 `rendered`로 승격한다.
-- 판정: `fit.footprint`가 params에서 계산되고, `fit.feasibility`가 **실제 PageFrame
-  contentBox**(preset별 live receipt)와 대조돼 `fits` 또는 `needs-split`으로 확정된다.
-  manifest validator가 두 계산을 모두 재수행하므로 선언만으로 통과할 수 없다.
-- 경계: **계층형 경계 상자**로 판정한다 — 가장 넓은 zone(노드 행)과 가장 깊은 stack(zone 수)을
-  동시에 만족하는 상자이며 zone label band·zone padding·zone 간 routing corridor를 포함한다.
-  Wave 1 검증 구성은 zone ≤ 4, 한 zone 최대 4 node, **총 node ≤ 9**이고, footprint는 그
-  상한(가장 넓은 zone × 가장 깊은 stack)을 계산하므로 어떤 합법 구성도 이 안에 들어간다.
-  두 preset에서 성립한다.
+- Arrangement: grid (zones × nodes per zone)
+- Evidence level: while the manifest's `fit.floor_basis` reads `geometry`, these numbers are a
+  **geometric assumption**, not a value confirmed by rendering. They are promoted to `rendered`
+  only after passing the CP2B stress render (getBBox, containment, PNG inspection).
+- Decision: `fit.footprint` is computed from the params, and `fit.feasibility` is settled as
+  `fits` or `needs-split` against the **live PageFrame contentBox** (a per-preset receipt). The
+  manifest validator recomputes both, so a declaration alone never passes.
+- Boundary: judged by a **hierarchical bounding box** — the box that simultaneously satisfies the
+  widest zone (a row of nodes) and the deepest stack (the zone count), including the zone label band,
+  zone padding and the inter-zone routing corridor. The Wave 1 verified configuration is zones ≤ 4,
+  at most 4 nodes in one zone and **9 nodes in total**; the footprint computes that upper bound
+  (widest zone × deepest stack), so every legal configuration fits inside it. It holds in both presets.
 
 ## 5. Layout, encoding and connector rules
 
@@ -71,50 +71,49 @@ Fit is decided **before** layout: 배치 시도 전에 이 타입이 해당 regi
 
 ## 7. Verifier, receipt and fixture contract
 
-원본 archetype의 check를 **기계가 증명하는 것**과 **사람이 보거나 이후 verifier가 증명할
-것**으로 나눈다. 규칙을 §5에 적는 것과 그 규칙이 검증된다고 말하는 것은 다르다.
+This splits the original archetype's checks into what **a machine proves** and what **a person reads,
+or a later verifier proves**. Writing a rule in §5 is not the same as saying the rule is verified.
 
-**Machine (generic guard가 실제로 검사하는 것)**
+**Machine (what the generic guards actually check)**
 
-generic lint와 layout guard는 **annotation이 붙은 일반 geometry**를 검사한다 — topology
-의미 모델을 아는 전용 경로는 Wave 1에 없다.
+The generic lint and layout guard check **annotated general geometry** — Wave 1 has no dedicated path
+that understands the topology semantic model.
 
-- annotated container/child containment(zone frame 안에 node 카드가 들어가는지)
-- SVG reference 무결성(`url(#…)`·dangling id)과 중복 id
-- **arrowhead 가시 크기와 shaft 대비 비율**(arrow 자체의 크기 규칙)
-- 하나의 `cluster-h1`, module heading이 section scale에 머무름
+- annotated container/child containment (whether node cards sit inside the zone frame)
+- SVG reference integrity (`url(#…)`, dangling ids) and duplicate ids
+- **visible arrowhead size and its ratio to the shaft** (a rule about the arrow itself)
+- a single `cluster-h1`, with module headings staying at section scale
 
-generic guard에 **arrow tip과 target node 사이 간격을 재는 경로는 없다** — arrowhead
-크기 검사를 target clearance 검증으로 읽으면 안 된다.
+The generic guards have **no path that measures the gap between an arrow tip and its target node** —
+an arrowhead size check must not be read as target clearance verification.
 
-**아직 증명되지 않음(등록 fixture 없음).** 위 항목도 이 TypePack의 fixture가 등록되기
-전까지는 *계약*이며 통과 증거가 아니다. "proved"라고 말할 수 있는 것은 실제 fixture로
-통과시킨 항목뿐이다.
+**Not yet proved (no registered fixture).** Even the items above are a *contract* rather than evidence
+of passing until this TypePack's fixtures are registered. Only what an actual fixture has passed may be
+called "proved".
 
-**Visual / manual (Wave 1에서는 기계 증명 대상이 아님)**
+**Visual / manual (not machine-proved in Wave 1)**
 
-- **arrow tip–target 8–12px gap**과 visible shaft corridor — 규칙은 §5가 정하지만 현재
-  이를 측정하는 generic 경로가 없다(annotation 기반 connector guard가 생기면 Machine으로
-  승격한다)
-- node → zone **semantic** ownership(annotation이 아닌 의미 모델 수준)
-- edge endpoint가 실재하는 node를 가리키는지(semantic dangling)
-- edge crossing 없음 — 현재는 육안 확인이며 자동 판정하지 않는다
-- edge label이 선 **옆**에 있고 선 위에 놓이지 않았는지
-- external actor가 system boundary **밖**에 있는지
-- 3×3 cell 재배치 후 실제로 읽히는지
+- the **arrow tip–target 8–12px gap** and the visible shaft corridor — §5 sets the rule but no generic
+  path measures it today (it is promoted to Machine once an annotation-based connector guard exists)
+- node → zone **semantic** ownership (at the meaning-model level, not the annotation level)
+- whether an edge endpoint names a node that exists (semantic dangling)
+- no edge crossings — read by eye today, not decided automatically
+- whether an edge label sits **beside** the line rather than on it
+- whether an external actor sits **outside** the system boundary
+- whether a 3×3 cell rearrangement actually reads
 
 **Future verifier (Wave 2 topology verifier)**
 
-reachability·cycle·completeness 주장은 verifier가 생기기 전에는 할 수 없다. 그때까지
-receipt는 선언된 사실(zone·node·edge·direction·boundary)만 담고, 위 visual 항목은
-증명이 아니라 검토 항목으로 남는다.
+Reachability, cycle and completeness claims cannot be made before a verifier exists. Until then the
+receipt carries only declared facts (zones, nodes, edges, direction, boundary), and the visual items
+above remain review items rather than proof.
 
-- **Verifier**: `verifier: null`(Wave 1) — topology annex를 선언한 TypePack은 verifier와
-  receipt schema가 등록되기 전에는 `core`로 승격되지 않는다(manifest validator가 강제).
-- **Receipt**: zones, node→zone 소유, edges(semantic kind·delivery·visibility·direction),
+- **Verifier**: `verifier: null` (Wave 1) — a TypePack that declares the topology annex is not promoted
+  to `core` until a verifier and a receipt schema are registered (the manifest validator enforces this).
+- **Receipt**: zones, node→zone ownership, edges (semantic kind, delivery, visibility, direction),
   boundary.
-- **Fixtures**: preset별 positive + crossing edge baseline-red. 하나의 artifact는 하나의
-  (kind, preset) 주장만 담당한다.
+- **Fixtures**: a positive per preset plus a crossing-edge baseline-red. One artifact carries exactly
+  one (kind, preset) claim.
 
 ## 8. Reading order, accessibility and locale
 
@@ -135,16 +134,16 @@ receipt는 선언된 사실(zone·node·edge·direction·boundary)만 담고, �
 Nodes are `node-<slug>` and zones are `zone-<slug>`; ids are stable within one artifact and are what edges and receipts reference. A node's identity never depends on its position.
 
 ### Edge kind and direction
-Edge는 세 축을 **분리해서** 기록한다 — 의미(kind)와 전달 방식(delivery), 노출 범위
-(visibility)를 하나로 합치면 "private sync edge" 같은 조합이 receipt에서 사라진다.
+An edge records three axes **separately** — collapsing meaning (kind), delivery and exposure
+(visibility) into one would erase combinations such as a "private sync edge" from the receipt.
 
-- `kind: request | dependency` — 의미상 무엇인지
-- `delivery: sync | async` — 동기/비동기
-- `visibility: public | private` — 경계 안팎 노출
+- `kind: request | dependency` — what it means
+- `delivery: sync | async` — synchronous or asynchronous
+- `visibility: public | private` — exposure across the boundary
 
-방향은 항상 consumer → provider로 읽는다. **선 스타일은 이 셋에서 파생된다**:
-`delivery: async` 또는 `visibility: private`이면 dashed, 그 외에는 solid. 두 스타일이
-함께 나오면 legend가 필요하며, legend는 스타일이 아니라 그것이 뜻하는 축을 설명한다.
+Direction always reads consumer → provider. **The line style derives from these three**: dashed when
+`delivery: async` or `visibility: private`, solid otherwise. When both styles appear a legend is
+required, and the legend explains the axis it stands for rather than the style itself.
 
 ### Cardinality
 At most 12 edges and 9 nodes per artifact; a node may have any in-degree but an edge references exactly one source and one target, both of which must exist.

--- a/skills/svg-infographic/scripts/skin.test.mjs
+++ b/skills/svg-infographic/scripts/skin.test.mjs
@@ -647,22 +647,22 @@ test("R1-5: unrelated gallery heading·재사용 artifact로는 core 증거가 �
 
 test("R1-3·R1-6: topology spec은 증거 수준을 구현에 맞추고 edge 축을 분리한다", () => {
   const spec = fs.readFileSync(path.join(here, "..", "references", "types", "specs", "topology-component.md"), "utf8");
-  assert.match(spec, /\*\*Machine \(generic guard가 실제로 검사하는 것\)/);
-  assert.match(spec, /topology\s*\n의미 모델을 아는 전용 경로는 Wave 1에 없다|의미 모델을 아는 전용 경로는 Wave 1에 없다/);
-  assert.match(spec, /아직 증명되지 않음\(등록 fixture 없음\)/);
+  assert.match(spec, /\*\*Machine \(what the generic guards actually check\)/);
+  assert.match(spec, /no dedicated path\s*\nthat understands the topology semantic model|that understands the topology semantic model/);
+  assert.match(spec, /Not yet proved \(no registered fixture\)/);
   assert.match(spec, /node → zone \*\*semantic\*\* ownership/);
   // R1C-P1: arrow-target clearance는 machine 목록이 아니라 미증명 목록에 있어야 한다
-  const machine = spec.split("**Machine (generic guard가 실제로 검사하는 것)**")[1].split("**Visual / manual")[0];
+  const machine = spec.split("**Machine (what the generic guards actually check)**")[1].split("**Visual / manual")[0];
   const manual = spec.split("**Visual / manual")[1];
   // machine **목록 항목**에 clearance 주장이 없어야 한다(부재를 밝히는 설명 문장은 허용)
   const machineBullets = machine.split("\n").filter((l) => l.startsWith("- ")).join("\n");
   assert.doesNotMatch(machineBullets, /clearance|tip/, "target clearance를 machine 항목으로 주장하면 안 된다");
-  assert.match(machine, /간격을 재는 경로는 없다/, "부재를 명시적으로 밝혀야 한다");
-  assert.match(machine, /arrowhead 가시 크기와 shaft 대비 비율/, "arrowhead 크기 규칙만 machine이다");
+  assert.match(machine, /no path that measures the gap between an arrow tip and its target node/, "부재를 명시적으로 밝혀야 한다");
+  assert.match(machine, /visible arrowhead size and its ratio to the shaft/, "arrowhead 크기 규칙만 machine이다");
   assert.match(manual, /arrow tip–target 8–12px gap/, "target clearance는 미증명·수동 항목이다");
   for (const axis of ["kind: request \\| dependency", "delivery: sync \\| async", "visibility: public \\| private"])
     assert.match(spec, new RegExp(axis), axis);
-  assert.match(spec, /선 스타일은 이 셋에서 파생된다/);
+  assert.match(spec, /The line style derives from these three/);
 });
 
 test("R1B-P2: fit schema는 음수 gap·잘못된 orientation·중복 tuple을 거부한다", () => {
@@ -697,8 +697,8 @@ test("R1B-P1: topology fit은 zone 내부 구조를 포함한 계층형 경계 �
   for (const k of ["maxNodesPerZone", "zonePad", "zoneLabelBand", "zoneGap"])
     assert.ok(b.includes(k), `${k} 파라미터 필요`);
   const spec = fs.readFileSync(path.join(here, "..", "references", "types", "specs", "topology-component.md"), "utf8");
-  assert.match(spec, /총 node ≤ 9/, "zone당 상한과 총량 상한이 함께 적혀야 한다");
-  assert.doesNotMatch(spec, /4 zone × zone당 4 node까지 두 preset에서 성립/, "총 9개 계약과 충돌하는 문구 제거");
+  assert.match(spec, /9 nodes in total/, "zone당 상한과 총량 상한이 함께 적혀야 한다");
+  assert.doesNotMatch(spec, /4 zones × 4 nodes per zone hold in both presets/, "총 9개 계약과 충돌하는 문구 제거");
 });
 
 test("R1B-P1c: content floor는 이름으로 구분되고 근거 수준이 표시된다", () => {
@@ -711,7 +711,7 @@ test("R1B-P1c: content floor는 이름으로 구분되고 근거 수준이 표�
   assert.match(layer, /floor: wide, result: needs-split/, "chip 4개는 4:5에서 성립하지 않는다");
   for (const f of ["cards-kpi-grid", "layer-stack", "process-flow"]) {
     const spec = fs.readFileSync(path.join(here, "..", "references", "types", "specs", `${f}.md`), "utf8");
-    assert.match(spec, /floor_basis`가 `geometry`인 동안 이 수치는 \*\*기하 가정\*\*/, f);
+    assert.match(spec, /`fit\.floor_basis` reads `geometry`, these numbers are a\s*\n\s*\*\*geometric assumption\*\*/, f);
   }
 });
 


### PR DESCRIPTION
## 요약

`references/types/specs/*.md` 9종의 산문을 English canonical로 통일한다. 이 표면은 **설치된 skill이 소비하는 package guidance**이므로 영어가 기준이다. **의미 변경이 아니라 언어 정규화**이며, 일부만 고쳐 불균형을 키우지 않도록 9종을 한 번에 처리했다.

한국어 산문 **213줄 → 0줄**. 그중 89줄이 9개 파일에 동일한 §4 fit 공통 블록이라 한 번에 옮겼고, 나머지 124줄을 파일별로 처리했다.

## 의미 보존 검토

| 검토 축 | 결과 |
| --- | --- |
| 섹션 제목·불릿 수·번호 단계(§1~§9) | 9종 전 섹션 동일 |
| backtick identifier · `data-*` · error code · §ref · 계약 수치 · preset 이름 · 상태 enum | **손실 0** |
| degrade ladder 단계 수·순서, verifier 선언(`null`) | 변화 없음 |

## 자체 교정 3건

초안이 의미를 흘렸고 대조에서 잡혔다.

1. `` `fit` `` 토큰이 9개 파일에서 사라졌다 — "manifest의 `fit` 블록"을 "The manifest owns…"로 옮기며 식별자를 문장에 녹였다. `` The manifest's `fit` block owns… ``로 복원.
2. 계약 수치 12건이 digit → word로 바뀌었다("4노드" → "four nodes"). 규범 문서에서는 grep 가능성과 manifest 대조가 중요하므로 전부 숫자로 되돌렸다.
3. `arrow tip–target 8–12px gap`은 **원래부터 영어**였는데 어순을 바꿨다. 원문 그대로 복원 — 이건 테스트가 잡았다.

## 회귀가 잡은 실질 결함

`skin.test.mjs`의 세 테스트가 spec의 **한국어 문구를 정규식으로 직접 검사**하고 있었다. 즉 spec 문구가 테스트의 계약 표면이었다.

```js
assert.match(spec, /\*\*Machine \(generic guard가 실제로 검사하는 것\)/);
assert.match(machine, /간격을 재는 경로는 없다/, "부재를 명시적으로 밝혀야 한다");
assert.match(spec, /총 node ≤ 9/, "zone당 상한과 총량 상한이 함께 적혀야 한다");
```

검사 **의도를 보존한 채** 영어 canonical 문구로 갱신했다 — machine 목록이 clearance를 주장하지 않을 것, 부재를 명시할 것, arrowhead 크기만 machine일 것, tip–target gap은 manual일 것, edge 세 축과 선 스타일 파생, 총 node ≤ 9, floor_basis 근거 수준 문장.

## 구조 변경 1건(의도적)

roadmap-timeline의 접근성 status 어휘가 산문 안에서 KO/EN 혼용이었다(`` `done` = 완료 / Done ``). "한 문단 안 혼용 금지"와 "한국어 payload는 번역하지 않음"이 동시에 걸리는 자리라 산문에서 빼내 **데이터 표로 분리**했다. 남은 한국어 3줄은 그 표의 렌더 문안 값이며 번역 대상이 아니다.

`.ko.md` mirror는 만들지 않는다 — 이번에는 English canonical만 유지한다.

## 회귀

```
skin 118 · preflight 29 · check-svg 70 · check-layout 47 · route-orthogonal 28
font-probe 6 · render 23 · compose 51 · generate 29
all suites green (exit 0)
```

`package-surface.yaml` `surface_revision` 9 → 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)