### PR TITLE
feat(svg-infographic): treatment 축과 손글씨 optical calibration을 추가한다

### DIFF
--- a/skills/svg-infographic/references/design-kernel.md
+++ b/skills/svg-infographic/references/design-kernel.md
@@ -423,6 +423,38 @@ comparing receipts before/after an edit exposes any invariant the edit broke.
 Generalizing the guard beyond annotated rect geometry to semantic region
 annotations is a named follow-up (`svg-infographic-semantic-region-annotation`).
 
+## 7g. Surface treatment axis (opt-in, experimental)
+
+`flat` is the canonical default. `sketch` is an **experimental opt-in preview** selected with
+`generate.mjs --treatment sketch`; nothing routes to it automatically and no TypePack claims it.
+
+Ownership is split so no layer reaches into another's concern:
+
+| Owner | Concern |
+| --- | --- |
+| generator | selecting the treatment and building the artifact structure |
+| treatment resolver (`scripts/treatment.mjs`) | paper surface, rough-line/rough-box filters, highlight, displacement bound |
+| typography profile | face, weight, subset, license (`treatments.sketch`) |
+| materializer | semantic paint values only |
+
+Filters and fonts never move into the materializer, and palette roles are never merged with overlay
+tokens. The resolver reads its numbers from the overlay declaration rather than restating them.
+
+The axis is fail-closed on the **artifact**, not the flag. A treatment must be selected by the skin
+registry (an overlay file alone is not authorisation); a selected treatment whose artifact lacks the
+paper surface, the treatment defs, an applied filter or a displacement map is refused; and a renamed
+flat render never counts as a treatment. `dark × sketch` stays rejected until it is visually approved.
+
+Two properties are re-measured rather than declared. Containment includes the **displacement bound**
+and the filter region: a rough stroke that leaves the canvas, or a filter region narrower than the
+canvas (percentage regions collapse on straight strokes), fails. Font coverage is enforced at subset
+time: if the embedded subset does not cover every character the artifact uses, the build fails rather
+than letting an implicit system fallback supply the glyph.
+
+Geometry, copy, semantic ids and reading order are identical across treatments. A treatment never
+patches coordinates; if a face's metrics would overflow, the shared budget is recomputed or the build
+fails closed.
+
 ## 8. Composition (multi-type scenes)
 
 One page is not limited to one type. A scene may combine TypePacks — summary cards

--- a/skills/svg-infographic/references/package-surface.yaml
+++ b/skills/svg-infographic/references/package-surface.yaml
@@ -14,7 +14,7 @@
 # evidence 또는 CI artifact로만 저장한다.
 
 schema_version: 1
-surface_revision: 10
+surface_revision: 11
 
 canonicalization:
   version: 1
@@ -44,6 +44,7 @@ entries:
   - { path: scripts/font-probe.mjs, kind: production-entrypoint }
   - { path: scripts/render.sh, kind: production-shim }
   - { path: scripts/preflight-lib.mjs, kind: production-lib }
+  - { path: scripts/treatment.mjs, kind: production-lib }
 
   # --- normative docs (agent 판단 표면) --------------------------------------
   - { path: SKILL.md, kind: normative-doc }

--- a/skills/svg-infographic/references/types/manifest.yaml
+++ b/skills/svg-infographic/references/types/manifest.yaml
@@ -300,7 +300,13 @@ typepacks:
         preset: social-4x5
         layout: zones
         count: 3
-        residual_disposition: { bottom: 194, reason: "zone 높이는 node 기하에서 파생하고 corridor는 배선 수요만큼만 열린다 — 남는 공간은 선언된 breathing이다(kernel §8)." }
+        # 잔여는 최대값이 아니라 **실측과 일치하는 선언**이다. treatment마다 실측이 다르므로
+        # 각각 정확값을 선언한다 — 단방향 비교는 stale 선언과 과도한 content expansion을 통과시킨다.
+        residual_disposition:
+          reason: "zone 높이는 node 기하에서 파생하고 corridor는 배선 수요만큼만 열린다 — 남는 공간은 선언된 breathing이다(kernel §8)."
+          by_treatment:
+            - { treatment: flat, bottom: 194 }
+            - { treatment: sketch, calibration: hi-melody-optical-v1, bottom: 93 }
         routing_expected: routable
       stress:
         - id: topology-component-stress-cardinality

--- a/skills/svg-infographic/references/typography/typography-v1.yaml
+++ b/skills/svg-infographic/references/typography/typography-v1.yaml
@@ -65,6 +65,21 @@ treatments:
     fallback: [Pretendard, sans-serif]
     synthetic: forbidden
     weight-policy: normalize-400
+    # Optical size compensation — named calibration, NOT a change to the base type scale.
+    # Hi Melody renders far smaller than Pretendard at the same nominal px, so equal nominal
+    # size is not equal visual hierarchy. The base scale keeps its owner (PageFrame profile);
+    # this token only compensates the apparent size of THIS face. Per-file or per-string
+    # adjustment is forbidden — a band is the smallest unit.
+    optical_calibration:
+      id: hi-melody-optical-v1
+      # Owner selection 2026-08-15 after the 1.6x / 1.8x / 2.0x audition (KO + EN).
+      # Chosen for optical parity and legibility — the H1 hierarchy reads closest to flat —
+      # not because it is the largest value that happens to fit. 2.0x is refused by the
+      # layout at 4:5 and at 16:9; 1.8x keeps route 3/3, bend 0 and a 36px minimum inset.
+      basis: owner selection 2026-08-15 — optical parity audition (1.6x / 1.8x / 2.0x, KO + EN)
+      bands:
+        display: 1.8
+        body: 1.8
     asset:
       policy: bundled
       path: assets/fonts/HiMelody-Regular.ttf

--- a/skills/svg-infographic/scripts/compose-fixtures/fragments-en/summary-cards.receipt.json
+++ b/skills/svg-infographic/scripts/compose-fixtures/fragments-en/summary-cards.receipt.json
@@ -83,7 +83,7 @@
  ],
  "identity": {
   "skinProfileDigest": "d02498fd9e0a2efe",
-  "typographyProfileDigest": "e7a4a23b4112dcbb",
+  "typographyProfileDigest": "34fefa621b3b5c1a",
   "pageFrameDigest": "f4edd624bbe296d4",
   "kernelVersion": "kernel-v1",
   "iconSetId": "line-icons-v1"

--- a/skills/svg-infographic/scripts/compose-fixtures/fragments-en/tree.receipt.json
+++ b/skills/svg-infographic/scripts/compose-fixtures/fragments-en/tree.receipt.json
@@ -84,7 +84,7 @@
  ],
  "identity": {
   "skinProfileDigest": "d02498fd9e0a2efe",
-  "typographyProfileDigest": "e7a4a23b4112dcbb",
+  "typographyProfileDigest": "34fefa621b3b5c1a",
   "pageFrameDigest": "f4edd624bbe296d4",
   "kernelVersion": "kernel-v1",
   "iconSetId": "line-icons-v1"

--- a/skills/svg-infographic/scripts/compose-fixtures/fragments-en/tree.spacious.receipt.json
+++ b/skills/svg-infographic/scripts/compose-fixtures/fragments-en/tree.spacious.receipt.json
@@ -84,7 +84,7 @@
  ],
  "identity": {
   "skinProfileDigest": "d02498fd9e0a2efe",
-  "typographyProfileDigest": "e7a4a23b4112dcbb",
+  "typographyProfileDigest": "34fefa621b3b5c1a",
   "pageFrameDigest": "f4edd624bbe296d4",
   "kernelVersion": "kernel-v1",
   "iconSetId": "line-icons-v1"

--- a/skills/svg-infographic/scripts/compose-fixtures/fragments/icon-band.receipt.json
+++ b/skills/svg-infographic/scripts/compose-fixtures/fragments/icon-band.receipt.json
@@ -21,7 +21,7 @@
  ],
  "identity": {
   "skinProfileDigest": "d02498fd9e0a2efe",
-  "typographyProfileDigest": "e7a4a23b4112dcbb",
+  "typographyProfileDigest": "34fefa621b3b5c1a",
   "pageFrameDigest": "f4edd624bbe296d4",
   "kernelVersion": "kernel-v1",
   "iconSetId": "line-icons-v1"

--- a/skills/svg-infographic/scripts/compose-fixtures/fragments/summary-cards.receipt.json
+++ b/skills/svg-infographic/scripts/compose-fixtures/fragments/summary-cards.receipt.json
@@ -83,7 +83,7 @@
  ],
  "identity": {
   "skinProfileDigest": "d02498fd9e0a2efe",
-  "typographyProfileDigest": "e7a4a23b4112dcbb",
+  "typographyProfileDigest": "34fefa621b3b5c1a",
   "pageFrameDigest": "f4edd624bbe296d4",
   "kernelVersion": "kernel-v1",
   "iconSetId": "line-icons-v1"

--- a/skills/svg-infographic/scripts/compose-fixtures/fragments/tree.receipt.json
+++ b/skills/svg-infographic/scripts/compose-fixtures/fragments/tree.receipt.json
@@ -84,7 +84,7 @@
  ],
  "identity": {
   "skinProfileDigest": "d02498fd9e0a2efe",
-  "typographyProfileDigest": "e7a4a23b4112dcbb",
+  "typographyProfileDigest": "34fefa621b3b5c1a",
   "pageFrameDigest": "f4edd624bbe296d4",
   "kernelVersion": "kernel-v1",
   "iconSetId": "line-icons-v1"

--- a/skills/svg-infographic/scripts/compose-fixtures/fragments/tree.spacious.receipt.json
+++ b/skills/svg-infographic/scripts/compose-fixtures/fragments/tree.spacious.receipt.json
@@ -84,7 +84,7 @@
  ],
  "identity": {
   "skinProfileDigest": "d02498fd9e0a2efe",
-  "typographyProfileDigest": "e7a4a23b4112dcbb",
+  "typographyProfileDigest": "34fefa621b3b5c1a",
   "pageFrameDigest": "f4edd624bbe296d4",
   "kernelVersion": "kernel-v1",
   "iconSetId": "line-icons-v1"

--- a/skills/svg-infographic/scripts/font-subset.py
+++ b/skills/svg-infographic/scripts/font-subset.py
@@ -114,6 +114,17 @@ def main():
     if leaked:
         fail(5, "reserved font name still present in identity records after rewrite:\n  " + "\n  ".join(leaked))
 
+    # delivery 정책의 on_glyph_missing: fail-closed 를 **실제로 집행한다**.
+    # 요청 문자가 subset의 cmap에 없으면 렌더는 조용히 fallback face로 새고,
+    # portable artifact가 "설치 글꼴에 의존하지 않는다"는 주장이 깨진다.
+    cmap = set()
+    for table in font["cmap"].tables:
+        cmap.update(table.cmap.keys())
+    missing = sorted({ch for ch in text if ord(ch) not in cmap and ch not in "\r\n\t"})
+    if missing:
+        fail(7, "the subset does not cover %d requested character(s) — an implicit fallback would be needed: %s"
+             % (len(missing), " ".join(repr(c) for c in missing[:20])))
+
     try:
         font.save(a.out)
     except Exception as e:  # noqa: BLE001
@@ -127,6 +138,7 @@ def main():
         "identity": {"family": family, "fullName": full, "postScriptName": ps, "uniqueID": unique},
         "preservedLegalNameIDs": sorted({r.nameID for r in name.names if r.nameID in LEGAL_IDS}),
         "rfnGuard": "clean",
+        "glyphCoverage": {"requested": len(set(text)), "missing": 0},
         "bytes": len(blob),
         "digest": "sha256:" + hashlib.sha256(blob).hexdigest(),
     }))

--- a/skills/svg-infographic/scripts/generate.mjs
+++ b/skills/svg-infographic/scripts/generate.mjs
@@ -21,6 +21,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { preflight, guardPackagePath, provenance, SKILL_LOCATOR } from "./preflight-lib.mjs";
 import { parseYaml, derivePanelFloor, deriveAlignInventory, serializeAlignInventory, deriveMatrixPlacement } from "./skin.mjs";
+import { loadTreatment, treatmentDefs, paperRect, displacementBound, filterAttr } from "./treatment.mjs";
 import { estimateWidth } from "./check-svg.mjs";
 import { planChannels, routeEdges, pathData, auditTopology, alignRows, ROUTE_DEFAULTS } from "./route-orthogonal.mjs";
 
@@ -190,10 +191,22 @@ function renderCards(input, loc, cb, sc, tp) {
     bounds: { x: cb.x, y: cb.y, w: gw, h: blockH } };
 }
 
-function renderTopology(input, loc, cb, sc, tp, degradeLevel = 0) {
+function renderTopology(input, loc, cb, sc, tp, degradeLevel = 0, F = { fs: (n) => n }) {
   const zones = input.zones, nz = zones.length;
-  const pad = 12, band = 22;
+  // zone label band는 상수가 아니라 **실제 label 크기**에서 나온다. optical calibration으로
+  // 글자가 커지면 band도 함께 커져야 하고, 그러지 않으면 routing corridor가 label을 가로지른다.
+  // (글자를 다시 줄여 기존 band에 맞추지 않는다 — 그것은 보정의 취지를 되돌리는 것이다.)
+  const pad = 12;
+  // zone은 **label band + node area**다. band 높이는 상수가 아니라 resolved label line-box와
+  // 공통 padding에서 나온다(scale 1.0에서는 기존 값 22가 그대로 산출된다).
+  // 그리고 band에는 connector가 들어올 **entry corridor**를 반드시 남긴다 — corridor 폭은
+  // lane 수·clearance에서 계산하며 파일별 좌표는 없다. label이 그 폭에 안 들어가면
+  // 글자를 줄이지 않고 **줄바꿈**한다.
   const K = ROUTE_DEFAULTS;
+  // entry corridor: connector가 label bounds **밖으로** band를 통과할 폭. lane 간격과
+  // clearance에서 계산하며 파일별 좌표는 없다.
+  const corridorReserve = 2 * K.labelPad + K.laneGap + K.outerClearance;
+  const labelLineH = (n) => Math.round(F.fs(12) * 1.5 * n + 4);
 
   // 1) 배선 수요를 먼저 묻는다 — 배치가 먼저 굳으면 선은 결국 관통하거나 겹친다.
   const nodeZone = new Map(), nodeIndex = new Map();
@@ -220,6 +233,21 @@ function renderTopology(input, loc, cb, sc, tp, degradeLevel = 0) {
   const corridorTotal = corridors.reduce((a, b) => a + b, 0);
   const intraH = (zid) => (plan.intraLanes.get(zid) ?? 0) * K.laneGap;
   const maxIntra = Math.max(0, ...zones.map((z) => intraH(z.id)));
+  // label은 corridor를 남긴 폭 안에서 **줄바꿈**한다 — 글자를 줄여 한 줄에 욱여넣지 않는다.
+  // corridor는 zone 폭이 아니라 **node의 port 범위** 안에 있어야 한다 — 위 zone에서 내려오는
+  // 선은 목표 node 상단에 붙기 때문이다. 그래서 label 폭 상한은 node 폭에서 유도한다.
+  const nwProbe = (zoneW - 2 * pad - (Math.max(...zones.map((z) => (z.nodes ?? []).length)) - 1) * K.laneGap) / Math.max(...zones.map((z) => (z.nodes ?? []).length));
+  const labelMaxW = Math.min(zoneW - 2 * pad - corridorReserve,
+    nwProbe - K.portInset - K.outerClearance - 2 * K.labelPad);
+  if (process.env.SVGINFO_DEBUG_TOPOLOGY) console.error(`[topo] zoneW=${r1(zoneW)} nwProbe=${r1(nwProbe)} labelMaxW=${r1(labelMaxW)} fs=${F.fs(12)}`);
+  const labelWrap = new Map();
+  for (const z of zones) {
+    const w = ["ko", "en"].map((lc) => wrapLines(String(z.label[lc] ?? ""), labelMaxW, F.fs(12), true, 2));
+    if (w.some((x) => x.overflow)) { console.error(`generate: zone label "${z.id}" does not fit the ${r1(labelMaxW)}px label band even wrapped — widen the preset or shorten the label`); process.exit(1); }
+    labelWrap.set(z.id, w);
+  }
+  const labelLines = Math.max(1, ...[...labelWrap.values()].flat().map((x) => x.lines.length));
+  const band = labelLines === 1 ? Math.round(F.fs(12) * 1.5 + 4) : labelLineH(labelLines);
   const nodeH = Math.min(96, (cb.h - corridorTotal - nz * (band + 2 * pad + maxIntra)) / nz);
   const zoneH = (zid) => band + 2 * pad + nodeH + intraH(zid);
 
@@ -238,8 +266,8 @@ function renderTopology(input, loc, cb, sc, tp, degradeLevel = 0) {
     });
     // 장애물로서의 label 폭은 글자 수 어림이 아니라 lint와 같은 추정기로 재고,
     // **KO/EN 중 넓은 쪽**으로 고정한다 — 배선 기하가 언어에 따라 달라지면 안 된다.
-    const labelTextW = Math.max(...["ko", "en"].map((lc) => estimateWidth(String(z.label[lc] ?? ""), 12, true, 0)));
-    const labelW = Math.min(zoneW - 2 * pad, labelTextW * 1.08 + 2 * ROUTE_DEFAULTS.labelPad);
+    const labelTextW = Math.max(...labelWrap.get(z.id).flatMap((w) => w.lines.map((l) => estimateWidth(l, F.fs(12), true, 0))));
+    const labelW = Math.min(labelMaxW, labelTextW * 1.08 + 2 * ROUTE_DEFAULTS.labelPad);
     zoneBoxes.push({ id: z.id, x: zoneX, y: zy, w: zoneW, h: zh,
       labelBox: { x: zoneX + pad, y: zy + 4, w: labelW, h: band - 4 } });
     zy += zh + (corridors[zi] ?? 0);
@@ -248,6 +276,38 @@ function renderTopology(input, loc, cb, sc, tp, degradeLevel = 0) {
 
   // 3) 배선 — 좌표는 router가 정한다. 문제가 남으면 spec §6 ladder를 밟는다.
   const ladder = [];
+  // layout이 label bounds·node bounds·clearance에서 **합법 port 구간**을 계산해 router에 넘긴다.
+  // router는 그 안에서만 후보를 만든다. 구간이 없으면(=zone 밖에서 들어오지 않으면) 무제약이다.
+  const zoneOf = new Map();
+  for (const zb of zoneBoxes) for (const nd of (zones.find((z) => z.id === zb.id)?.nodes ?? [])) zoneOf.set(nd.id, zb);
+  const entryInterval = (nid) => {
+    const zb = zoneOf.get(nid), nb = nodeBox[nid];
+    if (!zb || !zb.labelBox || !nb) return null;
+    const lb = zb.labelBox;
+    // label은 hard obstacle이다 — 구간은 label 오른쪽 끝 + clearance부터 시작한다.
+    // layout이 보장하는 것은 "port가 label 아래에 있지 않다"까지다. 선과 label 사이의
+    // 간격은 router가 자기 obstacle 규칙으로 강제한다 — 여기서 더 엄격하게 잡으면
+    // 기존(무제약) 산출물의 배선이 이유 없이 옮겨간다.
+    const lo = Math.max(nb.x + K.portInset, lb.x + lb.w);
+    const hi = nb.x + nb.w - K.portInset;
+    if (!(lo <= hi)) return null;                    // 합법 구간이 없으면 선언하지 않는다(제약 없음과 다르다)
+    return { lo: r1(lo), hi: r1(hi), axis: "x" };
+  };
+  const constrain = (list) => list.map((e) => {
+    const from = zoneOf.get(e.from), to = zoneOf.get(e.to);
+    if (!from || !to || from.id === to.id) return e;   // 같은 zone 안 배선은 band를 지나지 않는다
+    const iv = entryInterval(e.to);
+    if (!iv) return e;
+    // 제약은 **필요할 때만** 건다. 자연스러운 port(두 node의 중심)가 이미 label 밖이면
+    // 구간을 선언하지 않는다 — 그래야 기존 호출의 후보·순서·산출물이 그대로 유지된다.
+    const src = nodeBox[e.from], dst = nodeBox[e.to];
+    const natural = src && dst ? (src.x + src.w / 2 + dst.x + dst.w / 2) / 2 : null;
+    if (natural != null && natural >= iv.lo && natural <= iv.hi) return e;
+    return { ...e, allowedPortInterval: { to: iv } };
+  });
+  plan.classified = constrain(plan.classified);
+  const portConstraints = plan.classified.filter((e) => e.allowedPortInterval)
+    .map((e) => ({ edge: e.id, endpoint: "to", node: e.to, allowed: e.allowedPortInterval.to }));
   let routed = routeEdges({ nodes: nodeBox, zones: zoneBoxes, plan, frame: cb, degradeLevel });
   if (routed.problems.length) {
     ladder.push({ step: 1, action: "drop edge labels to the legend", applied: false, reason: "이 TypePack은 edge label을 그리지 않는다 — 회수할 여유가 없다" });
@@ -282,7 +342,13 @@ function renderTopology(input, loc, cb, sc, tp, degradeLevel = 0) {
   </g>`);
     labels.push(`  <g data-layout-role="zone-label" data-label-bounds="${r1(zb.labelBox.x)},${r1(zb.labelBox.y)},${r1(zb.labelBox.w)},${r1(zb.labelBox.h)}">
     <rect x="${r1(zb.labelBox.x)}" y="${r1(zb.labelBox.y)}" width="${r1(zb.labelBox.w)}" height="${r1(zb.labelBox.h)}" rx="4" fill="#F4F8FC" data-fill-role="surface-tint"/>
-    <text x="${r1(zb.x + pad)}" y="${r1(zb.y + band / 2 + 4)}" font-size="12" font-weight="700" fill="#636A75" data-fill-role="muted" dominant-baseline="central">${esc(z.label[loc])}</text>
+    ${(() => { const L = labelWrap.get(z.id)[loc === "ko" ? 0 : 1].lines, lh = F.fs(12) * 1.5,
+        y0 = zb.y + (band - (L.length - 1) * lh) / 2 + 4;
+      // 한 줄이면 기존 단일 text 형태를 그대로 쓴다 — 줄바꿈이 없을 때 마크업이 바뀌면
+      // flat baseline이 이유 없이 깨진다.
+      return L.length === 1
+        ? `<text x="${r1(zb.x + pad)}" y="${r1(y0)}" font-size="${F.fs(12)}" font-weight="700" fill="#636A75" data-fill-role="muted" dominant-baseline="central">${esc(L[0])}</text>`
+        : `<text font-size="${F.fs(12)}" font-weight="700" fill="#636A75" data-fill-role="muted" dominant-baseline="central">${tspans(L, zb.x + pad, y0, lh)}</text>`; })()}
   </g>`);
   });
 
@@ -298,7 +364,7 @@ function renderTopology(input, loc, cb, sc, tp, degradeLevel = 0) {
     nodeArt.push(`  <g data-comp-entity="${nd.id}" data-entity="${nd.id}">
     <rect x="${r1(b.x)}" y="${r1(b.y)}" width="${r1(b.w)}" height="${r1(b.h)}" rx="10" fill="#FFFFFF" stroke="#DEE0E2" stroke-width="1" data-fill-role="surface" data-stroke-role="rule" data-layout-parent="${nodeZone.get(nd.id)}" data-layout-item="${nodeZone.get(nd.id)}-row"/>
     ${icon(nd.icon, b.x + b.w / 2, b.y + b.h / 2 - 14, 20)}
-    <text x="${r1(b.x + b.w / 2)}" y="${r1(b.y + b.h / 2 + 16)}" font-size="12" fill="#252B35" data-fill-role="ink" text-anchor="middle" dominant-baseline="central">${esc(nd.name[loc])}</text>
+    <text x="${r1(b.x + b.w / 2)}" y="${r1(b.y + b.h / 2 + 16)}" font-size="${F.fs(12)}" fill="#252B35" data-fill-role="ink" text-anchor="middle" dominant-baseline="central">${esc(nd.name[loc])}</text>
   </g>`);
   }
 
@@ -313,7 +379,7 @@ function renderTopology(input, loc, cb, sc, tp, degradeLevel = 0) {
       const x = lx + i * 260;
       return `    <g data-layout-role="legend-key">
       <path d="M${r1(x)} ${r1(ly)} L${r1(x + 34)} ${r1(ly)}" fill="none" stroke="${EDGE}" stroke-width="2.2"${style === "dashed" ? ' stroke-dasharray="5 4"' : ""} marker-end="url(#ah-secondary)"/>
-      <text x="${r1(x + 56)}" y="${r1(ly)}" font-size="12" fill="#636A75" data-fill-role="muted" dominant-baseline="central">${esc(label)}</text>
+      <text x="${r1(x + 56)}" y="${r1(ly)}" font-size="${F.fs(12)}" fill="#636A75" data-fill-role="muted" dominant-baseline="central">${esc(label)}</text>
     </g>`;
     }).join("\n");
     labels.push(`  <g data-layout-role="legend" data-entity="legend">\n${items}\n  </g>`);
@@ -336,7 +402,7 @@ function renderTopology(input, loc, cb, sc, tp, degradeLevel = 0) {
     body: defs + "\n" + body.join("\n"), consumed,
     bounds: { x: cb.x, y: cb.y, w: cb.w, h: contentBottom - cb.y + legendH },
     routing: {
-      degradeLevel: routed.degradeLevel, ladder, problems: routed.problems, hops: routed.hopCount,
+      degradeLevel: routed.degradeLevel, ladder, portConstraints, problems: routed.problems, hops: routed.hopCount,
       alignment: aligned.moves, attempts: routed.attempts, diagnostics: routed.diagnostics,
       legend: routed.legendRequired,
       demoted: routed.demoted.map((e) => e.id),
@@ -972,7 +1038,7 @@ function usedChars(svg) {
   for (const t of texts) for (const ch of t.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")) set.add(ch);
   return [...set].sort().join("");
 }
-function embedSubset(svg, delivery) {
+function embedSubset(svg, delivery, treatment = "flat") {
   const m = delivery.policy.modes[delivery.mode];
   if (m.embed !== "subset") return { svg, faces: [] };
   const full = readYamlFile(path.join(here, "..", "references", "delivery", "font-delivery-v1.yaml"));
@@ -980,11 +1046,15 @@ function embedSubset(svg, delivery) {
   const chars = usedChars(svg);
   if (!chars) { console.error("generate: portable delivery found no text to subset"); process.exit(4); }
   const tp = readYamlFile(path.join(here, "..", "references", "typography", "typography-v1.yaml"));
-  const flat = tp.doc.treatments.flat;
-  const rfn = flat.license?.rfn ?? [];
+  // 글꼴은 typography profile이 소유한다 — treatment resolver도 generator도 face를 고르지 않는다.
+  const prof = tp.doc.treatments[treatment];
+  if (!prof) { console.error(`generate: typography profile declares no "${treatment}" treatment`); process.exit(4); }
+  const rfn = prof.license?.rfn ?? [];
+  // 단일 face profile(sketch)은 faces 배열이 없다 — 선언 형태를 그대로 읽는다.
+  const declared = prof.asset.faces ?? [{ weight: (prof.locales.ko.weights ?? [400])[0], path: prof.asset.path, digest: prof.asset.digest }];
   const faces = [];
   let css = "", tool = null, identity = [];
-  for (const f of flat.asset.faces) {
+  for (const f of declared) {
     const abs = path.join(here, "..", String(f.path));
     const style = Number(f.weight) >= 700 ? "Bold" : "Regular";
     const { buf, receipt } = subsetFace(abs, chars, cfg.tool, style, f.weight, cfg.alias, rfn);
@@ -993,7 +1063,7 @@ function embedSubset(svg, delivery) {
     faces.push({ weight: Number(f.weight), sourceDigest: f.digest, subsetDigest: receipt.digest, bytes: buf.length });
     css += `@font-face{font-family:'${cfg.alias}';font-style:normal;font-weight:${f.weight};src:url(data:font/woff2;base64,${buf.toString("base64")}) format('woff2');}`;
   }
-  const stack = `'${cfg.alias}',` + flat.locales.ko.face + "," + flat.fallback.map((x) => /\s/.test(x) ? `'${x}'` : x).join(",");
+  const stack = `'${cfg.alias}',` + (/\s/.test(prof.locales.ko.face) ? `'${prof.locales.ko.face}'` : prof.locales.ko.face) + "," + prof.fallback.map((x) => /\s/.test(x) ? `'${x}'` : x).join(",");
   const out = svg
     .replace(/style="font-family:[^"]*"/, `style="font-family:${stack}"`)
     .replace("</desc>", `</desc>\n  <style>${css}</style>`);
@@ -1010,12 +1080,25 @@ function build(argv) {
   const override = opt("preset");
   const audition = argv.includes("--audition");
   const preset = override ?? (tp.presets.includes(sc.preset) ? sc.preset : tp.presets[0]);
+  // treatment는 registry가 허용한 것만 고를 수 있다 — 파일 존재가 허가가 아니다.
+  let tx;
+  try { tx = loadTreatment(opt("treatment") ?? "flat", opt("mode") ?? "light"); }
+  catch (e) { console.error(`generate: ${e.message}`); process.exit(2); }
+  // 시각 크기 보정은 typography SSoT의 named calibration이 소유한다. generator는 값을
+  // 정하지 않고 band factor를 읽어 **명목 크기 → 해석 크기**로 옮기기만 한다.
+  const typoDoc = readYamlFile(path.join(here, "..", "references", "typography", "typography-v1.yaml")).doc;
+  const cal = typoDoc.treatments?.[tx.name]?.optical_calibration ?? null;
+  const overrideScale = opt("optical-scale") ? Number(opt("optical-scale")) : null;
+  const band = (b) => (overrideScale ?? Number(cal?.bands?.[b] ?? 1));
+  const TS = { display: band("display"), body: band("body"),
+    fs: (nominal, b = "body") => r1(Number(nominal) * band(b)),
+    calibration: cal ? { id: cal.id, bands: { display: band("display"), body: band("body") } } : null };
   if (override && !tp.presets.includes(override) && !audition) {
     console.error(`generate: preset "${override}" is not declared by ${tid} (declared: ${tp.presets.join(", ")}) — pass --audition to render it as evidence, which marks the receipt non-canonical`);
     process.exit(1);
   }
   const render = (cbox) => tid === "cards-kpi-grid" ? renderCards(input, loc, cbox, sc, tp)
-    : tid === "topology-component" ? renderTopology(input, loc, cbox, sc, tp)
+    : tid === "topology-component" ? renderTopology(input, loc, cbox, sc, tp, 0, TS)
     : tid === "process-flow" ? renderProcessFlow(input, loc, cbox, sc, tp)
     : tid === "approval-gate" ? renderApprovalGate(input, loc, cbox, sc, tp)
     : tid === "layer-stack" ? renderLayerStack(input, loc, cbox, sc, tp)
@@ -1024,13 +1107,14 @@ function build(argv) {
     : tid === "decision-matrix" ? renderDecisionMatrix(input, loc, cbox, sc, tp)
     : tid === "roadmap-timeline" ? renderRoadmapTimeline(input, loc, cbox, sc, tp)
     : (console.error(`generate: no renderer registered for "${tid}"`), process.exit(2));
-  let pf = spawnJson([skinCli, "pageframe", preset, "--json"], "skin.mjs pageframe");
+  const osArgs = TS.display === 1 ? [] : ["--optical-scale", String(TS.display)];
+  let pf = spawnJson([skinCli, "pageframe", preset, ...osArgs, "--json"], "skin.mjs pageframe");
   if (pf.regions.fluid) {
     // fluid 캔버스는 내용 높이를 따라간다 — 블록을 먼저 재고 그 높이로 프레임을 다시 만든다.
     const probe = render({ ...pf.regions.contentBox, h: 100000 });
     // 배치가 성립하지 않으면 잴 높이도 없다 — 프레임은 그대로 두고 아래 needs-split 경로가 판정한다.
     if (probe.bounds)
-      pf = spawnJson([skinCli, "pageframe", preset, "--content-height", String(Math.ceil(probe.bounds.h)), "--json"], "skin.mjs pageframe");
+      pf = spawnJson([skinCli, "pageframe", preset, ...osArgs, "--content-height", String(Math.ceil(probe.bounds.h)), "--json"], "skin.mjs pageframe");
   }
   const cb = pf.regions.contentBox;
   const need = computeFit(tp, sc);
@@ -1097,13 +1181,18 @@ function build(argv) {
   const title = input.title?.[loc];
   if (!title) { console.error("generate: input payload must carry title.ko/title.en — the H1 is content, not something the generator may invent"); process.exit(1); }
   const subtitle = loc === "ko" ? `${tid} · ${sc.id}` : `${tid} · ${sc.id}`;
+  // treatment는 **표면 처리**만 바꾼다 — 좌표·문안·semantic id·reading order는 그대로다.
+  const canvas = { w: pf.canvas.width, h: canvasH };
+  const defs = treatmentDefs(tx, canvas);
+  const body = tx.name === "flat" ? R.body
+    : R.body.replace(/<g data-layer="(containers|connectors|nodes)"/g, (m, k) => `${m}${filterAttr(tx, k === "connectors" ? "rough-line" : "rough-box")}`);
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${pf.canvas.width} ${canvasH}" width="${pf.canvas.width}" height="${canvasH}" role="img"
   style="font-family:Pretendard,Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
   <title>${esc(title)}</title>
   <desc>${esc(tid)} ${esc(sc.id)} (${loc}) — generated from the declared TypePack input payload.</desc>
-  <rect data-fill-role="canvas" fill="#F7F7F5" width="${pf.canvas.width}" height="${pf.canvas.height}"/>
+  <rect data-fill-role="canvas" fill="#F7F7F5" width="${pf.canvas.width}" height="${pf.canvas.height}"/>${tx.name === "flat" ? "" : `\n${paperRect(tx, canvas)}\n  <defs data-treatment-defs="${tx.name}">\n${defs}\n  </defs>`}
 ${header(pf, title, eyebrow, subtitle, R.bounds.y)}
-${R.body}
+${body}
 </svg>
 `;
   // kernel §8: 배치 후 contentFlowBounds와 residual을 기록하고, 큰 하단 여백은
@@ -1117,13 +1206,31 @@ ${R.body}
       console.error(`generate: bottom residual ${residual.bottom}px (${Math.round(100 * residual.bottom / cb.h)}% of the contentBox) exceeds the ${Math.round(100 * RESIDUAL_FLOOR)}% floor and the scenario declares no residual_disposition — declare it with a reason or choose a preset/variant that fills the page`);
       process.exit(1);
     }
-    if (Math.abs(Number(decl.bottom) - residual.bottom) > RESIDUAL_TOL) {
-      console.error(`generate: declared residual_disposition.bottom ${decl.bottom}px does not match the measured ${residual.bottom}px (tol ${RESIDUAL_TOL}px)`);
+    // 잔여 선언은 **최대값이 아니라 실측과 일치하는 값**이다 — 단방향 비교는 stale 선언과
+    // 과도한 content expansion을 통과시킨다. treatment마다 실측이 다르므로 항목도 treatment별이다.
+    const want = residualEntry(decl, tx, TS);
+    if (want.error) { console.error(`generate: ${want.error}`); process.exit(1); }
+    if (Math.abs(Number(want.bottom) - residual.bottom) > RESIDUAL_TOL) {
+      console.error(`generate: declared residual_disposition.bottom ${want.bottom}px does not match the measured ${residual.bottom}px (tol ${RESIDUAL_TOL}px, treatment ${tx.name}${want.calibration ? ` + ${want.calibration}` : ""})`);
       process.exit(1);
     }
   }
   const delivery = fontDelivery(opt("font-delivery"));
-  const embedded = embedSubset(svg, delivery);
+  const embedded = embedSubset(svg, delivery, tx.name);
+  // treatment를 선택했으면 산출물이 실제로 그 treatment여야 한다. 이름만 바뀌고 flat과
+  // 같은 바이트가 나오는 것을 성공으로 인정하지 않는다(materialize `updated 0`와 같은 함정).
+  if (tx.name !== "flat") {
+    const miss = [];
+    if (!/data-treatment-paper="1"/.test(embedded.svg)) miss.push("paper surface");
+    if (!new RegExp(`data-treatment-defs="${tx.name}"`).test(embedded.svg)) miss.push("treatment defs");
+    for (const f of tx.filters) if (!embedded.svg.includes(`filter="url(#tx-${f.id})"`)) miss.push(`applied ${f.id} filter`);
+    if (!/<feDisplacementMap/.test(embedded.svg)) miss.push("displacement map");
+    if (delivery.mode === "portable" && embedded.faces?.some((f) => f.subsetDigest === undefined)) miss.push("subset-embedded face");
+    if (miss.length) {
+      console.error(`generate: treatment "${tx.name}" was selected but the artifact lacks ${miss.join(", ")} — a renamed flat render is not a treatment`);
+      process.exit(1);
+    }
+  }
   const artifact = embedded.svg.replace(/[ \t]+$/gm, "");   // digest 대상은 실제로 기록되는 바이트다
   if (out) writeFileSync(out, artifact);
   const receipt = { ...base, status: "ok", artifact: out ? path.basename(out) : null,
@@ -1133,6 +1240,7 @@ ${R.body}
       policyDigest: delivery.policy.profile.digest, typographyProfileDigest: delivery.policy.typographyProfileDigest,
       alias: embedded.alias ?? null, glyphs: embedded.chars ?? 0, faces: embedded.faces,
       tool: embedded.tool ?? null, wrapperDigest: embedded.wrapperDigest ?? null, identity: embedded.identity ?? [] },
+    treatment: { name: tx.name, mode: tx.mode, overlay: tx.overlay, displacementBound: displacementBound(tx) },
     routing: R.routing ?? null,
     matrix: R.matrix ?? null,
     timeline: R.timeline ?? null,
@@ -1377,6 +1485,120 @@ function auditTimeline(svg, input, rcp, tp) {
   return errs;
 }
 
+// treatment 감사: rough stroke는 기하 bounds 밖으로 **밀려나므로**, 선언 좌표만 보면
+// 경계를 넘는 것을 놓친다. displacement 폭과 filter region까지 포함해 검사한다.
+function auditTreatment(svg, rcp) {
+  const errs = [];
+  const t = rcp.treatment;
+  if (!t) { errs.push("E-TX-RECEIPT receipt carries no treatment block"); return errs; }
+  const declared = /<defs data-treatment-defs="([a-z]+)"/.exec(svg);
+  const paper = /data-treatment-paper="1"/.test(svg);
+  if (t.name === "flat") {
+    if (declared || paper) errs.push("E-TX-FLAT the receipt says flat but the artifact carries treatment surfaces");
+    return errs;
+  }
+  if (!declared || declared[1] !== t.name)
+    errs.push(`E-TX-STRUCT the artifact does not declare the "${t.name}" treatment defs`);
+  if (!paper) errs.push("E-TX-STRUCT the artifact has no treatment paper surface");
+  const vb = /viewBox="0 0 ([\d.]+) ([\d.]+)"/.exec(svg);
+  if (!vb) { errs.push("E-TX-STRUCT viewBox is unreadable"); return errs; }
+  const W = Number(vb[1]), H = Number(vb[2]);
+  const d = Number(t.displacementBound ?? 0);
+  if (!(d > 0)) errs.push("E-TX-STRUCT a surface treatment must declare a positive displacement bound");
+  // filter region은 canvas 전체여야 한다 — 좁은 region은 직선에서 붕괴하고 stroke를 잘라낸다.
+  for (const m of svg.matchAll(/<filter id="tx-([a-z-]+)"([^>]*)>/g)) {
+    const a = (k) => Number((m[2].match(new RegExp(`\\b${k}="([\\d.-]+)"`)) ?? [])[1]);
+    if (!/filterUnits="userSpaceOnUse"/.test(m[2]))
+      errs.push(`E-TX-REGION filter "${m[1]}" must use userSpaceOnUse (percentage regions collapse on straight strokes)`);
+    if (a("x") !== 0 || a("y") !== 0 || a("width") < W || a("height") < H)
+      errs.push(`E-TX-REGION filter "${m[1]}" region ${a("width")}×${a("height")} at ${a("x")},${a("y")} does not cover the ${W}×${H} canvas — displaced strokes would be clipped`);
+  }
+  // filter가 실제로 적용된 layer만 displacement 대상이다.
+  const filtered = new Set([...svg.matchAll(/<g data-layer="([a-z]+)"[^>]*filter="url\(#tx-[a-z-]+\)"/g)].map((m) => m[1]));
+  if (!filtered.size) errs.push("E-TX-STRUCT no layer carries the treatment filter");
+  // rough stroke가 canvas 경계를 넘지 않는지: 선언 기하 + displacement.
+  const rects = [...svg.matchAll(/<rect[^>]*\/>/g)].map((m) => m[0])
+    .filter((r) => !/data-treatment-paper|data-fill-role="canvas"/.test(r));
+  for (const r of rects) {
+    const n = (k) => Number((r.match(new RegExp(`\\b${k}="([\\d.-]+)"`)) ?? [])[1]);
+    const x = n("x"), y = n("y"), w = n("width"), h = n("height");
+    if (![x, y, w, h].every(Number.isFinite)) continue;
+    const sw = Number((r.match(/stroke-width="([\d.]+)"/) ?? [])[1] ?? 0) / 2;
+    if (x - sw - d < 0 || y - sw - d < 0 || x + w + sw + d > W || y + h + sw + d > H)
+      errs.push(`E-TX-CONTAIN a surface at ${r1(x)},${r1(y)} ${r1(w)}×${r1(h)} leaves the canvas once the ${d}px rough displacement is applied`);
+  }
+  // 폰트: portable에서 implicit fallback이 남으면 "설치 글꼴 비의존" 주장이 깨진다.
+  if (rcp.fontDelivery?.mode === "portable") {
+    if (!(rcp.fontDelivery.faces ?? []).length) errs.push("E-TX-FONT portable sketch must embed at least one subset face");
+    const css = /<style>([\s\S]*?)<\/style>/.exec(svg);
+    if (!css || !/@font-face/.test(css[1])) errs.push("E-TX-FONT the artifact carries no embedded @font-face");
+    const stack = (/style="font-family:([^"]*)"/.exec(svg) ?? [])[1] ?? "";
+    if (!stack.startsWith(`'${rcp.fontDelivery.alias}'`))
+      errs.push(`E-TX-FONT the embedded alias must lead the font stack (got "${stack.slice(0, 48)}")`);
+  }
+  return errs;
+}
+
+// allowed port interval 감사: receipt를 정답으로 쓰지 않고 **산출물의 layout metric**
+// (label bounds · node bounds · route 상수)에서 구간을 다시 계산해 대조한다.
+function auditPortIntervals(svg, rcp) {
+  const errs = [];
+  const pc = rcp.routing?.portConstraints ?? [];
+  if (!pc.length) return errs;
+  const K = ROUTE_DEFAULTS;
+  const num = (t, k) => Number((t.match(new RegExp(`\\b${k}="([\\d.-]+)"`)) ?? [])[1]);
+  const nodes = new Map();
+  for (const m of svg.matchAll(/<rect[^>]*data-entity="([^"]+)"[^>]*\/>/g))
+    nodes.set(m[1], { x: num(m[0], "x"), y: num(m[0], "y"), w: num(m[0], "width"), h: num(m[0], "height") });
+  for (const m of svg.matchAll(/<g[^>]*data-entity="([^"]+)"[^>]*>\s*<rect([^>]*)\/>/g))
+    if (!nodes.has(m[1])) nodes.set(m[1], { x: num(m[2], "x"), y: num(m[2], "y"), w: num(m[2], "width"), h: num(m[2], "height") });
+  const labels = [...svg.matchAll(/data-label-bounds="([\d.,-]+)"/g)]
+    .map((m) => m[1].split(",").map(Number)).map(([x, y, w, h]) => ({ x, y, w, h }));
+  for (const c of pc) {
+    const n = nodes.get(c.node);
+    if (!n) { errs.push(`E-PORT-INTERVAL constraint names node "${c.node}" which is absent from the artifact`); continue; }
+    // 이 node를 덮는 label을 찾아 layout과 같은 식으로 구간을 다시 만든다.
+    const over = labels.filter((l) => l.y <= n.y && l.x < n.x + n.w && l.x + l.w > n.x);
+    const right = over.length ? Math.max(...over.map((l) => l.x + l.w)) : -Infinity;
+    // layout과 **같은 식**을 쓴다 — 선과 label 사이 간격은 router가 강제한다.
+    const lo = r1(Math.max(n.x + K.portInset, right === -Infinity ? -Infinity : right));
+    const hi = r1(n.x + n.w - K.portInset);
+    if (Math.abs(lo - Number(c.allowed.lo)) > 0.5 || Math.abs(hi - Number(c.allowed.hi)) > 0.5)
+      errs.push(`E-PORT-INTERVAL edge "${c.edge}" declares [${c.allowed.lo}, ${c.allowed.hi}] but the layout metric recomputes [${lo}, ${hi}]`);
+    if (!(Number(c.allowed.lo) >= n.x + K.portInset - 0.5 && Number(c.allowed.hi) <= n.x + n.w - K.portInset + 0.5))
+      errs.push(`E-PORT-INTERVAL edge "${c.edge}" interval leaves the port range of node "${c.node}"`);
+    // 선택된 port가 구간 안에 있는지 — 기록된 path에서 다시 잰다.
+    const rt = (rcp.routing.routes ?? []).find((r) => r.id === c.edge);
+    // 좌표 d만 잡는다 — data-route-kind 같은 다른 속성이 먼저 걸리면 NaN이 된다.
+    const d = (svg.match(new RegExp(`data-route-id="${c.edge}"[^>]*?\\sd="(M[^"]+)"`)) ?? [])[1];
+    if (d) {
+      const pts = [...d.matchAll(/-?[\d.]+/g)].map(Number);
+      const endX = pts.at(-2);
+      if (!(endX >= Number(c.allowed.lo) - 0.5 && endX <= Number(c.allowed.hi) + 0.5))
+        errs.push(`E-PORT-INTERVAL edge "${c.edge}" attaches at x=${r1(endX)}, outside its allowed interval [${c.allowed.lo}, ${c.allowed.hi}]`);
+    }
+    void rt;
+  }
+  return errs;
+}
+
+
+// 잔여 선언 조회: treatment(+calibration) 항목이 없거나 ID가 다르면 **fail-closed**다.
+// 항목 없이 통과시키면 "선언되지 않은 dead space"가 다시 열린다.
+function residualEntry(decl, tx, TS) {
+  const calId = TS.calibration?.id ?? null;
+  if (Array.isArray(decl.by_treatment)) {
+    const hit = decl.by_treatment.find((e) => e.treatment === tx.name
+      && (e.calibration === undefined ? calId === null : e.calibration === calId));
+    if (!hit) return { error: `residual_disposition declares no entry for treatment "${tx.name}"${calId ? ` + calibration "${calId}"` : ""} — declare the measured value instead of reusing another treatment's` };
+    if (!Number.isFinite(Number(hit.bottom))) return { error: `residual_disposition entry for "${tx.name}" has no numeric bottom` };
+    return { bottom: hit.bottom, calibration: hit.calibration ?? null };
+  }
+  // 단일 선언은 flat 전용이다 — treatment를 켠 채 이것을 쓰면 실측과 어긋난다.
+  if (tx.name !== "flat") return { error: `residual_disposition is declared once (flat only) but treatment "${tx.name}" is active — declare it per treatment with by_treatment` };
+  return { bottom: decl.bottom, calibration: null };
+}
+
 function verify(argv) {
   const opt = (n, d = null) => { const i = argv.indexOf(`--${n}`); return i >= 0 ? argv[i + 1] : d; };
   const rcpP = opt("receipt"), svgP = opt("svg"), pairP = opt("pair");
@@ -1414,6 +1636,15 @@ function verify(argv) {
         errors.push(`E-GEN-ALIGN alignment inventory recomputed from the input does not match the artifact\n    input:    ${expectedInv}\n    artifact: ${gotInv ?? "(none)"}`);
       if (rcp.typepack === "decision-matrix") for (const e of auditMatrixAxes(svg, input, rcp.locale)) errors.push(e);
       if (rcp.typepack === "roadmap-timeline") for (const e of auditTimeline(svg, input, rcp, caseTp)) errors.push(e);
+      for (const e of auditTreatment(svg, rcp)) errors.push(e);
+      for (const e of auditPortIntervals(svg, rcp)) errors.push(e);
+      // residual도 receipt를 정답으로 쓰지 않는다 — 최종 contentFlowBounds와 contentBox에서 다시 잰다.
+      if (rcp.contentFlowBounds && rcp.contentBox) {
+        const cbY = rcp.contentFlowBounds.y - (rcp.residual?.top ?? 0);
+        const recomputed = r1(cbY + rcp.contentBox.h - (rcp.contentFlowBounds.y + rcp.contentFlowBounds.h));
+        if (Math.abs(recomputed - Number(rcp.residual?.bottom ?? NaN)) > 0.5)
+          errors.push(`E-GEN-RESIDUAL receipt residual.bottom ${rcp.residual?.bottom} != ${recomputed} recomputed from contentFlowBounds and contentBox`);
+      }
       // 배선은 산출물에서 다시 잰다 — receipt가 아니라 기록된 path가 근거다
       const audit = auditTopology(svg);
       for (const e of audit.errors) errors.push(`E-GEN-ROUTE ${e}`);

--- a/skills/svg-infographic/scripts/generate.test.mjs
+++ b/skills/svg-infographic/scripts/generate.test.mjs
@@ -8,6 +8,8 @@ import { readFileSync, writeFileSync, existsSync, mkdtempSync, rmSync } from "no
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
@@ -89,7 +91,7 @@ test("G-3: payload에 title이 없으면 H1을 지어내지 않고 실패한다"
 test("G-4: 하단 잔여가 floor를 넘는데 선언이 없으면 실패한다", () => {
   const pkg = pkgCopy();
   // topology canonical은 고정 캔버스에서 선언된 breathing을 남긴다 — 그 선언을 지우면 통과하면 안 된다.
-  editManifest(pkg, (m) => m.replace(/\n\s+residual_disposition: \{ bottom: 194[^\n]*\n/, "\n"));
+  editManifest(pkg, (m) => m.replace(/\n *residual_disposition:\n(?: +[^\n]*\n)+?(?= *routing_expected:)/, "\n"));
   const b = build(pkg, "topology-component", "canonical", "ko");
   assert.equal(b.code, 1, b.out);
   assert.match(b.out, /residual_disposition/);
@@ -98,7 +100,7 @@ test("G-4: 하단 잔여가 floor를 넘는데 선언이 없으면 실패한다"
 
 test("G-5: 선언한 잔여가 측정치와 다르면 실패한다", () => {
   const pkg = pkgCopy();
-  editManifest(pkg, (m) => m.replace("bottom: 194,", "bottom: 120,"));
+  editManifest(pkg, (m) => m.replace("{ treatment: flat, bottom: 194 }", "{ treatment: flat, bottom: 120 }"));
   const b = build(pkg, "topology-component", "canonical", "ko");
   assert.equal(b.code, 1, b.out);
   assert.match(b.out, /does not match the measured/);
@@ -494,4 +496,229 @@ test("G-28: 투명한 future dot은 거부한다 — 축 rail이 비친다", () 
     assert.match(r.out, why);
     drop(pkg);
   }
+});
+
+// --- treatment axis: sketch는 이름이 아니라 산출물로 증명된다 -------------------------
+// flat이 canonical/default이고 sketch는 opt-in experimental preview다. 아래는 그 경계를
+// 이름이 아니라 **산출물**에서 지키는지 고정한다.
+
+const TX = ["--treatment", "sketch", "--font-delivery", "portable"];
+const hasSubsetter = () => Boolean(process.env.SVGINFO_PYTHON && existsSync(process.env.SVGINFO_PYTHON));
+
+test("G-29: registry가 허용하지 않는 treatment는 거부한다", () => {
+  const pkg = pkgCopy();
+  const r = runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical",
+    "--locale", "ko", "--treatment", "watercolour", "--out", out(pkg, "x.svg"), "--receipt", out(pkg, "x.json")]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /unknown treatment/);
+  drop(pkg);
+});
+
+test("G-30: dark × sketch는 미지원 조합으로 거부한다", () => {
+  const pkg = pkgCopy();
+  const r = runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical",
+    "--locale", "ko", "--treatment", "sketch", "--mode", "dark", "--out", out(pkg, "x.svg"), "--receipt", out(pkg, "x.json")]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /unsupported combination: dark \+ sketch/);
+  drop(pkg);
+});
+
+test("G-31: overlay가 registry에서 빠지면 sketch를 선택할 수 없다", () => {
+  const pkg = pkgCopy();
+  const reg = path.join(pkg, "references", "skins", "registry.yaml");
+  writeFileSync(reg, readFileSync(reg, "utf8").replace(/^overlays:\n  sketch: .*$/m, "overlays: {}"));
+  const r = runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical",
+    "--locale", "ko", "--treatment", "sketch", "--out", out(pkg, "x.svg"), "--receipt", out(pkg, "x.json")]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /not selected by the skin registry/);
+  drop(pkg);
+});
+
+test("G-32: sketch 구조가 일부만 빠져도 verify가 거부한다", () => {
+  if (!hasSubsetter()) { console.error("  note: pinned subsetter 없음 — sketch 구조 negative 미검증"); return; }
+  const muts = [
+    [(s) => s.replace(/ data-treatment-paper="1"/, " data-was-paper=\"1\""), /no treatment paper surface/],
+    [(s) => s.replace(/<defs data-treatment-defs="sketch">/, "<defs>"), /does not declare the "sketch" treatment defs/],
+    [(s) => s.replace(/filterUnits="userSpaceOnUse"/g, 'filterUnits="objectBoundingBox"'), /must use userSpaceOnUse/],
+    [(s) => s.replace(/(<filter id="tx-rough-box"[^>]*?)width="\d+"/, '$1width="40"'), /does not cover the/],
+  ];
+  for (const [mutate, why] of muts) {
+    const pkg = pkgCopy();
+    const svg = out(pkg, "s.svg"), rcp = out(pkg, "s.json");
+    const b = runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical",
+      "--locale", "ko", ...TX, "--out", svg, "--receipt", rcp]);
+    assert.equal(b.code, 0, b.out);
+    const before = readFileSync(svg, "utf8"), after = mutate(before);
+    assert.notEqual(after, before, `fixture mutation did not apply for ${why}`);
+    writeFileSync(svg, after);
+    const r = runIn(pkg, ["verify", "--receipt", rcp, "--svg", svg]);
+    assert.notEqual(r.code, 0, r.out);
+    assert.match(r.out, why);
+    drop(pkg);
+  }
+});
+
+test("G-33: sketch receipt로 flat 산출물을 통과시킬 수 없다 (silent flat fallback)", () => {
+  if (!hasSubsetter()) return;
+  const pkg = pkgCopy();
+  const fsvg = out(pkg, "f.svg"), frcp = out(pkg, "f.json");
+  const ssvg = out(pkg, "s.svg"), srcp = out(pkg, "s.json");
+  assert.equal(runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical", "--locale", "ko",
+    "--font-delivery", "portable", "--out", fsvg, "--receipt", frcp]).code, 0);
+  assert.equal(runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical", "--locale", "ko",
+    ...TX, "--out", ssvg, "--receipt", srcp]).code, 0);
+  // flat과 sketch가 실제로 다른 산출물이어야 한다 — 이름만 바뀐 것은 treatment가 아니다.
+  assert.notEqual(readFileSync(fsvg, "utf8"), readFileSync(ssvg, "utf8"));
+  // sketch receipt + flat artifact = 조용한 fallback. 거부돼야 한다.
+  const s = JSON.parse(readFileSync(srcp, "utf8"));
+  s.artifactDigest = JSON.parse(readFileSync(frcp, "utf8")).artifactDigest;
+  writeFileSync(srcp, JSON.stringify(s));
+  const r = runIn(pkg, ["verify", "--receipt", srcp, "--svg", fsvg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /E-TX-STRUCT|E-TX-FLAT/);
+  drop(pkg);
+});
+
+test("G-34: portable sketch는 embedded alias가 stack을 이끈다 (implicit fallback 금지)", () => {
+  if (!hasSubsetter()) return;
+  const pkg = pkgCopy();
+  const svg = out(pkg, "s.svg"), rcp = out(pkg, "s.json");
+  assert.equal(runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical",
+    "--locale", "ko", ...TX, "--out", svg, "--receipt", rcp]).code, 0);
+  const text = readFileSync(svg, "utf8");
+  assert.match(text, /style="font-family:'SkinSans-Subset','Hi Melody'/);
+  assert.match(text, /@font-face/);
+  // alias를 stack에서 떨어뜨리면 설치 글꼴에 의존하게 된다 — 거부돼야 한다.
+  writeFileSync(svg, text.replace(/font-family:'SkinSans-Subset',/, "font-family:"));
+  const r = runIn(pkg, ["verify", "--receipt", rcp, "--svg", svg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /E-TX-FONT/);
+  drop(pkg);
+});
+
+// --- allowedPortInterval: layout이 증명한 구간을 router가 소비한다 --------------------
+
+test("G-35: interval 밖 port는 verify가 거부한다", () => {
+  if (!hasSubsetter()) return;
+  const pkg = pkgCopy();
+  const svg = out(pkg, "s.svg"), rcp = out(pkg, "s.json");
+  assert.equal(runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical",
+    "--locale", "ko", ...TX, "--out", svg, "--receipt", rcp]).code, 0);
+  const t = JSON.parse(readFileSync(rcp, "utf8"));
+  const pc = t.routing.portConstraints;
+  assert.ok(pc?.length, "sketch topology는 entry interval을 선언해야 한다");
+  // 선택된 port를 구간 밖으로 옮긴다(선언은 그대로) — 재측정이 잡아야 한다.
+  const text = readFileSync(svg, "utf8");
+  const m = new RegExp(`data-route-id="${pc[0].edge}"[^>]*?\\sd="(M[^"]+)"`).exec(text);
+  // 경로 전체를 왼쪽으로 옮긴다 — attach x가 구간 밖으로 나가야 한다.
+  const moved = m[1].replace(/([ML])([\d.]+)/g, (_, cmd, x) => `${cmd}${Number(x) - 200}`);
+  writeFileSync(svg, text.replace(`d="${m[1]}"`, `d="${moved}"`));
+  const r = runIn(pkg, ["verify", "--receipt", rcp, "--svg", svg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /E-PORT-INTERVAL/);
+  drop(pkg);
+});
+
+test("G-36: node port 범위를 벗어난 interval 선언은 거부한다", () => {
+  if (!hasSubsetter()) return;
+  const pkg = pkgCopy();
+  const svg = out(pkg, "s.svg"), rcp = out(pkg, "s.json");
+  runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical", "--locale", "ko", ...TX, "--out", svg, "--receipt", rcp]);
+  const t = JSON.parse(readFileSync(rcp, "utf8"));
+  t.routing.portConstraints[0].allowed.hi += 500;   // node 밖까지 허용한다고 주장
+  writeFileSync(rcp, JSON.stringify(t));
+  const r = runIn(pkg, ["verify", "--receipt", rcp, "--svg", svg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /leaves the port range|recomputes/);
+  drop(pkg);
+});
+
+test("G-37: label clearance를 만족하지 않는 interval은 거부한다", () => {
+  if (!hasSubsetter()) return;
+  const pkg = pkgCopy();
+  const svg = out(pkg, "s.svg"), rcp = out(pkg, "s.json");
+  runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical", "--locale", "ko", ...TX, "--out", svg, "--receipt", rcp]);
+  const t = JSON.parse(readFileSync(rcp, "utf8"));
+  t.routing.portConstraints[0].allowed.lo -= 120;   // label 쪽으로 구간을 넓혔다고 주장
+  writeFileSync(rcp, JSON.stringify(t));
+  const r = runIn(pkg, ["verify", "--receipt", rcp, "--svg", svg]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /recomputes/);
+  drop(pkg);
+});
+
+test("G-38: 합법 구간이 기존 sweep 밖에 있어도 라우팅된다 (interval 소비 증거)", () => {
+  if (!hasSubsetter()) return;
+  const pkg = pkgCopy();
+  const svg = out(pkg, "s.svg"), rcp = out(pkg, "s.json");
+  const b = runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical", "--locale", "ko", ...TX, "--out", svg, "--receipt", rcp]);
+  assert.equal(b.code, 0, b.out);
+  const t = JSON.parse(readFileSync(rcp, "utf8"));
+  // 큰 손글씨에서 label이 넓어져도 3개 edge가 모두 살아 있어야 한다.
+  assert.equal(t.routing.routes.length, 3, "1.8x에서도 전 edge가 라우팅돼야 한다");
+  assert.equal(t.routing.problems.length, 0);
+  for (const c of t.routing.portConstraints) assert.ok(c.allowed.hi > c.allowed.lo, "구간은 finite이고 비어 있지 않다");
+  drop(pkg);
+});
+
+test("G-39: straight-first와 결정성은 interval 아래에서도 유지된다", () => {
+  if (!hasSubsetter()) return;
+  const pkg = pkgCopy();
+  const a = out(pkg, "a.svg"), ar = out(pkg, "a.json"), c = out(pkg, "c.svg"), cr = out(pkg, "c.json");
+  runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical", "--locale", "ko", ...TX, "--out", a, "--receipt", ar]);
+  runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical", "--locale", "ko", ...TX, "--out", c, "--receipt", cr]);
+  assert.equal(readFileSync(a, "utf8"), readFileSync(c, "utf8"), "같은 입력은 같은 산출물이어야 한다");
+  const t = JSON.parse(readFileSync(ar, "utf8"));
+  for (const rt of t.routing.routes) assert.equal(rt.path, "straight", `${rt.id}은 직선이어야 한다(불필요한 dogleg 금지)`);
+  assert.equal(t.routing.problems.length, 0);
+  drop(pkg);
+});
+
+test("G-40: 후보 수가 안전 상한을 넘으면 조용히 자르지 않고 명시 실패한다", async () => {
+  const { routeEdges, ROUTE_DEFAULTS } = await import("./route-orthogonal.mjs");
+  const K = ROUTE_DEFAULTS;
+  // 파생 후보 수 = floor((hi-lo)/portSpreadStep)+1. 상한 64를 넘기려면 겹치는 구간 폭 > 768px.
+  const W = (64 + 4) * K.portSpreadStep;                 // 816px → 후보 69개
+  const nodes = { a: { x: 0, y: 0, w: W, h: 60 }, b: { x: 0, y: 300, w: W, h: 60 } };
+  const plan = { classified: [{ id: "e1", from: "a", to: "b", weight: "primary", dashed: false }] };
+  const r = routeEdges({ nodes, zones: [], plan, frame: { x: -20, y: -20, w: W + 40, h: 420 }, degradeLevel: 0 });
+  assert.ok(r.problems.some((p) => /safety cap/.test(p)),
+    `cap 초과가 명시 실패여야 한다: problems=${JSON.stringify(r.problems)} routes=${r.routes.length}`);
+  assert.ok((r.diagnostics ?? []).some((d) => d.code === "R-CANDIDATE-CAP"), "R-CANDIDATE-CAP 진단이 남아야 한다");
+  assert.equal(r.routes.length, 0, "잘라낸 뒤 성공으로 처리하지 않는다");
+});
+
+test("G-41: treatment 항목이 없는 잔여 선언은 fail-closed다", () => {
+  if (!hasSubsetter()) return;
+  const pkg = pkgCopy();
+  // sketch 항목을 지운다 — flat 값을 재사용해 통과시키면 안 된다.
+  editManifest(pkg, (t) => t.replace(/\n *- \{ treatment: sketch, calibration: [^}]*\}/, ""));
+  const r = runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical",
+    "--locale", "ko", ...TX, "--out", out(pkg, "s.svg"), "--receipt", out(pkg, "s.json")]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /declares no entry for treatment "sketch"/);
+  drop(pkg);
+});
+
+test("G-42: calibration ID가 다르면 잔여 선언을 쓰지 않는다", () => {
+  if (!hasSubsetter()) return;
+  const pkg = pkgCopy();
+  editManifest(pkg, (t) => t.replace("calibration: hi-melody-optical-v1", "calibration: hi-melody-optical-v0"));
+  const r = runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical",
+    "--locale", "ko", ...TX, "--out", out(pkg, "s.svg"), "--receipt", out(pkg, "s.json")]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /declares no entry for treatment "sketch"/);
+  drop(pkg);
+});
+
+test("G-43: 잔여는 exact-match다 — 선언보다 작아도 통과하지 않는다", () => {
+  if (!hasSubsetter()) return;
+  const pkg = pkgCopy();
+  editManifest(pkg, (t) => t.replace("{ treatment: sketch, calibration: hi-melody-optical-v1, bottom: 93 }",
+    "{ treatment: sketch, calibration: hi-melody-optical-v1, bottom: 300 }"));
+  const r = runIn(pkg, ["build", "--typepack", "topology-component", "--case", "canonical",
+    "--locale", "ko", ...TX, "--out", out(pkg, "s.svg"), "--receipt", out(pkg, "s.json")]);
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /does not match the measured/);
+  drop(pkg);
 });

--- a/skills/svg-infographic/scripts/route-orthogonal.mjs
+++ b/skills/svg-infographic/scripts/route-orthogonal.mjs
@@ -159,6 +159,12 @@ export function routeEdges({ nodes, zones, plan, frame, degradeLevel = 0 }) {
       continue;
     }
     const all = candidates(e, A, B, nodes, zones, frame, usedPorts, { isReturn });
+    if (all.capOverflow) {
+      // 후보 공간이 안전 상한을 넘었다 — 잘라내고 "없다"고 말하지 않는다.
+      diagnostics.push({ ...all.capOverflow, supportedFixes: ["narrow the allowed port interval", "increase the lane gap"] });
+      problems.push(`edge ${e.id}: the allowed port interval yields more candidates than the safety cap — narrow the interval instead of truncating the search`);
+      continue;
+    }
     // 되돌이는 주 흐름과 같은 축도, 같은 면도 쓰지 않는다 — 반대 방향 화살촉이 한 면에 몰리면 읽히지 않는다.
     const cands = isReturn ? all.filter((c) => c.kind === "side-channel") : all;
     const tried = [];
@@ -217,9 +223,20 @@ function candidates(e, A, B, nodes, zones, frame, usedPorts, opt = {}) {
   const vOut = dy > 0 ? "bottom" : "top", vIn = dy > 0 ? "top" : "bottom";
   const hOut = dx > 0 ? "right" : "left", hIn = dx > 0 ? "left" : "right";
   const vertical = Math.abs(dy) >= Math.abs(dx);
-  const iv = (n, side) => side === "top" || side === "bottom"
+  // allowedPortInterval: layout이 label bounds·node bounds·clearance에서 이미 증명한
+  // **합법 port 구간**이다. router는 그 안에서만 후보를 만들고, 없으면 기존과 완전히 같다.
+  // 구간은 node의 실제 port 범위와 교집합을 내며, 교집합이 비면 fail-closed다.
+  const allow = e.allowedPortInterval ?? null;
+  const ivRaw = (n, side) => side === "top" || side === "bottom"
     ? { lo: n.x + K.portInset, hi: n.x + n.w - K.portInset, axis: "x" }
     : { lo: n.y + K.portInset, hi: n.y + n.h - K.portInset, axis: "y" };
+  const iv = (n, side) => {
+    const base = ivRaw(n, side);
+    const end = n === A ? allow?.from : allow?.to;
+    if (!end || end.axis !== base.axis) return base;
+    const lo = Math.max(base.lo, Number(end.lo)), hi = Math.min(base.hi, Number(end.hi));
+    return { lo, hi, axis: base.axis, constrained: true, empty: lo > hi };
+  };
   const at = (n, side, v) => side === "top" ? { x: v, y: n.y }
     : side === "bottom" ? { x: v, y: n.y + n.h }
     : side === "left" ? { x: n.x, y: v } : { x: n.x + n.w, y: v };
@@ -252,12 +269,24 @@ function candidates(e, A, B, nodes, zones, frame, usedPorts, opt = {}) {
       : (tc >= lo && tc <= hi ? tc : (lo + hi) / 2);
     // 겹치는 구간 안에서 **여러 직선 후보**를 낸다 — 첫 좌표가 장애물(예: zone label)에 막혔다고
     // 직선이라는 모양 자체를 포기하면, 옆으로 조금만 옮기면 되는 경우에도 꺾이게 된다.
+    // 후보 수는 임의 상수가 아니라 **구간 폭 / lane gap**에서 나온다 — 구간이 좁으면 적고
+    // 넓으면 그만큼 많다. 순서는 wish에서 바깥으로, 즉 straight-first와 결정성을 유지한다.
+    // 후보 수는 구간 폭에서 나온다. 안전 상한에 닿으면 **조용히 잘라내지 않고** 진단으로 남긴다 —
+    // 잘린 뒤 "후보가 없었다"고 보고하면 실패 근거가 거짓이 된다.
+    const want = Math.max(1, Math.floor((hi - lo) / K.portSpreadStep) + 1);
+    const CAND_CAP = 64;
+    if (want > CAND_CAP) {
+      out.capOverflow = { code: "R-CANDIDATE-CAP", subject: e.id,
+        evidence: { interval: [r1(lo), r1(hi)], step: K.portSpreadStep, want, cap: CAND_CAP } };
+      return out;
+    }
+    const cap = want;
     let made = 0;
     for (const v of nudge(clamp(wish, lo, hi), lo, hi)) {
       if (!free(e.from, sf, v) || !free(e.to, st, v)) continue;
       const p0 = at(A, sf, v), p1 = tip(B, st, v);
       out.push(mk("straight", [p0, p1], sf, st, [[e.from, sf, p0], [e.to, st, p1]]));
-      if (++made >= 12) break;
+      if (++made >= cap) break;
     }
   }
   // ② 1-bend — 한 축으로 나가 다른 축으로 들어간다. 두 조합을 모두 만든다.

--- a/skills/svg-infographic/scripts/skin.mjs
+++ b/skills/svg-infographic/scripts/skin.mjs
@@ -212,10 +212,29 @@ function loadTypography(errors, overridePath = null) {
   for (const t of TYPO_TREATMENTS) if (!(t in T)) errors.push(`typography: missing treatment "${t}"`);
   for (const [t, cfg] of Object.entries(T)) {
     if (!TYPO_TREATMENTS.includes(t)) { errors.push(`typography: unknown treatment "${t}"`); continue; }
-    const TK = ["locales", "fallback", "synthetic", "weight-policy", "asset", "license"];
+    const TK = ["locales", "fallback", "synthetic", "weight-policy", "optical_calibration", "asset", "license"];
     for (const k of Object.keys(cfg)) if (!TK.includes(k)) errors.push(`typography: ${t}: unknown field "${k}"`);
     if (cfg.synthetic !== "forbidden") errors.push(`typography: ${t}: synthetic must be "forbidden" (synthetic bold/italic is never allowed)`);
     if ("weight-policy" in cfg && cfg["weight-policy"] !== "normalize-400") errors.push(`typography: ${t}: unknown weight-policy "${cfg["weight-policy"]}"`);
+    // optical_calibration: base type scale을 바꾸지 않고 **face의 시각 크기**만 보정하는
+    // named token이다. band는 보정의 최소 단위이고, 파일별·문자열별 보정은 표현할 수 없다.
+    if ("optical_calibration" in cfg) {
+      const oc = cfg.optical_calibration;
+      if (!oc || typeof oc !== "object") errors.push(`typography: ${t}: optical_calibration must be a map`);
+      else {
+        for (const k of Object.keys(oc)) if (!["id", "basis", "bands"].includes(k)) errors.push(`typography: ${t}: optical_calibration unknown field "${k}"`);
+        if (!oc.id || !/^[a-z0-9][a-z0-9-]*$/.test(String(oc.id))) errors.push(`typography: ${t}: optical_calibration.id must be a kebab-case token (a calibration is named, not anonymous)`);
+        if (!oc.basis) errors.push(`typography: ${t}: optical_calibration.basis must record what the value was judged against`);
+        const bands = oc.bands ?? {};
+        const known = ["display", "body"];
+        if (!Object.keys(bands).length) errors.push(`typography: ${t}: optical_calibration.bands must declare at least one band`);
+        for (const [b, v] of Object.entries(bands)) {
+          if (!known.includes(b)) errors.push(`typography: ${t}: optical_calibration unknown band "${b}" (${known.join("|")})`);
+          const n = Number(v);
+          if (!Number.isFinite(n) || n < 1 || n > 3) errors.push(`typography: ${t}: optical_calibration.bands.${b} must be a factor between 1 and 3 (got ${v})`);
+        }
+      }
+    }
     if (!Array.isArray(cfg.fallback) || cfg.fallback.length === 0 || cfg.fallback.some((f) => typeof f !== "string" || !f.trim()))
       errors.push(`typography: ${t}: fallback must be a non-empty family list`);
     for (const loc of TYPO_LOCALES) {
@@ -608,7 +627,7 @@ const OPTION_SPEC = {
   typography: { "--json": false },
   "typography-check": { "--json": false },
   "delivery": { "--json": false },
-  pageframe: { "--h1-lines": true, "--eyebrow": true, "--subtitle": true, "--support": true, "--footer": true, "--content-height": true, "--json": false },
+  pageframe: { "--h1-lines": true, "--eyebrow": true, "--subtitle": true, "--support": true, "--footer": true, "--content-height": true, "--optical-scale": true, "--json": false },
 };
 function parseOptions(cmd, rest) {
   const spec = OPTION_SPEC[cmd];
@@ -1193,19 +1212,27 @@ function main() {
       contentHeight = Number(po["--content-height"]);
       if (!Number.isFinite(contentHeight) || contentHeight <= 0) fail(2, "--content-height must be a positive number");
     }
+    // optical scale은 base type scale을 **덮어쓰지 않는다** — 이 실행에 한해 header 지표를
+    // 보정한 사본을 만들고, header region 높이도 PageFrame이 그 값으로 다시 계산한다.
+    const os = po["--optical-scale"] === undefined ? 1 : Number(po["--optical-scale"]);
+    if (!Number.isFinite(os) || os < 1 || os > 3) fail(2, "--optical-scale must be a factor between 1 and 3");
+    const Peff = os === 1 ? P : { ...P, header: Object.fromEntries(Object.entries(P.header).map(([k, v]) => [k, Math.round(Number(v) * os)])) };
     const opts = { h1Lines, eyebrow: b(po["--eyebrow"], true), subtitle: b(po["--subtitle"], true), support, footer: b(po["--footer"], false), contentHeight };
-    const out = computePageFrame(P, opts);
+    const out = computePageFrame(Peff, opts);
     if (!out.fluid && (out.contentBox.h == null || out.contentBox.h <= 0)) fail(1, `preset ${preset}: computed contentBox height is not positive (${out.contentBox.h}) — canvas too small for the requested regions`);
     if (out.contentBox.w <= 0) fail(1, `preset ${preset}: computed contentBox width is not positive (${out.contentBox.w})`);
     // headerScale: 파일별 수기 상수가 아니라 profile에서 파생된 header 지표 —
     // title-keyline 등 header treatment는 이 값만 소비한다
     const HIm = P["header-internal"];
     const headerScale = {
-      eyebrow: P.header.eyebrow, h1: P.header.h1, subtitle: P.header.subtitle,
-      h1LinePitch: Math.round(P.header.h1 * HIm["h1-line-mult"]),
-      keyline: { width: Math.round(P.header.h1 * HIm["keyline-width-mult"]),
-                 gap: Math.round(P.header.h1 * HIm["keyline-gap-mult"]),
-                 pad: Math.round(P.header.h1 * HIm["keyline-pad-mult"]) } };
+      // nominal은 profile이 소유하고, resolved는 optical calibration이 적용된 값이다.
+      nominal: { eyebrow: P.header.eyebrow, h1: P.header.h1, subtitle: P.header.subtitle },
+      opticalScale: os,
+      eyebrow: Peff.header.eyebrow, h1: Peff.header.h1, subtitle: Peff.header.subtitle,
+      h1LinePitch: Math.round(Peff.header.h1 * HIm["h1-line-mult"]),
+      keyline: { width: Math.round(Peff.header.h1 * HIm["keyline-width-mult"]),
+                 gap: Math.round(Peff.header.h1 * HIm["keyline-gap-mult"]),
+                 pad: Math.round(Peff.header.h1 * HIm["keyline-pad-mult"]) } };
     const receipt = { schemaVersion: 1, command: "pageframe", kernelVersion: "kernel-v1",
       profile: { id: pf.doc.id, digest: pf.digest }, preset, orientation: P.orientation,
       canvas: { width: P["canvas-width"], height: P["canvas-height"] },
@@ -1348,6 +1375,7 @@ function main() {
       treatments: typo && !errors.length ? Object.fromEntries(Object.entries(typo.doc.treatments).map(([t, cfg]) => [t, {
         ko: cfg.locales.ko.face, en: cfg.locales.en.face,
         weights: cfg.locales.ko.weights, weightPolicy: cfg["weight-policy"] ?? null,
+        opticalCalibration: cfg.optical_calibration ?? null,
         stack: serializeStack(cfg.locales.ko.face, cfg.fallback),
         asset: cfg.asset, rfn: cfg.license.rfn }])) : null,
       errors, warnings: [] };

--- a/skills/svg-infographic/scripts/treatment.mjs
+++ b/skills/svg-infographic/scripts/treatment.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// treatment.mjs — surface treatment resolver.
+//
+// 소유권 경계(이 파일이 지키는 것):
+//   generator     : treatment 선택과 artifact 구조 생성        (generate.mjs)
+//   treatment     : paper·rough filter·highlight 등 시각 처리   ← 이 파일
+//   typography    : face·weight·subset·license                 (typography-v1.yaml)
+//   materializer  : semantic paint 값 갱신만                    (skin.mjs materializeSvg)
+//
+// 그래서 여기서는 filter와 paper·highlight만 만들고 **글꼴을 고르지 않으며**,
+// palette role 값을 다시 칠하지도 않는다. 반대로 materializer에 filter를 넣지 않는다.
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseYaml } from "./skin.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const refs = path.join(here, "..", "references");
+
+export const TREATMENTS = ["flat", "sketch"];
+
+// registry가 허용한 overlay만 treatment로 선택할 수 있다 — 파일이 있다고 쓰지 않는다.
+export function loadTreatment(name, mode = "light") {
+  if (!TREATMENTS.includes(name)) throw new Error(`unknown treatment "${name}" (${TREATMENTS.join("|")})`);
+  if (name === "flat") return { name, mode, overlay: null, filters: [], paper: null, highlight: null };
+  const reg = parseYaml(readFileSync(path.join(refs, "skins", "registry.yaml"), "utf8"), "registry.yaml");
+  const sel = reg.overlays?.[name];
+  if (!sel) throw new Error(`treatment "${name}" is not selected by the skin registry — an overlay file alone does not authorise it`);
+  const overlay = parseYaml(readFileSync(path.join(refs, "skins", `${sel}.yaml`), "utf8"), `${sel}.yaml`);
+  if (overlay.kind !== "surface-treatment") throw new Error(`registry selects "${sel}" for treatment "${name}" but it is not a surface-treatment overlay`);
+  // dark × sketch는 시각 승인 전까지 거부한다(overlay가 선언한 제약).
+  if (mode !== "light") throw new Error(`unsupported combination: ${mode} + ${name} (this kernel supports light only)`);
+  const t = overlay.tokens ?? {};
+  for (const k of ["paper", "sketch-ink", "highlight"])
+    if (!t[k]) throw new Error(`overlay ${sel} is missing the "${k}" token`);
+  return {
+    name, mode, overlay: sel,
+    paper: t.paper, ink: t["sketch-ink"], highlight: t.highlight,
+    // 수치는 overlay 선언에서 읽는다 — 이 파일에 상수를 다시 적지 않는다.
+    filters: ["rough-box", "rough-line"].map((id) => ({ id, spec: String(overlay.treatment?.[id] ?? "") })),
+  };
+}
+
+const num = (spec, key, fallback) => {
+  const m = new RegExp(`${key}=([\\d.]+)`).exec(spec);
+  return m ? Number(m[1]) : fallback;
+};
+
+// filter defs는 treatment가 소유한다. 전면 userSpaceOnUse 영역을 쓰는 이유는
+// authoring E-FILTERBOUNDS에 적혀 있다 — 퍼센트 영역은 직선에서 붕괴한다.
+export function treatmentDefs(t, canvas) {
+  if (t.name === "flat") return "";
+  const region = ` x="0" y="0" width="${canvas.w}" height="${canvas.h}" filterUnits="userSpaceOnUse"`;
+  return t.filters.map(({ id, spec }) => {
+    const bf = num(spec, "baseFrequency", 0.05), oc = num(spec, "numOctaves", 2), sc = num(spec, "scale", 3);
+    return `    <filter id="tx-${id}"${region}>
+      <feTurbulence type="fractalNoise" baseFrequency="${bf}" numOctaves="${oc}" seed="7" result="n"/>
+      <feDisplacementMap in="SourceGraphic" in2="n" scale="${sc}" xChannelSelector="R" yChannelSelector="G"/>
+    </filter>`;
+  }).join("\n");
+}
+
+// paper는 canvas role을 **대체**하는 것이 아니라 그 위에 깔리는 treatment 표면이다.
+export function paperRect(t, canvas) {
+  return t.name === "flat" ? ""
+    : `  <rect data-treatment-paper="1" x="0" y="0" width="${canvas.w}" height="${canvas.h}" fill="${t.paper}" data-paint-static="true"/>`;
+}
+
+// displacement가 실제로 얼마나 밀어낼 수 있는지 — containment 검사가 이 값을 쓴다.
+export function displacementBound(t) {
+  return t.name === "flat" ? 0 : Math.max(0, ...t.filters.map(({ spec }) => num(spec, "scale", 3)));
+}
+
+export const filterAttr = (t, kind) => (t.name === "flat" ? "" : ` filter="url(#tx-${kind})"`);
+export const highlightOf = (t) => (t.name === "flat" ? null : t.highlight);


### PR DESCRIPTION
## 요약

`topology-component` canonical KO/EN을 vertical slice로 삼아 **surface treatment 축**을 붙인다. **`flat` = canonical / default**, **`sketch` = experimental opt-in preview**다. 9종 전체 지원으로 확대하지 않았고 어떤 TypePack도 sketch로 라우팅되지 않는다.

## 소유권 분리

| Owner | Concern |
| --- | --- |
| generator | treatment 선택과 artifact 구조 |
| treatment resolver (`scripts/treatment.mjs`) | paper · rough filter · highlight · displacement bound |
| typography profile | face · weight · subset · license (`treatments.sketch`) |
| materializer | semantic paint 값만 (무변경) |

filter·font를 materializer에 넣지 않았고 palette role과 overlay token을 합치지 않았다. filter 수치는 overlay 선언에서 읽는다.

## Optical calibration 1.8× (owner 선택)

Hi Melody는 같은 px에서 훨씬 작게 보여 **명목 크기 동일이 위계 동일이 아니다.** base type scale 소유권은 PageFrame에 두고, named calibration token이 **그 face의 시각 크기만** 보정한다. band(`display`/`body`)가 보정의 최소 단위이며 파일별·문자열별 보정은 표현할 수 없다.

1.6× / 1.8× / 2.0× audition 결과 **2.0×는 4:5과 16:9 모두에서 layout이 거부**한다. 1.8×는 "들어가는 최대값"이라서가 아니라 optical parity와 가독성으로 선택했고, route 3/3 · bend 0 · 최소 inset 36px을 유지한다.

## metric-driven zone reflow (모든 treatment 공유)

zone을 `label band + node area`로 나누고 band 높이를 resolved label line-box와 공통 padding에서 유도한다. label은 corridor를 남긴 폭 안에서 **줄바꿈**한다 — 글자를 줄여 기존 band에 욱여넣지 않는다.

## allowedPortInterval (endpoint 계약)

layout이 label bounds · node bounds에서 합법 port 구간을 계산해 넘기고, router는 node 실제 port 범위와의 **교집합** 안에서만 후보를 만든다. verify는 receipt를 믿지 않고 **산출물의 layout metric에서 구간을 재계산**해 대조하며 선택된 port를 기록된 path에서 재측정한다.

layout이 보장하는 것은 "port가 label 아래에 있지 않다"까지이고 선과 label의 간격은 router가 자기 obstacle 규칙으로 강제한다 — layout이 더 엄격하면 기존 산출물의 배선이 이유 없이 옮겨간다.

## fail-closed 4종

- 선택한 treatment가 산출물에 없으면(paper · defs · applied filter · displacement map) 실패. **이름만 바뀐 flat 렌더는 treatment가 아니다.**
- subset이 사용 glyph를 덮지 못하면 실패 — implicit system fallback으로 새지 않는다(`on_glyph_missing: fail-closed`를 실제로 집행).
- residual은 treatment별 **exact-match**. 항목 없음·calibration ID 불일치는 거부하고, 선언보다 작아도 통과하지 않는다.
- 후보 수가 안전 상한을 넘으면 조용히 자르지 않고 `R-CANDIDATE-CAP`으로 실패한다.

`dark × sketch`는 기존대로 거부한다.

## 불변 증명 (실제 산출물 대조)

```
flat topology  ko 5125de5ba4fec5e2 = 5125de5ba4fec5e2   en 1f70784b98784bc0 = 1f70784b98784bc0
8 TypePack × KO/EN (svg·geometry·semantic ID·consumed·residual)     변경 0 / 16
```

이 대조가 suite green이 놓친 회귀를 잡았다 — flat 배선이 `192.5 → 259.8`로 옮겨져 있었고, 원인 2단계(flat 경로에도 interval 적용 / layout이 router보다 엄격한 clearance)를 분리해 되돌렸다.

## 회귀

```
skin 118 · preflight 29 · check-svg 70 · check-layout 47 · route-orthogonal 28
font-probe 6 · render 23 · compose 51 · generate 44
all suites green (exit 0)
```

negative 15종(G-29~G-43). compose fixture 7개는 `regen-receipts.mjs`로 재생성했고 변경 field는 `typographyProfileDigest` 하나다. `surface_revision` 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)