### PR TITLE
feat(gallery): verified example에서 파생되는 gallery model을 추가한다 (CP3B)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Repo validation (M1)
         run: PYTHONPATH=tools python3 -m skillstead_validate repo --repo-root .
 
+      - name: Gallery model drift (CP3B)
+        run: PYTHONPATH=tools python3 -m skillstead_validate gallery --repo-root .
+
       - name: Continuous tag checks (M3)
         run: PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref origin/main --repo-root .
 

--- a/gallery/model.json
+++ b/gallery/model.json
@@ -1,7 +1,7 @@
 {
  "schemaVersion": 1,
  "generatedBy": "skillstead_validate gallery",
- "note": "Generated view. Every field is owned by the manifest, an input payload, a receipt or an artifact — this file is authority for none of them.",
+ "note": "Generated view. Every field is owned by the manifest, an input payload, a receipt or an artifact — this file is authority for none of them. `verified` attaches to the SVG only; PNGs are a present/digest inventory.",
  "runtimeSurfaceDigest": "sha256:31f5af7ae5643fbc58d0883729b2e4fe30377bb21ce72a4fe527982d99a41401",
  "tokens": "gallery/tokens.json",
  "typepackCount": 9,
@@ -12,50 +12,139 @@
    "spec": "types/specs/approval-gate.md",
    "profile": "constrained-layout",
    "support": "experimental",
+   "presets": [
+    "document-compact",
+    "social-4x5",
+    "presentation-16x9"
+   ],
    "preferredPreset": "document-compact",
    "treatment": "flat",
+   "fontDelivery": "portable",
+   "preset": "document-compact",
+   "stress": [
+    {
+     "id": "approval-gate-stress-cardinality",
+     "path": "types/inputs/approval-gate.stress-cardinality.yaml",
+     "preset": "presentation-16x9",
+     "count": 4,
+     "geometryExpected": "fits",
+     "covers": [
+      "cardinality-max"
+     ],
+     "residualDisposition": {
+      "bottom": 484,
+      "reason": "A 4-node band exceeds the fluid preset width (680) so the preferred preset cannot be used — the vertical breathing is the cost of choosing a wider fixed preset."
+     }
+    },
+    {
+     "id": "approval-gate-stress-copy",
+     "path": "types/inputs/approval-gate.stress-copy.yaml",
+     "preset": "document-compact",
+     "count": 3,
+     "geometryExpected": "fits",
+     "covers": [
+      "copy-boundary-candidate",
+      "gate-caption"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "approval-gate-stress-degrade",
+     "path": "types/inputs/approval-gate.stress-degrade.yaml",
+     "preset": "social-4x5",
+     "count": 4,
+     "geometryExpected": "needs-split",
+     "covers": [
+      "cardinality-max",
+      "gate-caption",
+      "degrade-path"
+     ],
+     "residualDisposition": null
+    }
+   ],
+   "feasibility": [
+    {
+     "preset": "document-compact",
+     "orientation": "portrait",
+     "count": 4,
+     "layout": "row",
+     "result": "needs-split"
+    },
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 4,
+     "layout": "row",
+     "result": "needs-split"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 4,
+     "layout": "row",
+     "result": "fits"
+    }
+   ],
    "locales": {
     "ko": {
      "title": "요청은 승인 게이트를 지난다",
      "prompt": "요청이 승인 게이트를 지나 반영되는 경로를 보여줘. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.svg",
-     "png": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.png",
-     "receipt": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.json",
-     "svgDigest": "sha256:166a397c33345f406e9df710751b05bd5fe49db0616059111a26813448284563",
-     "pngDigest": "sha256:590a0906f4f12953b0905d57fa4d2d4f489520cfb5c76393de9ece386d27bc31",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "node-1",
       "node-2",
       "node-3",
       "gate-1"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.svg",
+     "svgDigest": "sha256:166a397c33345f406e9df710751b05bd5fe49db0616059111a26813448284563",
+     "receipt": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.png",
+      "digest": "sha256:590a0906f4f12953b0905d57fa4d2d4f489520cfb5c76393de9ece386d27bc31",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     },
     "en": {
      "title": "Requests pass an approval gate",
      "prompt": "A request passing an approval gate. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.svg",
-     "png": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.png",
-     "receipt": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.json",
-     "svgDigest": "sha256:9f1e8dd31082b30537ae9d22cacb731b27fd25fa0cf92b0c9f030681a4764e9b",
-     "pngDigest": "sha256:176ad2f0fac47379f2b1953c913f5cfc51863d002897b471fb8a1a541dbe384f",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "node-1",
       "node-2",
       "node-3",
       "gate-1"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.svg",
+     "svgDigest": "sha256:9f1e8dd31082b30537ae9d22cacb731b27fd25fa0cf92b0c9f030681a4764e9b",
+     "receipt": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.png",
+      "digest": "sha256:176ad2f0fac47379f2b1953c913f5cfc51863d002897b471fb8a1a541dbe384f",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     }
    }
   },
@@ -65,46 +154,120 @@
    "spec": "types/specs/before-after.md",
    "profile": "constrained-layout",
    "support": "experimental",
+   "presets": [
+    "document-compact",
+    "social-4x5",
+    "presentation-16x9"
+   ],
    "preferredPreset": "document-compact",
    "treatment": "flat",
+   "fontDelivery": "portable",
+   "preset": "document-compact",
+   "stress": [
+    {
+     "id": "before-after-stress-cardinality",
+     "path": "types/inputs/before-after.stress-cardinality.yaml",
+     "preset": "document-compact",
+     "count": 2,
+     "geometryExpected": "fits",
+     "covers": [
+      "cardinality-max",
+      "mirrored-slots"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "before-after-stress-copy",
+     "path": "types/inputs/before-after.stress-copy.yaml",
+     "preset": "document-compact",
+     "count": 2,
+     "geometryExpected": "fits",
+     "covers": [
+      "cardinality-max",
+      "copy-boundary-candidate"
+     ],
+     "residualDisposition": null
+    }
+   ],
+   "feasibility": [
+    {
+     "preset": "document-compact",
+     "orientation": "portrait",
+     "count": 2,
+     "layout": "row",
+     "result": "fits"
+    },
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 2,
+     "layout": "row",
+     "result": "fits"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 2,
+     "layout": "row",
+     "result": "fits"
+    }
+   ],
    "locales": {
     "ko": {
      "title": "자동화가 배포 시간을 줄였다",
      "prompt": "마이그레이션 전후를 두 항목으로 비교해줘. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/before-after/before-after.ko.svg",
-     "png": "examples/svg-infographic/typepacks/before-after/before-after.ko.png",
-     "receipt": "examples/svg-infographic/typepacks/before-after/before-after.ko.json",
-     "svgDigest": "sha256:e15b0bd322c545023f9383c815b68b71bede0d85b8e67b1c60c80f1fc410a5ee",
-     "pngDigest": "sha256:c5c4d1cfdfa55bf102a4dd202882250e8136ee522b0586a3fa4e20af153f98bb",
-     "consumed": [
-      "before",
-      "after"
-     ],
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
      "geometry": "fits",
+     "geometryExpected": "fits",
      "residual": {
       "top": 0,
       "bottom": 0
      },
-     "verified": true
+     "residualDisposition": null,
+     "consumed": [
+      "before",
+      "after"
+     ],
+     "svg": "examples/svg-infographic/typepacks/before-after/before-after.ko.svg",
+     "svgDigest": "sha256:e15b0bd322c545023f9383c815b68b71bede0d85b8e67b1c60c80f1fc410a5ee",
+     "receipt": "examples/svg-infographic/typepacks/before-after/before-after.ko.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/before-after/before-after.ko.png",
+      "digest": "sha256:c5c4d1cfdfa55bf102a4dd202882250e8136ee522b0586a3fa4e20af153f98bb",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     },
     "en": {
      "title": "Automation cut the delivery time",
      "prompt": "Compare before and after across two slots. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/before-after/before-after.en.svg",
-     "png": "examples/svg-infographic/typepacks/before-after/before-after.en.png",
-     "receipt": "examples/svg-infographic/typepacks/before-after/before-after.en.json",
-     "svgDigest": "sha256:f6d7bc171359e34ab9cba5f3fd4b43d196be42dd5ab7801595593d3136bb61a5",
-     "pngDigest": "sha256:2f787ee4d20cf183331f0b5f14ab31c3b2397e59d1ff3c050f06337b821037bc",
-     "consumed": [
-      "before",
-      "after"
-     ],
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
      "geometry": "fits",
+     "geometryExpected": "fits",
      "residual": {
       "top": 0,
       "bottom": 0
      },
-     "verified": true
+     "residualDisposition": null,
+     "consumed": [
+      "before",
+      "after"
+     ],
+     "svg": "examples/svg-infographic/typepacks/before-after/before-after.en.svg",
+     "svgDigest": "sha256:f6d7bc171359e34ab9cba5f3fd4b43d196be42dd5ab7801595593d3136bb61a5",
+     "receipt": "examples/svg-infographic/typepacks/before-after/before-after.en.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/before-after/before-after.en.png",
+      "digest": "sha256:2f787ee4d20cf183331f0b5f14ab31c3b2397e59d1ff3c050f06337b821037bc",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     }
    }
   },
@@ -114,50 +277,148 @@
    "spec": "types/specs/cards-kpi-grid.md",
    "profile": "constrained-layout",
    "support": "experimental",
+   "presets": [
+    "document-compact",
+    "social-4x5",
+    "presentation-16x9"
+   ],
    "preferredPreset": "document-compact",
    "treatment": "flat",
+   "fontDelivery": "portable",
+   "preset": "document-compact",
+   "stress": [
+    {
+     "id": "cards-kpi-grid-stress-cardinality",
+     "path": "types/inputs/cards-kpi-grid.stress-cardinality.yaml",
+     "preset": "document-compact",
+     "count": 6,
+     "geometryExpected": "fits",
+     "covers": [
+      "cardinality-max"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "cards-kpi-grid-stress-copy",
+     "path": "types/inputs/cards-kpi-grid.stress-copy.yaml",
+     "preset": "document-compact",
+     "count": 4,
+     "geometryExpected": "fits",
+     "covers": [
+      "copy-boundary-candidate"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "cards-kpi-grid-stress-degrade",
+     "path": "types/inputs/cards-kpi-grid.stress-degrade.yaml",
+     "preset": "social-4x5",
+     "count": 6,
+     "geometryExpected": "needs-split",
+     "covers": [
+      "cardinality-max",
+      "degrade-path"
+     ],
+     "residualDisposition": null
+    }
+   ],
+   "feasibility": [
+    {
+     "preset": "document-compact",
+     "orientation": "portrait",
+     "count": 6,
+     "layout": "grid",
+     "result": "fits"
+    },
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 6,
+     "layout": "grid",
+     "result": "fits"
+    },
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 6,
+     "layout": "row",
+     "result": "needs-split"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 6,
+     "layout": "grid",
+     "result": "fits"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 6,
+     "layout": "row",
+     "result": "fits"
+    }
+   ],
    "locales": {
     "ko": {
      "title": "핵심 4가지를 한눈에",
      "prompt": "핵심 4가지를 동등한 카드로 요약해줘. 소셜 포스트용 4:5 비율.",
-     "svg": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.svg",
-     "png": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.png",
-     "receipt": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.json",
-     "svgDigest": "sha256:016f3f30774aa45dbebd78418edd26bf0a729bd75a68bb568d6e0561369b83a7",
-     "pngDigest": "sha256:4c754a0208b2922c8d5844c1f282efedcef610bec53bf39ce9b969c2db8132f5",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "observability",
       "delivery",
       "cost",
       "security"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.svg",
+     "svgDigest": "sha256:016f3f30774aa45dbebd78418edd26bf0a729bd75a68bb568d6e0561369b83a7",
+     "receipt": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.png",
+      "digest": "sha256:4c754a0208b2922c8d5844c1f282efedcef610bec53bf39ce9b969c2db8132f5",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     },
     "en": {
      "title": "Four key points at a glance",
      "prompt": "Summarise the four key points as equal cards, 4:5 social post.",
-     "svg": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.svg",
-     "png": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.png",
-     "receipt": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.json",
-     "svgDigest": "sha256:33fec63cada3ba543471a59b08c226f3d8f11e5fb5f24450ba9575687d5fe243",
-     "pngDigest": "sha256:697e277b0da4a6ceef5f069e2ce10cc1afce8a39a7a5837a1ca934b1ce9a8888",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "observability",
       "delivery",
       "cost",
       "security"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.svg",
+     "svgDigest": "sha256:33fec63cada3ba543471a59b08c226f3d8f11e5fb5f24450ba9575687d5fe243",
+     "receipt": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.png",
+      "digest": "sha256:697e277b0da4a6ceef5f069e2ce10cc1afce8a39a7a5837a1ca934b1ce9a8888",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     }
    }
   },
@@ -167,50 +428,137 @@
    "spec": "types/specs/decision-matrix.md",
    "profile": "constrained-layout",
    "support": "experimental",
+   "presets": [
+    "document-compact",
+    "social-4x5",
+    "presentation-16x9"
+   ],
    "preferredPreset": "document-compact",
    "treatment": "flat",
+   "fontDelivery": "portable",
+   "preset": "document-compact",
+   "stress": [
+    {
+     "id": "decision-matrix-stress-cardinality",
+     "path": "types/inputs/decision-matrix.stress-cardinality.yaml",
+     "preset": "presentation-16x9",
+     "count": 9,
+     "geometryExpected": "fits",
+     "covers": [
+      "cardinality-max"
+     ],
+     "residualDisposition": {
+      "bottom": 358,
+      "reason": "With the axis reservation included a 3x3 grid exceeds the fluid width — leaving 16:9 as the only declared preset wide enough. Cell height is set by content and never stretched to fill the canvas — this vertical space is the cost of gaining width."
+     }
+    },
+    {
+     "id": "decision-matrix-stress-degrade",
+     "path": "types/inputs/decision-matrix.stress-degrade.yaml",
+     "preset": "document-compact",
+     "count": 9,
+     "geometryExpected": "needs-split",
+     "covers": [
+      "cardinality-max",
+      "degrade-path"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "decision-matrix-stress-copy",
+     "path": "types/inputs/decision-matrix.stress-copy.yaml",
+     "preset": "document-compact",
+     "count": 4,
+     "geometryExpected": "fits",
+     "covers": [
+      "copy-boundary-candidate"
+     ],
+     "residualDisposition": null
+    }
+   ],
+   "feasibility": [
+    {
+     "preset": "document-compact",
+     "orientation": "portrait",
+     "count": 9,
+     "layout": "grid",
+     "result": "needs-split"
+    },
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 9,
+     "layout": "grid",
+     "result": "fits"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 9,
+     "layout": "grid",
+     "result": "fits"
+    }
+   ],
    "locales": {
     "ko": {
      "title": "두 축이 우선순위를 정한다",
      "prompt": "두 축으로 옵션을 2×2 사분면에 배치해줘. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.svg",
-     "png": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.png",
-     "receipt": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.json",
-     "svgDigest": "sha256:1c6c06d5c73694d89fa5c63602083cab3940e5395a3dcaa7ac4cf9a593d0d99b",
-     "pngDigest": "sha256:8027994556216b8a4b469ff9acbd8f910a761fb4712dcda5d2de9d9fce6e126d",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "cell-1",
       "cell-2",
       "cell-3",
       "cell-4"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.svg",
+     "svgDigest": "sha256:1c6c06d5c73694d89fa5c63602083cab3940e5395a3dcaa7ac4cf9a593d0d99b",
+     "receipt": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.png",
+      "digest": "sha256:8027994556216b8a4b469ff9acbd8f910a761fb4712dcda5d2de9d9fce6e126d",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     },
     "en": {
      "title": "Two axes set the priority",
      "prompt": "Place options in a 2×2 matrix. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.svg",
-     "png": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.png",
-     "receipt": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.json",
-     "svgDigest": "sha256:d29504aed3cf3aa04f541ba0127095b9ca7287d736477b115a288ef62782aa25",
-     "pngDigest": "sha256:e56448f49b399c31f312a777a1529dc195e40c70cd286ea218a235b190102908",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "cell-1",
       "cell-2",
       "cell-3",
       "cell-4"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.svg",
+     "svgDigest": "sha256:d29504aed3cf3aa04f541ba0127095b9ca7287d736477b115a288ef62782aa25",
+     "receipt": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.png",
+      "digest": "sha256:e56448f49b399c31f312a777a1529dc195e40c70cd286ea218a235b190102908",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     }
    }
   },
@@ -220,17 +568,114 @@
    "spec": "types/specs/layer-stack.md",
    "profile": "constrained-layout",
    "support": "experimental",
+   "presets": [
+    "document-compact",
+    "social-4x5",
+    "presentation-16x9"
+   ],
    "preferredPreset": "document-compact",
    "treatment": "flat",
+   "fontDelivery": "portable",
+   "preset": "document-compact",
+   "stress": [
+    {
+     "id": "layer-stack-stress-cardinality",
+     "path": "types/inputs/layer-stack.stress-cardinality.yaml",
+     "preset": "presentation-16x9",
+     "count": 5,
+     "geometryExpected": "fits",
+     "covers": [
+      "cardinality-max",
+      "chips-max"
+     ],
+     "residualDisposition": {
+      "bottom": 132,
+      "reason": "\\\"Vertical breathing left over from choosing a wider landscape preset to hold four chips — the band is not stretched to fill it.\\\""
+     }
+    },
+    {
+     "id": "layer-stack-stress-copy",
+     "path": "types/inputs/layer-stack.stress-copy.yaml",
+     "preset": "document-compact",
+     "count": 4,
+     "geometryExpected": "fits",
+     "covers": [
+      "copy-boundary-candidate"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "layer-stack-stress-degrade",
+     "path": "types/inputs/layer-stack.stress-degrade.yaml",
+     "preset": "social-4x5",
+     "count": 5,
+     "geometryExpected": "needs-split",
+     "covers": [
+      "cardinality-max",
+      "chips-max",
+      "degrade-path"
+     ],
+     "residualDisposition": null
+    }
+   ],
+   "feasibility": [
+    {
+     "preset": "document-compact",
+     "orientation": "portrait",
+     "count": 5,
+     "layout": "column",
+     "result": "fits"
+    },
+    {
+     "preset": "document-compact",
+     "orientation": "portrait",
+     "count": 5,
+     "layout": "column",
+     "result": "needs-split"
+    },
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 5,
+     "layout": "column",
+     "result": "fits"
+    },
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 5,
+     "layout": "column",
+     "result": "needs-split"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 5,
+     "layout": "column",
+     "result": "fits"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 5,
+     "layout": "column",
+     "result": "fits"
+    }
+   ],
    "locales": {
     "ko": {
      "title": "플랫폼 역량은 층으로 쌓인다",
      "prompt": "플랫폼 역량을 4개 계층으로 쌓아서 보여줘. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.svg",
-     "png": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.png",
-     "receipt": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.json",
-     "svgDigest": "sha256:9d84f282db9f8055891d3659fce3aec5dc4e28b7bf90eaee1d3af04ca2af2f76",
-     "pngDigest": "sha256:db1abf971502ac2ca523a9510159b11e4b672d84c4fb321fb5d1382486b500b8",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "layer-1",
       "layer-1-chip-1",
@@ -245,21 +690,30 @@
       "layer-4-chip-1",
       "layer-4-chip-2"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.svg",
+     "svgDigest": "sha256:9d84f282db9f8055891d3659fce3aec5dc4e28b7bf90eaee1d3af04ca2af2f76",
+     "receipt": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.png",
+      "digest": "sha256:db1abf971502ac2ca523a9510159b11e4b672d84c4fb321fb5d1382486b500b8",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     },
     "en": {
      "title": "Platform capability stacks in layers",
      "prompt": "Show the platform capability as four stacked layers. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.svg",
-     "png": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.png",
-     "receipt": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.json",
-     "svgDigest": "sha256:8bd40672c183d3bf17d67039f33d4d451a5e33d7fcd34986af855458ca1fa152",
-     "pngDigest": "sha256:d076a3a6245f4c0f1db383b5fb5bbf5d505b5d9e2788bec563d746a258650978",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "layer-1",
       "layer-1-chip-1",
@@ -274,12 +728,16 @@
       "layer-4-chip-1",
       "layer-4-chip-2"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.svg",
+     "svgDigest": "sha256:8bd40672c183d3bf17d67039f33d4d451a5e33d7fcd34986af855458ca1fa152",
+     "receipt": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.png",
+      "digest": "sha256:d076a3a6245f4c0f1db383b5fb5bbf5d505b5d9e2788bec563d746a258650978",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     }
    }
   },
@@ -289,48 +747,121 @@
    "spec": "types/specs/nested-scope.md",
    "profile": "constrained-layout",
    "support": "experimental",
+   "presets": [
+    "document-compact",
+    "social-4x5",
+    "presentation-16x9"
+   ],
    "preferredPreset": "document-compact",
    "treatment": "flat",
+   "fontDelivery": "portable",
+   "preset": "document-compact",
+   "stress": [
+    {
+     "id": "nested-scope-stress-cardinality",
+     "path": "types/inputs/nested-scope.stress-cardinality.yaml",
+     "preset": "document-compact",
+     "count": 4,
+     "geometryExpected": "fits",
+     "covers": [
+      "cardinality-max",
+      "containment-depth"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "nested-scope-stress-copy",
+     "path": "types/inputs/nested-scope.stress-copy.yaml",
+     "preset": "document-compact",
+     "count": 3,
+     "geometryExpected": "fits",
+     "covers": [
+      "copy-boundary-candidate"
+     ],
+     "residualDisposition": null
+    }
+   ],
+   "feasibility": [
+    {
+     "preset": "document-compact",
+     "orientation": "portrait",
+     "count": 4,
+     "layout": "concentric",
+     "result": "fits"
+    },
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 4,
+     "layout": "concentric",
+     "result": "fits"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 4,
+     "layout": "concentric",
+     "result": "fits"
+    }
+   ],
    "locales": {
     "ko": {
      "title": "신뢰 경계는 안쪽일수록 좁다",
      "prompt": "신뢰 경계를 3겹 동심 구조로 보여줘. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.svg",
-     "png": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.png",
-     "receipt": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.json",
-     "svgDigest": "sha256:f7938cfdca961c6d3fbc145b69f1140c4fd9ae4145ae93c03ba83b8529a305eb",
-     "pngDigest": "sha256:4da96b21c365503d51f2930e7b69cba2a54d9190004e01ab302c9e5c0eae9480",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "ring-1",
       "ring-2",
       "ring-3"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.svg",
+     "svgDigest": "sha256:f7938cfdca961c6d3fbc145b69f1140c4fd9ae4145ae93c03ba83b8529a305eb",
+     "receipt": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.png",
+      "digest": "sha256:4da96b21c365503d51f2930e7b69cba2a54d9190004e01ab302c9e5c0eae9480",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     },
     "en": {
      "title": "Trust narrows toward the core",
      "prompt": "Show the trust boundary as 3 concentric scopes. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.svg",
-     "png": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.png",
-     "receipt": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.json",
-     "svgDigest": "sha256:e9d4aff3855882f3750d79d7b61f64d114cea26b597567af4ffeb8b003220d70",
-     "pngDigest": "sha256:a6b7c710d7982d59125cf39173a1c71e583fea73334bb3597586019d07feeac7",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "ring-1",
       "ring-2",
       "ring-3"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.svg",
+     "svgDigest": "sha256:e9d4aff3855882f3750d79d7b61f64d114cea26b597567af4ffeb8b003220d70",
+     "receipt": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.png",
+      "digest": "sha256:a6b7c710d7982d59125cf39173a1c71e583fea73334bb3597586019d07feeac7",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     }
    }
   },
@@ -340,50 +871,148 @@
    "spec": "types/specs/process-flow.md",
    "profile": "constrained-layout",
    "support": "experimental",
+   "presets": [
+    "document-compact",
+    "social-4x5",
+    "presentation-16x9"
+   ],
    "preferredPreset": "document-compact",
    "treatment": "flat",
+   "fontDelivery": "portable",
+   "preset": "document-compact",
+   "stress": [
+    {
+     "id": "process-flow-stress-cardinality",
+     "path": "types/inputs/process-flow.stress-cardinality.yaml",
+     "preset": "document-compact",
+     "count": 5,
+     "geometryExpected": "fits",
+     "covers": [
+      "cardinality-max"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "process-flow-stress-copy",
+     "path": "types/inputs/process-flow.stress-copy.yaml",
+     "preset": "document-compact",
+     "count": 4,
+     "geometryExpected": "fits",
+     "covers": [
+      "copy-boundary-candidate"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "process-flow-stress-degrade",
+     "path": "types/inputs/process-flow.stress-degrade.yaml",
+     "preset": "social-4x5",
+     "count": 5,
+     "geometryExpected": "needs-split",
+     "covers": [
+      "cardinality-max",
+      "degrade-path"
+     ],
+     "residualDisposition": null
+    }
+   ],
+   "feasibility": [
+    {
+     "preset": "document-compact",
+     "orientation": "portrait",
+     "count": 5,
+     "layout": "column",
+     "result": "fits"
+    },
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 5,
+     "layout": "row",
+     "result": "needs-split"
+    },
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 5,
+     "layout": "column",
+     "result": "fits"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 5,
+     "layout": "row",
+     "result": "fits"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 5,
+     "layout": "column",
+     "result": "fits"
+    }
+   ],
    "locales": {
     "ko": {
      "title": "배포는 검증을 지나 반영된다",
      "prompt": "배포 절차를 4단계로 위에서 아래로 보여줘. 4:5 세로.",
-     "svg": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.svg",
-     "png": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.png",
-     "receipt": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.json",
-     "svgDigest": "sha256:82534f5de711142cd0520345352bf67749d8c38b1175724a145c23164ec84acf",
-     "pngDigest": "sha256:e23f8c583f482b86946e177ecef8818d6a126a643b691cfbaf34b635be2eb8ae",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "step-1",
       "step-2",
       "step-3",
       "step-4"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.svg",
+     "svgDigest": "sha256:82534f5de711142cd0520345352bf67749d8c38b1175724a145c23164ec84acf",
+     "receipt": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.png",
+      "digest": "sha256:e23f8c583f482b86946e177ecef8818d6a126a643b691cfbaf34b635be2eb8ae",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     },
     "en": {
      "title": "Delivery ships through verification",
      "prompt": "Four top-to-bottom delivery steps. 4:5 portrait.",
-     "svg": "examples/svg-infographic/typepacks/process-flow/process-flow.en.svg",
-     "png": "examples/svg-infographic/typepacks/process-flow/process-flow.en.png",
-     "receipt": "examples/svg-infographic/typepacks/process-flow/process-flow.en.json",
-     "svgDigest": "sha256:d8b09a5dcfdd2e63c91ba2cc9b52b049f71a9fa054bb285992760db5756d0173",
-     "pngDigest": "sha256:59f6fdce18ea8eb42068a8dd877a23e97965067f18248ccf924d57b3bed90871",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "step-1",
       "step-2",
       "step-3",
       "step-4"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/process-flow/process-flow.en.svg",
+     "svgDigest": "sha256:d8b09a5dcfdd2e63c91ba2cc9b52b049f71a9fa054bb285992760db5756d0173",
+     "receipt": "examples/svg-infographic/typepacks/process-flow/process-flow.en.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/process-flow/process-flow.en.png",
+      "digest": "sha256:59f6fdce18ea8eb42068a8dd877a23e97965067f18248ccf924d57b3bed90871",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     }
    }
   },
@@ -393,50 +1022,165 @@
    "spec": "types/specs/roadmap-timeline.md",
    "profile": "constrained-layout",
    "support": "experimental",
+   "presets": [
+    "document-compact",
+    "social-4x5",
+    "presentation-16x9"
+   ],
    "preferredPreset": "document-compact",
    "treatment": "flat",
+   "fontDelivery": "portable",
+   "preset": "document-compact",
+   "stress": [
+    {
+     "id": "roadmap-timeline-stress-cardinality",
+     "path": "types/inputs/roadmap-timeline.stress-cardinality.yaml",
+     "preset": "presentation-16x9",
+     "count": 5,
+     "geometryExpected": "fits",
+     "covers": [
+      "cardinality-max",
+      "status-and-marker"
+     ],
+     "residualDisposition": {
+      "bottom": 501,
+      "reason": "A timeline is a structurally thin band. Five phases need 16:9 for width — and the band is never stretched to the canvas height — so this vertical space is left over."
+     }
+    },
+    {
+     "id": "roadmap-timeline-stress-body",
+     "path": "types/inputs/roadmap-timeline.stress-body.yaml",
+     "preset": "document-compact",
+     "count": 4,
+     "geometryExpected": "fits",
+     "covers": [
+      "status-and-marker"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "roadmap-timeline-stress-tail-current",
+     "path": "types/inputs/roadmap-timeline.stress-tail-current.yaml",
+     "preset": "document-compact",
+     "count": 4,
+     "geometryExpected": "fits",
+     "covers": [
+      "terminal-current"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "roadmap-timeline-stress-copy",
+     "path": "types/inputs/roadmap-timeline.stress-copy.yaml",
+     "preset": "presentation-16x9",
+     "count": 4,
+     "geometryExpected": "fits",
+     "covers": [
+      "copy-boundary-candidate",
+      "status-and-marker"
+     ],
+     "residualDisposition": {
+      "bottom": 501,
+      "reason": "Long titles leave 16:9 as the only preset wide enough. The band height is set by content and is never stretched to fill the canvas."
+     }
+    },
+    {
+     "id": "roadmap-timeline-stress-degrade",
+     "path": "types/inputs/roadmap-timeline.stress-degrade.yaml",
+     "preset": "document-compact",
+     "count": 5,
+     "geometryExpected": "needs-split",
+     "covers": [
+      "cardinality-max",
+      "status-and-marker",
+      "degrade-path"
+     ],
+     "residualDisposition": null
+    }
+   ],
+   "feasibility": [
+    {
+     "preset": "document-compact",
+     "orientation": "portrait",
+     "count": 5,
+     "layout": "row",
+     "result": "needs-split"
+    },
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 5,
+     "layout": "row",
+     "result": "needs-split"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 5,
+     "layout": "row",
+     "result": "fits"
+    }
+   ],
    "locales": {
     "ko": {
      "title": "롤아웃은 단계로 진행한다",
      "prompt": "롤아웃을 4개 단계로 마일스톤 카드와 함께 보여줘. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.svg",
-     "png": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.png",
-     "receipt": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.json",
-     "svgDigest": "sha256:a4ff21b816ed5d08a383378af4b37e0cd5fd46629690b08273fd717fff1d0b6f",
-     "pngDigest": "sha256:d0487c41a418f011ee6ad72ca87bc8f300918ce4ae7f67aca4bc960a18837e4c",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "phase-1",
       "phase-2",
       "phase-3",
       "phase-4"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.svg",
+     "svgDigest": "sha256:a4ff21b816ed5d08a383378af4b37e0cd5fd46629690b08273fd717fff1d0b6f",
+     "receipt": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.png",
+      "digest": "sha256:d0487c41a418f011ee6ad72ca87bc8f300918ce4ae7f67aca4bc960a18837e4c",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     },
     "en": {
      "title": "The rollout proceeds in phases",
      "prompt": "Four rollout phases with milestone cards. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.svg",
-     "png": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.png",
-     "receipt": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.json",
-     "svgDigest": "sha256:500867f18825febe5413be4370226b9f8f74e8ab51d0fd33ef3454445b1a6fe5",
-     "pngDigest": "sha256:5d56d66234881e0a4f37b0fbe2bc3f77da79f270b64686eed7d932f11d4d94b0",
+     "preset": "document-compact",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "residualDisposition": null,
      "consumed": [
       "phase-1",
       "phase-2",
       "phase-3",
       "phase-4"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 0
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.svg",
+     "svgDigest": "sha256:500867f18825febe5413be4370226b9f8f74e8ab51d0fd33ef3454445b1a6fe5",
+     "receipt": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.png",
+      "digest": "sha256:5d56d66234881e0a4f37b0fbe2bc3f77da79f270b64686eed7d932f11d4d94b0",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     }
    }
   },
@@ -446,17 +1190,85 @@
    "spec": "types/specs/topology-component.md",
    "profile": "editorial-composition",
    "support": "experimental",
+   "presets": [
+    "social-4x5",
+    "presentation-16x9"
+   ],
    "preferredPreset": "social-4x5",
    "treatment": "flat",
+   "fontDelivery": "portable",
+   "preset": "social-4x5",
+   "stress": [
+    {
+     "id": "topology-component-stress-cardinality",
+     "path": "types/inputs/topology-component.stress-cardinality.yaml",
+     "preset": "social-4x5",
+     "count": 4,
+     "geometryExpected": "fits",
+     "covers": [
+      "cardinality-max",
+      "edge-density"
+     ],
+     "residualDisposition": null
+    },
+    {
+     "id": "topology-component-stress-copy",
+     "path": "types/inputs/topology-component.stress-copy.yaml",
+     "preset": "social-4x5",
+     "count": 3,
+     "geometryExpected": "fits",
+     "covers": [
+      "copy-boundary-candidate"
+     ],
+     "residualDisposition": {
+      "bottom": 194,
+      "reason": "Even at the copy boundary the zone height derives from node geometry — so the residual is unchanged."
+     }
+    }
+   ],
+   "feasibility": [
+    {
+     "preset": "social-4x5",
+     "orientation": "portrait",
+     "count": 4,
+     "layout": "zones",
+     "result": "fits"
+    },
+    {
+     "preset": "presentation-16x9",
+     "orientation": "landscape",
+     "count": 4,
+     "layout": "zones",
+     "result": "fits"
+    }
+   ],
    "locales": {
     "ko": {
      "title": "요청은 zone을 따라 흐른다",
      "prompt": "요청 경로를 3개 zone으로 나눠 컴포넌트와 연결을 보여줘. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.svg",
-     "png": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.png",
-     "receipt": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.json",
-     "svgDigest": "sha256:308a08f6ed81c8d93da91aeb94aeca632df665214f8a49d5e913189363cbd0b1",
-     "pngDigest": "sha256:81db3828ccbb6c5b1c270c9028a432c2a2e57a931876e449f0afee4a0fb548ca",
+     "preset": "social-4x5",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 194
+     },
+     "residualDisposition": {
+      "reason": "Zone height derives from node geometry and corridors open only as far as routing demand requires — the remaining space is declared breathing (kernel §8).",
+      "by_treatment": [
+       {
+        "treatment": "flat",
+        "bottom": 194
+       },
+       {
+        "treatment": "sketch",
+        "calibration": "hi-melody-optical-v1",
+        "bottom": 93
+       }
+      ]
+     },
      "consumed": [
       "zone-1",
       "gw",
@@ -471,21 +1283,43 @@
       "e2",
       "boundary"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 194
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.svg",
+     "svgDigest": "sha256:308a08f6ed81c8d93da91aeb94aeca632df665214f8a49d5e913189363cbd0b1",
+     "receipt": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.png",
+      "digest": "sha256:81db3828ccbb6c5b1c270c9028a432c2a2e57a931876e449f0afee4a0fb548ca",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     },
     "en": {
      "title": "Requests flow across the zones",
      "prompt": "Show the request path across three zones with components and links. 4:5.",
-     "svg": "examples/svg-infographic/typepacks/topology-component/topology-component.en.svg",
-     "png": "examples/svg-infographic/typepacks/topology-component/topology-component.en.png",
-     "receipt": "examples/svg-infographic/typepacks/topology-component/topology-component.en.json",
-     "svgDigest": "sha256:eef5808edf3e5c021e70b82d9bae2edc8831d0ce31bb75aff819a90fd5de7cc7",
-     "pngDigest": "sha256:6bdac61d7a1c009f8c7565faeb7da53b8d065a9c23f49b7e82dcdd5d4bd5eed2",
+     "preset": "social-4x5",
+     "treatment": "flat",
+     "fontDelivery": "portable",
+     "geometry": "fits",
+     "geometryExpected": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 194
+     },
+     "residualDisposition": {
+      "reason": "Zone height derives from node geometry and corridors open only as far as routing demand requires — the remaining space is declared breathing (kernel §8).",
+      "by_treatment": [
+       {
+        "treatment": "flat",
+        "bottom": 194
+       },
+       {
+        "treatment": "sketch",
+        "calibration": "hi-melody-optical-v1",
+        "bottom": 93
+       }
+      ]
+     },
      "consumed": [
       "zone-1",
       "gw",
@@ -500,12 +1334,16 @@
       "e2",
       "boundary"
      ],
-     "geometry": "fits",
-     "residual": {
-      "top": 0,
-      "bottom": 194
-     },
-     "verified": true
+     "svg": "examples/svg-infographic/typepacks/topology-component/topology-component.en.svg",
+     "svgDigest": "sha256:eef5808edf3e5c021e70b82d9bae2edc8831d0ce31bb75aff819a90fd5de7cc7",
+     "receipt": "examples/svg-infographic/typepacks/topology-component/topology-component.en.json",
+     "verified": true,
+     "png": {
+      "path": "examples/svg-infographic/typepacks/topology-component/topology-component.en.png",
+      "digest": "sha256:6bdac61d7a1c009f8c7565faeb7da53b8d065a9c23f49b7e82dcdd5d4bd5eed2",
+      "verified": null,
+      "note": "render of the verified SVG; not itself re-verified"
+     }
     }
    }
   }

--- a/gallery/model.json
+++ b/gallery/model.json
@@ -1,0 +1,513 @@
+{
+ "schemaVersion": 1,
+ "generatedBy": "skillstead_validate gallery",
+ "note": "Generated view. Every field is owned by the manifest, an input payload, a receipt or an artifact — this file is authority for none of them.",
+ "runtimeSurfaceDigest": "sha256:31f5af7ae5643fbc58d0883729b2e4fe30377bb21ce72a4fe527982d99a41401",
+ "tokens": "gallery/tokens.json",
+ "typepackCount": 9,
+ "typepacks": [
+  {
+   "id": "approval-gate",
+   "selectionSignal": "A simple request path with one approval gate or checkpoint (a->b->c; a full sequence diagram is out of scope)",
+   "spec": "types/specs/approval-gate.md",
+   "profile": "constrained-layout",
+   "support": "experimental",
+   "preferredPreset": "document-compact",
+   "treatment": "flat",
+   "locales": {
+    "ko": {
+     "title": "요청은 승인 게이트를 지난다",
+     "prompt": "요청이 승인 게이트를 지나 반영되는 경로를 보여줘. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.svg",
+     "png": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.png",
+     "receipt": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.json",
+     "svgDigest": "sha256:166a397c33345f406e9df710751b05bd5fe49db0616059111a26813448284563",
+     "pngDigest": "sha256:590a0906f4f12953b0905d57fa4d2d4f489520cfb5c76393de9ece386d27bc31",
+     "consumed": [
+      "node-1",
+      "node-2",
+      "node-3",
+      "gate-1"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    },
+    "en": {
+     "title": "Requests pass an approval gate",
+     "prompt": "A request passing an approval gate. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.svg",
+     "png": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.png",
+     "receipt": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.json",
+     "svgDigest": "sha256:9f1e8dd31082b30537ae9d22cacb731b27fd25fa0cf92b0c9f030681a4764e9b",
+     "pngDigest": "sha256:176ad2f0fac47379f2b1953c913f5cfc51863d002897b471fb8a1a541dbe384f",
+     "consumed": [
+      "node-1",
+      "node-2",
+      "node-3",
+      "gate-1"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    }
+   }
+  },
+  {
+   "id": "before-after",
+   "selectionSignal": "Before and after — migration, modernisation, refactor outcome, trade-off comparison",
+   "spec": "types/specs/before-after.md",
+   "profile": "constrained-layout",
+   "support": "experimental",
+   "preferredPreset": "document-compact",
+   "treatment": "flat",
+   "locales": {
+    "ko": {
+     "title": "자동화가 배포 시간을 줄였다",
+     "prompt": "마이그레이션 전후를 두 항목으로 비교해줘. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/before-after/before-after.ko.svg",
+     "png": "examples/svg-infographic/typepacks/before-after/before-after.ko.png",
+     "receipt": "examples/svg-infographic/typepacks/before-after/before-after.ko.json",
+     "svgDigest": "sha256:e15b0bd322c545023f9383c815b68b71bede0d85b8e67b1c60c80f1fc410a5ee",
+     "pngDigest": "sha256:c5c4d1cfdfa55bf102a4dd202882250e8136ee522b0586a3fa4e20af153f98bb",
+     "consumed": [
+      "before",
+      "after"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    },
+    "en": {
+     "title": "Automation cut the delivery time",
+     "prompt": "Compare before and after across two slots. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/before-after/before-after.en.svg",
+     "png": "examples/svg-infographic/typepacks/before-after/before-after.en.png",
+     "receipt": "examples/svg-infographic/typepacks/before-after/before-after.en.json",
+     "svgDigest": "sha256:f6d7bc171359e34ab9cba5f3fd4b43d196be42dd5ab7801595593d3136bb61a5",
+     "pngDigest": "sha256:2f787ee4d20cf183331f0b5f14ab31c3b2397e59d1ff3c050f06337b821037bc",
+     "consumed": [
+      "before",
+      "after"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    }
+   }
+  },
+  {
+   "id": "cards-kpi-grid",
+   "selectionSignal": "A few key items or figures summarised as equal cards (feature highlights, principles, status counts, capability summaries; not a chart claiming data accuracy)",
+   "spec": "types/specs/cards-kpi-grid.md",
+   "profile": "constrained-layout",
+   "support": "experimental",
+   "preferredPreset": "document-compact",
+   "treatment": "flat",
+   "locales": {
+    "ko": {
+     "title": "핵심 4가지를 한눈에",
+     "prompt": "핵심 4가지를 동등한 카드로 요약해줘. 소셜 포스트용 4:5 비율.",
+     "svg": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.svg",
+     "png": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.png",
+     "receipt": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.json",
+     "svgDigest": "sha256:016f3f30774aa45dbebd78418edd26bf0a729bd75a68bb568d6e0561369b83a7",
+     "pngDigest": "sha256:4c754a0208b2922c8d5844c1f282efedcef610bec53bf39ce9b969c2db8132f5",
+     "consumed": [
+      "observability",
+      "delivery",
+      "cost",
+      "security"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    },
+    "en": {
+     "title": "Four key points at a glance",
+     "prompt": "Summarise the four key points as equal cards, 4:5 social post.",
+     "svg": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.svg",
+     "png": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.png",
+     "receipt": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.json",
+     "svgDigest": "sha256:33fec63cada3ba543471a59b08c226f3d8f11e5fb5f24450ba9575687d5fe243",
+     "pngDigest": "sha256:697e277b0da4a6ceef5f069e2ce10cc1afce8a39a7a5837a1ca934b1ce9a8888",
+     "consumed": [
+      "observability",
+      "delivery",
+      "cost",
+      "security"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    }
+   }
+  },
+  {
+   "id": "decision-matrix",
+   "selectionSignal": "Options or items placed by two qualitative axes — a 2x2 priority/decision quadrant, a 3x3 risk grid",
+   "spec": "types/specs/decision-matrix.md",
+   "profile": "constrained-layout",
+   "support": "experimental",
+   "preferredPreset": "document-compact",
+   "treatment": "flat",
+   "locales": {
+    "ko": {
+     "title": "두 축이 우선순위를 정한다",
+     "prompt": "두 축으로 옵션을 2×2 사분면에 배치해줘. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.svg",
+     "png": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.png",
+     "receipt": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.json",
+     "svgDigest": "sha256:1c6c06d5c73694d89fa5c63602083cab3940e5395a3dcaa7ac4cf9a593d0d99b",
+     "pngDigest": "sha256:8027994556216b8a4b469ff9acbd8f910a761fb4712dcda5d2de9d9fce6e126d",
+     "consumed": [
+      "cell-1",
+      "cell-2",
+      "cell-3",
+      "cell-4"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    },
+    "en": {
+     "title": "Two axes set the priority",
+     "prompt": "Place options in a 2×2 matrix. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.svg",
+     "png": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.png",
+     "receipt": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.json",
+     "svgDigest": "sha256:d29504aed3cf3aa04f541ba0127095b9ca7287d736477b115a288ef62782aa25",
+     "pngDigest": "sha256:e56448f49b399c31f312a777a1529dc195e40c70cd286ea218a235b190102908",
+     "consumed": [
+      "cell-1",
+      "cell-2",
+      "cell-3",
+      "cell-4"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    }
+   }
+  },
+  {
+   "id": "layer-stack",
+   "selectionSignal": "A hierarchy that stacks on or abstracts the layer beneath it (platform stacks, runtime layers, capability models)",
+   "spec": "types/specs/layer-stack.md",
+   "profile": "constrained-layout",
+   "support": "experimental",
+   "preferredPreset": "document-compact",
+   "treatment": "flat",
+   "locales": {
+    "ko": {
+     "title": "플랫폼 역량은 층으로 쌓인다",
+     "prompt": "플랫폼 역량을 4개 계층으로 쌓아서 보여줘. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.svg",
+     "png": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.png",
+     "receipt": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.json",
+     "svgDigest": "sha256:9d84f282db9f8055891d3659fce3aec5dc4e28b7bf90eaee1d3af04ca2af2f76",
+     "pngDigest": "sha256:db1abf971502ac2ca523a9510159b11e4b672d84c4fb321fb5d1382486b500b8",
+     "consumed": [
+      "layer-1",
+      "layer-1-chip-1",
+      "layer-1-chip-2",
+      "layer-2",
+      "layer-2-chip-1",
+      "layer-2-chip-2",
+      "layer-3",
+      "layer-3-chip-1",
+      "layer-3-chip-2",
+      "layer-4",
+      "layer-4-chip-1",
+      "layer-4-chip-2"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    },
+    "en": {
+     "title": "Platform capability stacks in layers",
+     "prompt": "Show the platform capability as four stacked layers. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.svg",
+     "png": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.png",
+     "receipt": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.json",
+     "svgDigest": "sha256:8bd40672c183d3bf17d67039f33d4d451a5e33d7fcd34986af855458ca1fa152",
+     "pngDigest": "sha256:d076a3a6245f4c0f1db383b5fb5bbf5d505b5d9e2788bec563d746a258650978",
+     "consumed": [
+      "layer-1",
+      "layer-1-chip-1",
+      "layer-1-chip-2",
+      "layer-2",
+      "layer-2-chip-1",
+      "layer-2-chip-2",
+      "layer-3",
+      "layer-3-chip-1",
+      "layer-3-chip-2",
+      "layer-4",
+      "layer-4-chip-1",
+      "layer-4-chip-2"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    }
+   }
+  },
+  {
+   "id": "nested-scope",
+   "selectionSignal": "Containment and scope — the inner lives inside the outer (trust zones, scope rings, platform -> app -> feature)",
+   "spec": "types/specs/nested-scope.md",
+   "profile": "constrained-layout",
+   "support": "experimental",
+   "preferredPreset": "document-compact",
+   "treatment": "flat",
+   "locales": {
+    "ko": {
+     "title": "신뢰 경계는 안쪽일수록 좁다",
+     "prompt": "신뢰 경계를 3겹 동심 구조로 보여줘. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.svg",
+     "png": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.png",
+     "receipt": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.json",
+     "svgDigest": "sha256:f7938cfdca961c6d3fbc145b69f1140c4fd9ae4145ae93c03ba83b8529a305eb",
+     "pngDigest": "sha256:4da96b21c365503d51f2930e7b69cba2a54d9190004e01ab302c9e5c0eae9480",
+     "consumed": [
+      "ring-1",
+      "ring-2",
+      "ring-3"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    },
+    "en": {
+     "title": "Trust narrows toward the core",
+     "prompt": "Show the trust boundary as 3 concentric scopes. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.svg",
+     "png": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.png",
+     "receipt": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.json",
+     "svgDigest": "sha256:e9d4aff3855882f3750d79d7b61f64d114cea26b597567af4ffeb8b003220d70",
+     "pngDigest": "sha256:a6b7c710d7982d59125cf39173a1c71e583fea73334bb3597586019d07feeac7",
+     "consumed": [
+      "ring-1",
+      "ring-2",
+      "ring-3"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    }
+   }
+  },
+  {
+   "id": "process-flow",
+   "selectionSignal": "Ordered steps or handoffs — processes, pipelines, data flows, review loops",
+   "spec": "types/specs/process-flow.md",
+   "profile": "constrained-layout",
+   "support": "experimental",
+   "preferredPreset": "document-compact",
+   "treatment": "flat",
+   "locales": {
+    "ko": {
+     "title": "배포는 검증을 지나 반영된다",
+     "prompt": "배포 절차를 4단계로 위에서 아래로 보여줘. 4:5 세로.",
+     "svg": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.svg",
+     "png": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.png",
+     "receipt": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.json",
+     "svgDigest": "sha256:82534f5de711142cd0520345352bf67749d8c38b1175724a145c23164ec84acf",
+     "pngDigest": "sha256:e23f8c583f482b86946e177ecef8818d6a126a643b691cfbaf34b635be2eb8ae",
+     "consumed": [
+      "step-1",
+      "step-2",
+      "step-3",
+      "step-4"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    },
+    "en": {
+     "title": "Delivery ships through verification",
+     "prompt": "Four top-to-bottom delivery steps. 4:5 portrait.",
+     "svg": "examples/svg-infographic/typepacks/process-flow/process-flow.en.svg",
+     "png": "examples/svg-infographic/typepacks/process-flow/process-flow.en.png",
+     "receipt": "examples/svg-infographic/typepacks/process-flow/process-flow.en.json",
+     "svgDigest": "sha256:d8b09a5dcfdd2e63c91ba2cc9b52b049f71a9fa054bb285992760db5756d0173",
+     "pngDigest": "sha256:59f6fdce18ea8eb42068a8dd877a23e97965067f18248ccf924d57b3bed90871",
+     "consumed": [
+      "step-1",
+      "step-2",
+      "step-3",
+      "step-4"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    }
+   }
+  },
+  {
+   "id": "roadmap-timeline",
+   "selectionSignal": "Time or phases — product phases, milestones, rollout waves, a status snapshot over time (evenly spaced, claiming no proportional duration)",
+   "spec": "types/specs/roadmap-timeline.md",
+   "profile": "constrained-layout",
+   "support": "experimental",
+   "preferredPreset": "document-compact",
+   "treatment": "flat",
+   "locales": {
+    "ko": {
+     "title": "롤아웃은 단계로 진행한다",
+     "prompt": "롤아웃을 4개 단계로 마일스톤 카드와 함께 보여줘. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.svg",
+     "png": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.png",
+     "receipt": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.json",
+     "svgDigest": "sha256:a4ff21b816ed5d08a383378af4b37e0cd5fd46629690b08273fd717fff1d0b6f",
+     "pngDigest": "sha256:d0487c41a418f011ee6ad72ca87bc8f300918ce4ae7f67aca4bc960a18837e4c",
+     "consumed": [
+      "phase-1",
+      "phase-2",
+      "phase-3",
+      "phase-4"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    },
+    "en": {
+     "title": "The rollout proceeds in phases",
+     "prompt": "Four rollout phases with milestone cards. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.svg",
+     "png": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.png",
+     "receipt": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.json",
+     "svgDigest": "sha256:500867f18825febe5413be4370226b9f8f74e8ab51d0fd33ef3454445b1a6fe5",
+     "pngDigest": "sha256:5d56d66234881e0a4f37b0fbe2bc3f77da79f270b64686eed7d932f11d4d94b0",
+     "consumed": [
+      "phase-1",
+      "phase-2",
+      "phase-3",
+      "phase-4"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 0
+     },
+     "verified": true
+    }
+   }
+  },
+  {
+   "id": "topology-component",
+   "selectionSignal": "Systems or components and their connections — request paths, cloud/network zones, service architecture with a system boundary",
+   "spec": "types/specs/topology-component.md",
+   "profile": "editorial-composition",
+   "support": "experimental",
+   "preferredPreset": "social-4x5",
+   "treatment": "flat",
+   "locales": {
+    "ko": {
+     "title": "요청은 zone을 따라 흐른다",
+     "prompt": "요청 경로를 3개 zone으로 나눠 컴포넌트와 연결을 보여줘. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.svg",
+     "png": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.png",
+     "receipt": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.json",
+     "svgDigest": "sha256:308a08f6ed81c8d93da91aeb94aeca632df665214f8a49d5e913189363cbd0b1",
+     "pngDigest": "sha256:81db3828ccbb6c5b1c270c9028a432c2a2e57a931876e449f0afee4a0fb548ca",
+     "consumed": [
+      "zone-1",
+      "gw",
+      "waf",
+      "zone-2",
+      "api",
+      "auth",
+      "zone-3",
+      "queue",
+      "e1",
+      "e3",
+      "e2",
+      "boundary"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 194
+     },
+     "verified": true
+    },
+    "en": {
+     "title": "Requests flow across the zones",
+     "prompt": "Show the request path across three zones with components and links. 4:5.",
+     "svg": "examples/svg-infographic/typepacks/topology-component/topology-component.en.svg",
+     "png": "examples/svg-infographic/typepacks/topology-component/topology-component.en.png",
+     "receipt": "examples/svg-infographic/typepacks/topology-component/topology-component.en.json",
+     "svgDigest": "sha256:eef5808edf3e5c021e70b82d9bae2edc8831d0ce31bb75aff819a90fd5de7cc7",
+     "pngDigest": "sha256:6bdac61d7a1c009f8c7565faeb7da53b8d065a9c23f49b7e82dcdd5d4bd5eed2",
+     "consumed": [
+      "zone-1",
+      "gw",
+      "waf",
+      "zone-2",
+      "api",
+      "auth",
+      "zone-3",
+      "queue",
+      "e1",
+      "e3",
+      "e2",
+      "boundary"
+     ],
+     "geometry": "fits",
+     "residual": {
+      "top": 0,
+      "bottom": 194
+     },
+     "verified": true
+    }
+   }
+  }
+ ]
+}

--- a/gallery/tokens.json
+++ b/gallery/tokens.json
@@ -1,0 +1,83 @@
+{
+  "$comment": [
+    "Semantic frame tokens for every human-facing surface built from the gallery model:",
+    "the repository gallery (CP3C), the README contact sheets (CP3D), and — later — Wave 2",
+    "figures. Names describe ROLE, not appearance, so a surface that renders differently",
+    "(HTML vs SVG contact sheet) still speaks the same vocabulary.",
+    "",
+    "Wave 1 closes the light palette only. A dark palette is a deliberate extension point,",
+    "not an omission: adding one means adding a sibling block here, not editing these values."
+  ],
+  "schemaVersion": 1,
+  "id": "gallery-frame-tokens",
+  "status": "current",
+
+  "palette": {
+    "$comment": "A near-neutral ground with a slight cool bias, so the artifacts — which carry the colour — read as the subject and the frame recedes.",
+    "ground": "#f4f4f6",
+    "card": "#ffffff",
+    "cardEdge": "#e0e0e7",
+    "ink": "#17171d",
+    "inkMuted": "#6c6c7c",
+    "verified": "#1f6f4f",
+    "verifiedGround": "#e6f2ec"
+  },
+
+  "shape": {
+    "cardRadius": 6,
+    "imageRadius": 4,
+    "chipRadius": 4,
+    "hairline": 1
+  },
+
+  "space": {
+    "$comment": "One 4px base step. Every gap below is a multiple, so surfaces stay on the same rhythm.",
+    "base": 4,
+    "cardPad": 20,
+    "cardGap": 20,
+    "pairGap": 16,
+    "captionGap": 7,
+    "chipGapX": 8,
+    "chipPadX": 8,
+    "chipPadY": 3
+  },
+
+  "type": {
+    "$comment": "Two roles. Identifiers and data are monospace because they ARE code identifiers — that is truthful, not stylistic. Prose is the reader's UI face.",
+    "identifier": {
+      "family": "ui-monospace, SFMono-Regular, Menlo, monospace",
+      "size": 16,
+      "weight": 600,
+      "tracking": -0.16
+    },
+    "prose": {
+      "family": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+      "size": 15,
+      "lineHeight": 1.65,
+      "weight": 400
+    },
+    "caption": {
+      "family": "ui-monospace, SFMono-Regular, Menlo, monospace",
+      "size": 11,
+      "weight": 600,
+      "tracking": 0.99,
+      "transform": "uppercase"
+    },
+    "chip": {
+      "family": "ui-monospace, SFMono-Regular, Menlo, monospace",
+      "size": 12,
+      "weight": 400
+    }
+  },
+
+  "grid": {
+    "$comment": "contactSheet.columns is an AUDITION CANDIDATE, not a settled value. CP3D renders it at GitHub's real display width and the Owner decides visually whether 3 columns keeps titles and structure legible.",
+    "galleryMaxWidth": 1180,
+    "pairMinWidth": 310,
+    "contactSheet": {
+      "columns": 3,
+      "status": "audition-candidate",
+      "cellMinWidth": 400
+    }
+  }
+}

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -1,0 +1,189 @@
+"""CP3B gallery model fixtures.
+
+The model's whole value is that it refuses to publish an example it cannot re-verify today. So the
+negatives here are not "does it parse" — they are the four ways an example can look fine and not be
+verified, plus the three ways the committed model can fall out of date with what it describes.
+
+These run against a copy of the real repository rather than a synthetic fixture: the join is over
+the actual manifest, payloads, receipts and artifacts, and a hand-built stand-in would prove the
+join works on data shaped the way the test author imagined it.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+
+from skillstead_validate.gallery import (  # noqa: E402
+    EXAMPLES, MODEL_PATH, TOKENS_PATH, GalleryError, NodeRunner, build_model, run_gallery,
+)
+
+REPO = Path(__file__).resolve().parent.parent
+NODE = shutil.which("node")
+
+
+def _copy_repo(dst: Path) -> Path:
+    """A working copy that keeps git ownership, which source-development preflight requires."""
+    subprocess.run(["git", "clone", "--quiet", "--no-hardlinks", str(REPO), str(dst)], check=True)
+    # Bring the working tree to what is on disk, not what is committed — the model is built from
+    # files, and an uncommitted example must still be catchable.
+    for rel in ("gallery", EXAMPLES, "skills/svg-infographic"):
+        src = REPO / rel
+        if src.exists():
+            shutil.rmtree(dst / rel, ignore_errors=True)
+            shutil.copytree(src, dst / rel)
+    subprocess.run(["git", "add", "-A"], cwd=dst, check=True, capture_output=True)
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "fixture"],
+                   cwd=dst, check=True, capture_output=True)
+    return dst
+
+
+@unittest.skipIf(NODE is None, "node is required: the digest framing and the verifier live in the package")
+class GalleryModelFixtures(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = _copy_repo(Path(self._tmp.name) / "repo")
+        self.addCleanup(self._tmp.cleanup)
+
+    def checks(self, write: bool = False) -> set[str]:
+        return {f.check for f in run_gallery(self.repo, write=write)}
+
+    def a_receipt(self, tid: str = "cards-kpi-grid", loc: str = "ko") -> Path:
+        return self.repo / EXAMPLES / tid / f"{tid}.{loc}.json"
+
+    def an_svg(self, tid: str = "cards-kpi-grid", loc: str = "ko") -> Path:
+        return self.repo / EXAMPLES / tid / f"{tid}.{loc}.svg"
+
+    # ---- positive ----------------------------------------------------------------------
+
+    def test_committed_model_is_current(self):
+        self.assertEqual(self.checks(), set(), "the committed model must already match its sources")
+
+    def test_model_joins_all_four_surfaces(self):
+        model, findings = build_model(self.repo)
+        self.assertEqual(findings, [])
+        self.assertEqual(model["typepackCount"], 9)
+        for t in model["typepacks"]:
+            self.assertTrue(t["selectionSignal"], f"{t['id']}: manifest field missing")
+            for loc, e in t["locales"].items():
+                self.assertTrue(e["prompt"], f"{t['id']}/{loc}: payload prompt missing")
+                self.assertTrue(e["title"], f"{t['id']}/{loc}: payload title missing")
+                self.assertTrue(e["consumed"], f"{t['id']}/{loc}: receipt consumed missing")
+                self.assertTrue(e["svgDigest"].startswith("sha256:"))
+                self.assertTrue(e["verified"], f"{t['id']}/{loc}: should verify")
+
+    # ---- the four verification facts, broken one at a time -----------------------------
+
+    def test_stale_runtime_digest_is_refused(self):
+        r = self.a_receipt()
+        d = json.loads(r.read_text())
+        d["provenance"]["runtimeSurfaceDigest"] = "sha256:" + "0" * 64
+        r.write_text(json.dumps(d, indent=1), encoding="utf-8")
+        self.assertIn("GAL-VERIFY", self.checks())
+
+    def test_receipt_missing_a_required_block_is_refused(self):
+        r = self.a_receipt()
+        d = json.loads(r.read_text())
+        del d["treatment"]
+        r.write_text(json.dumps(d, indent=1), encoding="utf-8")
+        self.assertIn("GAL-VERIFY", self.checks())
+
+    def test_artifact_edited_after_the_receipt_is_refused(self):
+        svg = self.an_svg()
+        svg.write_text(svg.read_text(encoding="utf-8") + "<!-- edited -->\n", encoding="utf-8")
+        self.assertIn("GAL-VERIFY", self.checks())
+
+    def test_verifier_failure_is_refused(self):
+        # Self-consistent to a shape check — the entity is renamed in both artifact and receipt —
+        # but the verifier recomputes from the input and rejects it.
+        svg = self.an_svg()
+        svg.write_text(svg.read_text(encoding="utf-8").replace('data-entity="observability"',
+                                                               'data-entity="ghost"'), encoding="utf-8")
+        r = self.a_receipt()
+        d = json.loads(r.read_text())
+        d["consumed"] = ["ghost" if c == "observability" else c for c in d["consumed"]]
+        r.write_text(json.dumps(d, indent=1), encoding="utf-8")
+        self.assertIn("GAL-VERIFY", self.checks())
+
+    def test_an_unverified_example_is_never_written(self):
+        r = self.a_receipt()
+        d = json.loads(r.read_text())
+        d["provenance"]["runtimeSurfaceDigest"] = "sha256:" + "0" * 64
+        r.write_text(json.dumps(d, indent=1), encoding="utf-8")
+        before = (self.repo / MODEL_PATH).read_text(encoding="utf-8")
+        self.assertTrue(self.checks(write=True))
+        self.assertEqual((self.repo / MODEL_PATH).read_text(encoding="utf-8"), before,
+                         "a failing build must leave the previous model untouched")
+
+    # ---- drift: the committed model no longer describes its sources --------------------
+
+    def test_forged_model_row_is_caught(self):
+        p = self.repo / MODEL_PATH
+        m = json.loads(p.read_text())
+        m["typepacks"][0]["selectionSignal"] = "something the manifest never said"
+        p.write_text(json.dumps(m, indent=1, ensure_ascii=False) + "\n", encoding="utf-8")
+        self.assertIn("GAL-DRIFT", self.checks())
+
+    def test_artifact_byte_change_is_caught(self):
+        png = self.repo / EXAMPLES / "layer-stack" / "layer-stack.en.png"
+        png.write_bytes(png.read_bytes() + b"\n")
+        self.assertIn("GAL-DRIFT", self.checks())
+
+    def test_missing_receipt_is_caught(self):
+        self.a_receipt("nested-scope", "en").unlink()
+        self.assertIn("GAL-ARTIFACT", self.checks())
+
+    def test_missing_model_is_caught(self):
+        (self.repo / MODEL_PATH).unlink()
+        self.assertIn("GAL-DRIFT", self.checks())
+
+    # ---- tokens ------------------------------------------------------------------------
+
+    def test_missing_required_token_is_caught(self):
+        p = self.repo / TOKENS_PATH
+        t = json.loads(p.read_text())
+        del t["palette"]["ground"]
+        p.write_text(json.dumps(t, indent=1), encoding="utf-8")
+        self.assertIn("GAL-TOKEN", self.checks())
+
+    def test_missing_tokens_file_fails_the_build(self):
+        (self.repo / TOKENS_PATH).unlink()
+        self.assertIn("GAL-BUILD", self.checks())
+
+    # ---- the package must not be reached for through the repository --------------------
+
+    def test_package_carries_no_reference_to_the_repository_gallery(self):
+        # The direction contract: an installed package must run knowing nothing about gallery/.
+        pkg = REPO / "skills/svg-infographic"
+        offenders = []
+        for p in pkg.rglob("*"):
+            if not p.is_file() or p.suffix in {".png", ".otf", ".ttf", ".woff2"}:
+                continue
+            try:
+                text = p.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            if "gallery/model.json" in text or "gallery/tokens.json" in text:
+                offenders.append(str(p.relative_to(REPO)))
+        self.assertEqual(offenders, [], "the package must not depend on repository presentation files")
+
+
+class GalleryWithoutNode(unittest.TestCase):
+    def test_absent_node_fails_closed(self):
+        """No Node means the digest and the verifier cannot be consulted — that is a refusal."""
+        class Missing(NodeRunner):
+            def runtime_surface_digest(self):
+                raise GalleryError("node is unavailable")
+        with self.assertRaises(GalleryError):
+            build_model(REPO, runner=Missing(REPO))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -29,19 +29,34 @@ REPO = Path(__file__).resolve().parent.parent
 NODE = shutil.which("node")
 
 
+def _git(dst: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run git and, on failure, surface what it said — a silent setUp failure hides its own cause."""
+    r = subprocess.run(["git", *args], cwd=dst, capture_output=True, text=True)
+    if check and r.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed ({r.returncode})\n"
+                             f"stdout: {r.stdout.strip()}\nstderr: {r.stderr.strip()}")
+    return r
+
+
 def _copy_repo(dst: Path) -> Path:
-    """A working copy that keeps git ownership, which source-development preflight requires."""
+    """A working copy that keeps git ownership, which source-development preflight requires.
+
+    The source tree may be clean (a CI checkout) or carry uncommitted work (a local branch mid-edit).
+    Both are legitimate, so the fixture commits only when the copy actually differs from HEAD —
+    committing unconditionally failed on a clean checkout, and `--allow-empty` would paper over it
+    by moving HEAD for no reason, muddying the provenance the model depends on.
+    """
     subprocess.run(["git", "clone", "--quiet", "--no-hardlinks", str(REPO), str(dst)], check=True)
     # Bring the working tree to what is on disk, not what is committed — the model is built from
     # files, and an uncommitted example must still be catchable.
-    for rel in ("gallery", EXAMPLES, "skills/svg-infographic"):
+    for rel in ("gallery", EXAMPLES, "skills/svg-infographic", "tools"):
         src = REPO / rel
         if src.exists():
             shutil.rmtree(dst / rel, ignore_errors=True)
             shutil.copytree(src, dst / rel)
-    subprocess.run(["git", "add", "-A"], cwd=dst, check=True, capture_output=True)
-    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "fixture"],
-                   cwd=dst, check=True, capture_output=True)
+    _git(dst, "add", "-A")
+    if _git(dst, "diff", "--cached", "--quiet", check=False).returncode != 0:
+        _git(dst, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "fixture")
     return dst
 
 
@@ -65,6 +80,27 @@ class GalleryModelFixtures(unittest.TestCase):
 
     def test_committed_model_is_current(self):
         self.assertEqual(self.checks(), set(), "the committed model must already match its sources")
+
+    def test_clean_working_tree_builds(self):
+        """Nothing uncommitted — what a CI checkout looks like.
+
+        `_copy_repo` leaves the copy clean whether or not it had to make a fixture commit, so this
+        is the state CI runs in regardless of how the source tree looked.
+        """
+        self.assertEqual(_git(self.repo, "status", "--porcelain").stdout.strip(), "",
+                         "the fixture copy should be clean here")
+        self.assertEqual(self.checks(), set())
+
+    def test_dirty_working_tree_builds(self):
+        """Uncommitted work present — a local branch mid-edit.
+
+        The model is built from files on disk, so a dirty tree must not change the verdict. The
+        change is deliberately something the model does not read: this asserts independence from
+        cleanliness, not that edits go unnoticed (the drift fixtures cover that).
+        """
+        (self.repo / "NOTES.txt").write_text("uncommitted\n", encoding="utf-8")
+        self.assertNotEqual(_git(self.repo, "status", "--porcelain").stdout.strip(), "")
+        self.assertEqual(self.checks(), set())
 
     def test_model_joins_all_four_surfaces(self):
         model, findings = build_model(self.repo)
@@ -95,6 +131,17 @@ class GalleryModelFixtures(unittest.TestCase):
         r.write_text(json.dumps(d, indent=1), encoding="utf-8")
         self.assertIn("GAL-VERIFY", self.checks())
 
+    def test_absent_artifact_digest_is_refused(self):
+        """Without the field there is nothing to compare against — hashing the file and agreeing
+        with ourselves would make the check decorative."""
+        r = self.a_receipt()
+        d = json.loads(r.read_text())
+        del d["artifactDigest"]
+        r.write_text(json.dumps(d, indent=1), encoding="utf-8")
+        findings = run_gallery(self.repo)
+        self.assertIn("GAL-VERIFY", {f.check for f in findings})
+        self.assertTrue(any("records nothing" in f.detail for f in findings), findings)
+
     def test_artifact_edited_after_the_receipt_is_refused(self):
         svg = self.an_svg()
         svg.write_text(svg.read_text(encoding="utf-8") + "<!-- edited -->\n", encoding="utf-8")
@@ -121,6 +168,80 @@ class GalleryModelFixtures(unittest.TestCase):
         self.assertTrue(self.checks(write=True))
         self.assertEqual((self.repo / MODEL_PATH).read_text(encoding="utf-8"), before,
                          "a failing build must leave the previous model untouched")
+
+    def test_missing_required_locale_field_is_refused(self):
+        """A field CP3C will render must come from its authority — a null is a finding, not a gap
+        to design around, because the gallery reads only this model."""
+        r = self.a_receipt()
+        d = json.loads(r.read_text())
+        del d["preset"]
+        r.write_text(json.dumps(d, indent=1), encoding="utf-8")
+        findings = run_gallery(self.repo)
+        self.assertIn("GAL-FIELD", {f.check for f in findings})
+
+    # ---- what the model must carry for CP3C ---------------------------------------------
+
+    def test_model_carries_what_the_detail_view_needs(self):
+        model, findings = build_model(self.repo)
+        self.assertEqual(findings, [])
+        for t in model["typepacks"]:
+            self.assertTrue(t["feasibility"], f"{t['id']}: fit verdicts missing")
+            self.assertTrue(t["stress"], f"{t['id']}: declared stress scenarios missing")
+            # Every declared preset must have a verdict, and every scenario an expectation — that is
+            # what makes the boundary drawable. Requiring a needs-split *per TypePack* would be
+            # asserting a property of the catalog: three types legitimately fit in every declared
+            # configuration, and the model should report that, not be failed for it.
+            for f in t["feasibility"]:
+                self.assertIn(f["result"], ("fits", "needs-split"), f"{t['id']}: {f}")
+                self.assertIn(f["preset"], t["presets"], f"{t['id']}: verdict for an undeclared preset")
+            for sc in t["stress"]:
+                self.assertIn(sc["geometryExpected"], ("fits", "needs-split"), f"{t['id']}: {sc['id']}")
+            for loc, e in t["locales"].items():
+                for field in ("preset", "treatment", "fontDelivery", "geometry"):
+                    self.assertIsNotNone(e[field], f"{t['id']}/{loc}: {field}")
+
+    def test_the_catalog_boundary_is_representable(self):
+        """Somewhere in the catalog a configuration must not fit — otherwise the detail view has no
+        needs-split to explain, and the model would be hiding it rather than the catalog lacking it."""
+        model, _ = build_model(self.repo)
+        split = [(t["id"], s["id"]) for t in model["typepacks"] for s in t["stress"]
+                 if s["geometryExpected"] == "needs-split"]
+        split += [(t["id"], f["preset"]) for t in model["typepacks"] for f in t["feasibility"]
+                  if f["result"] == "needs-split"]
+        self.assertTrue(split, "no needs-split anywhere — the boundary would be undemonstrable")
+
+    def test_png_is_inventory_not_a_verification_claim(self):
+        model, _ = build_model(self.repo)
+        for t in model["typepacks"]:
+            for loc, e in t["locales"].items():
+                self.assertTrue(e["verified"], f"{t['id']}/{loc}: the SVG carries the claim")
+                self.assertIsNone(e["png"]["verified"],
+                                  f"{t['id']}/{loc}: a PNG must never be called verified")
+                self.assertTrue(e["png"]["digest"].startswith("sha256:"))
+
+    def test_a_locale_difference_is_not_collapsed(self):
+        """Today every TypePack happens to agree across locales, so the keep-per-locale branch never
+        fires on real data. Forcing a disagreement is the only way to prove the lift is conditional
+        rather than an unconditional copy of the KO value."""
+        r = self.a_receipt("layer-stack", "en")
+        d = json.loads(r.read_text())
+        d["preset"] = "presentation-16x9"
+        r.write_text(json.dumps(d, indent=1), encoding="utf-8")
+        model, _ = build_model(self.repo)      # findings expected (verifier will object); the
+        t = [x for x in model["typepacks"] if x["id"] == "layer-stack"][0]   # join still runs
+        self.assertIsNone(t["preset"], "a differing preset must not be lifted to the TypePack")
+        self.assertEqual(t["locales"]["ko"]["preset"], "document-compact")
+        self.assertEqual(t["locales"]["en"]["preset"], "presentation-16x9")
+
+    def test_locale_values_are_lifted_only_when_they_agree(self):
+        model, _ = build_model(self.repo)
+        for t in model["typepacks"]:
+            ko, en = t["locales"]["ko"], t["locales"]["en"]
+            for field in ("treatment", "fontDelivery", "preset"):
+                if ko[field] == en[field]:
+                    self.assertEqual(t[field], ko[field], f"{t['id']}: {field} should be lifted")
+                else:
+                    self.assertIsNone(t[field], f"{t['id']}: {field} differs and must stay per-locale")
 
     # ---- drift: the committed model no longer describes its sources --------------------
 

--- a/tools/gallery_export.mjs
+++ b/tools/gallery_export.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// gallery_export.mjs — normalized machine export of the two YAML surfaces the gallery joins on.
+//
+// The gallery model needs the manifest and the canonical input payloads. Re-parsing that YAML in
+// Python would create a second parser free to disagree with the one that actually gates the
+// package: quoted values, multiline scalars and in-sentence punctuation are exactly where two
+// hand-rolled parsers drift. So this imports the package's OWN parser and emits what it produced.
+//
+// It lives in tools/ rather than in the package. That keeps the direction contract intact — nothing
+// under skills/ learns about the repository's presentation layer — and, just as importantly, adding
+// an export command inside the package would change its runtime surface digest and stale every
+// example receipt. Reading the package from outside costs nothing.
+//
+// usage: node tools/gallery_export.mjs [--repo-root PATH]   → JSON on stdout
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseYaml } from "../skills/svg-infographic/scripts/skin.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const i = process.argv.indexOf("--repo-root");
+const root = path.resolve(i > -1 ? process.argv[i + 1] : path.join(here, ".."));
+const REF = path.join(root, "skills", "svg-infographic", "references");
+
+const read = (p, label) => parseYaml(readFileSync(p, "utf8"), label);
+
+const manifest = read(path.join(REF, "types", "manifest.yaml"), "manifest.yaml");
+const packs = (manifest.typepacks ?? []).filter((p) => p.support !== "gated");
+
+const payloads = {};
+for (const p of packs) {
+  const entries = [p.inputs?.canonical, ...(p.inputs?.stress ?? [])].filter(Boolean);
+  for (const e of entries) {
+    const abs = path.join(REF, String(e.path));
+    if (!existsSync(abs)) continue;                    // absence is the model's finding to report
+    payloads[e.path] = read(abs, String(e.path));
+  }
+}
+
+process.stdout.write(JSON.stringify({ schemaVersion: 1, typepacks: packs, payloads }, null, 1) + "\n");

--- a/tools/skillstead_validate/__main__.py
+++ b/tools/skillstead_validate/__main__.py
@@ -5,6 +5,7 @@ Usage:
     python3 -m skillstead_validate preflight --plan PLAN.json [--repo-root PATH]
     python3 -m skillstead_validate apply-tags --plan PLAN.json [--repo-root PATH]
     python3 -m skillstead_validate tags [--main-ref REF] [--repo-root PATH]
+    python3 -m skillstead_validate gallery [--write] [--repo-root PATH]
     python3 -m skillstead_validate cutover (--releases-file F --latest-file F | --live --repo-slug OWNER/REPO) [...]
 
 Exit status: 0 when no findings (cutover: non-red verdict), 1 otherwise,
@@ -20,6 +21,7 @@ from pathlib import Path
 import json
 
 from .cutover import run_cutover
+from .gallery import run_gallery
 from .package_check import run_repo_validation
 from .release_gate import apply_tags, preflight
 from .release_plan import PlanError, parse_plan
@@ -42,6 +44,9 @@ def main(argv: list[str] | None = None) -> int:
     tags = sub.add_parser("tags", help="continuous tag checks (M3)")
     tags.add_argument("--main-ref", default="main")
     tags.add_argument("--repo-root", type=Path, default=Path.cwd())
+    gal = sub.add_parser("gallery", help="gallery model join + drift check (CP3B)")
+    gal.add_argument("--repo-root", type=Path, default=Path.cwd())
+    gal.add_argument("--write", action="store_true", help="regenerate gallery/model.json")
     cut = sub.add_parser("cutover", help="cutover verdict evaluator (M4)")
     cut.add_argument("--repo-root", type=Path, default=Path.cwd())
     cut.add_argument("--main-ref", default="main")
@@ -105,6 +110,14 @@ def main(argv: list[str] | None = None) -> int:
         for f in findings:
             print(f, file=sys.stderr)
         print(f"skillstead_validate tags: {len(findings)} finding(s)")
+        return 1 if findings else 0
+
+    if args.mode == "gallery":
+        findings = run_gallery(args.repo_root.resolve(), write=args.write)
+        for f in findings:
+            print(f, file=sys.stderr)
+        verb = "wrote" if args.write and not findings else "checked"
+        print(f"skillstead_validate gallery: {verb}, {len(findings)} finding(s)")
         return 1 if findings else 0
 
     if args.mode == "repo":

--- a/tools/skillstead_validate/gallery.py
+++ b/tools/skillstead_validate/gallery.py
@@ -8,28 +8,39 @@ it is built once, here, and written to `gallery/model.json`.
 **The model owns nothing.** It joins four surfaces, each of which stays the authority for its own
 fields:
 
-    manifest.yaml          TypePack identity, selection signal, preset/treatment, example membership
-    input payload (.yaml)  KO/EN prompts and locale copy
-    receipt (.json)        consumed, geometry, residual, fontDelivery, treatment, provenance
-    artifact (.svg/.png)   bytes, and the digests over them
+    manifest.yaml          TypePack identity, selection signal, presets, declared fit boundaries
+    input payload (.yaml)  KO/EN prompts and titles
+    receipt (.json)        preset, treatment, fontDelivery, geometry, residual, consumed, provenance
+    artifact (.svg)        bytes, and the digest over them
 
-Verification is the part worth being strict about. A receipt says `0 error(s)` about the package it
-was made against, which is not the same claim as "this artifact is verified today". So the model
-never copies a success string; it re-establishes the claim against four independent facts, and an
-example that cannot clear all four gets no verification state at all — the build fails rather than
-publishing an unverifiable example.
+Two boundaries are worth stating plainly, because both are places where a model like this usually
+overclaims.
+
+**What "verified" means here.** A receipt saying `0 error(s)` is a claim about the package it was
+made against, not about today. So nothing is copied: the claim is re-established against the live
+runtime digest, the recorded artifact digest, and the package's own verifier — which is the
+canonical owner of the exact receipt schema and of the semantic and geometry checks. This module
+deliberately does not re-implement a schema check; a second, weaker one in Python would let a
+receipt pass here that the verifier would reject.
+
+**What carries the claim.** Verification attaches to the **SVG**, because that is what the verifier
+re-checks. The PNG is a render of it, and re-rendering then rebuilding the model would happily bless
+whatever bytes were produced. PNGs are therefore recorded as a present/digest inventory and are
+never described as verified. Promoting them needs a render-evidence contract that does not exist
+yet; CP3D's contact sheets will own their own render and staleness gate.
 
 This lives at repository level, not inside the package, and that placement is the direction contract
-made concrete: the installed package must run with no knowledge of the repository's presentation
+made concrete: the installed package must run knowing nothing about the repository's presentation
 layer. It is Python because repo CI runs Python — a Node generator under `skills/` would be a gate
-nobody executes.
+nobody executes. Where package knowledge is genuinely needed (the YAML dialect, the digest framing,
+the verifier) it is borrowed by invoking the package rather than reimplemented.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
-import re
+import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -40,6 +51,7 @@ SKILL = "skills/svg-infographic"
 EXAMPLES = "examples/svg-infographic/typepacks"
 MODEL_PATH = "gallery/model.json"
 TOKENS_PATH = "gallery/tokens.json"
+EXPORTER = "tools/gallery_export.mjs"
 LOCALES = ("ko", "en")
 
 # Tokens the surfaces cannot render without. Missing any of these is a build failure, not a default.
@@ -50,6 +62,13 @@ REQUIRED_TOKEN_KEYS = (
     "grid.galleryMaxWidth", "grid.contactSheet.columns",
 )
 
+# Every locale entry must carry these, each from its stated authority. A null is a finding, not a
+# gap to render around — CP3C reads only this model, so anything missing here is missing forever.
+REQUIRED_LOCALE_FIELDS = (
+    "title", "prompt", "preset", "treatment", "fontDelivery", "geometry",
+    "consumed", "svg", "svgDigest",
+)
+
 
 class GalleryError(Exception):
     """Raised when the model cannot be built at all (as opposed to a per-example finding)."""
@@ -57,31 +76,39 @@ class GalleryError(Exception):
 
 @dataclass(frozen=True)
 class NodeRunner:
-    """Runs the package's own Node entrypoints.
+    """Runs the package's own entrypoints, and the exporter that borrows its parser.
 
-    The digest framing and the verifier live in the package. Reimplementing either here would create
-    a second implementation free to drift from the one that actually gates artifacts, so this shells
-    out and consumes the result instead.
+    The YAML dialect, the digest framing and the verifier all live in the package. Reimplementing
+    any of them here would create a second implementation free to drift from the one that actually
+    gates artifacts.
     """
 
     repo_root: Path
 
-    def _run(self, args: list[str], timeout: int = 120) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            ["node", *args], cwd=self.repo_root, capture_output=True, text=True,
-            timeout=timeout, env=self._env(),
-        )
-
     def _env(self) -> dict:
-        import os
         env = dict(os.environ)
         env["SVGINFO_EXECUTION_MODE"] = "source-development"
         return env
 
+    def _run(self, args: list[str], timeout: int = 180) -> subprocess.CompletedProcess:
+        return subprocess.run(["node", *args], cwd=self.repo_root, capture_output=True,
+                              text=True, timeout=timeout, env=self._env())
+
+    def export(self) -> dict:
+        r = self._run([EXPORTER, "--repo-root", "."])
+        if r.returncode != 0:
+            raise GalleryError(f"{EXPORTER} failed (exit {r.returncode}): "
+                               f"{(r.stderr or r.stdout).strip()[:400]}")
+        try:
+            return json.loads(r.stdout)
+        except json.JSONDecodeError as e:
+            raise GalleryError(f"{EXPORTER} did not emit JSON: {e}") from e
+
     def runtime_surface_digest(self) -> str:
         r = self._run([f"{SKILL}/scripts/preflight.mjs", "--json"])
         if r.returncode != 0:
-            raise GalleryError(f"preflight refused (exit {r.returncode}): {r.stderr.strip() or r.stdout.strip()}")
+            raise GalleryError(f"preflight refused (exit {r.returncode}): "
+                               f"{(r.stderr or r.stdout).strip()[:400]}")
         try:
             return json.loads(r.stdout)["digests"]["runtimeSurfaceDigest"]
         except (json.JSONDecodeError, KeyError) as e:
@@ -114,44 +141,13 @@ def _token(tokens: dict, dotted: str):
     return node
 
 
-# --- manifest reading -------------------------------------------------------------------
-# Only the fields the gallery joins on. The package's own validator owns the full schema; parsing it
-# again in full here would be a second contract.
+def _parity(ko, en):
+    """Lift a value to the TypePack only when both locales agree; otherwise keep it per locale.
 
-_ID = re.compile(r"^  - id: (\S+)$", re.M)
-
-
-def _manifest_blocks(text: str) -> dict[str, str]:
-    heads = list(_ID.finditer(text))
-    out = {}
-    for i, m in enumerate(heads):
-        end = heads[i + 1].start() if i + 1 < len(heads) else len(text)
-        out[m.group(1)] = text[m.start():end]
-    return out
-
-
-def _field(block: str, key: str) -> str | None:
-    m = re.search(rf'^    {re.escape(key)}: "?([^"\n]+?)"?$', block, re.M)
-    return m.group(1).strip() if m else None
-
-
-def _routable(block: str) -> bool:
-    return _field(block, "support") != "gated"
-
-
-def _prompts(payload_text: str) -> dict[str, str]:
-    out = {}
-    for loc in LOCALES:
-        m = re.search(rf'^prompt_{loc}:\s*"?(.+?)"?\s*$', payload_text, re.M)
-        if m:
-            out[loc] = m.group(1).strip()
-    return out
-
-
-def _title(payload_text: str, loc: str) -> str | None:
-    """The canonical title for a locale — the artifact's own H1, which is what alt text describes."""
-    m = re.search(r"^title:\n(?:  .+\n)*?  " + loc + r':\s*"?(.+?)"?\s*$', payload_text, re.M)
-    return m.group(1).strip() if m else None
+    Collapsing a differing pair would quietly assert a sameness the artifacts do not have —
+    approval-gate's pill width, for instance, is derived from the copy and legitimately differs.
+    """
+    return ko if ko == en else None
 
 
 def build_model(repo_root: Path, runner: NodeRunner | None = None) -> tuple[dict, list[Finding]]:
@@ -168,26 +164,22 @@ def build_model(repo_root: Path, runner: NodeRunner | None = None) -> tuple[dict
         if _token(tokens, key) is None:
             findings.append(Finding("GAL-TOKEN", TOKENS_PATH, f'required token "{key}" is missing'))
 
-    manifest_p = root / SKILL / "references/types/manifest.yaml"
-    try:
-        blocks = _manifest_blocks(manifest_p.read_text(encoding="utf-8"))
-    except OSError as e:
-        raise GalleryError(f"manifest unreadable: {e}") from e
-    routable = {tid: b for tid, b in blocks.items() if _routable(b)}
-    if not routable:
-        raise GalleryError("manifest declares no routable TypePack")
+    export = runner.export()
+    packs = export.get("typepacks") or []
+    payloads = export.get("payloads") or {}
+    if not packs:
+        raise GalleryError("the manifest declares no routable TypePack")
 
     live_digest = runner.runtime_surface_digest()
 
     entries = []
-    for tid in sorted(routable):
-        block = routable[tid]
-        payload_rel = _field(block, "path") or f"types/inputs/{tid}.canonical.yaml"
-        payload_p = root / SKILL / "references" / payload_rel
-        payload_text = payload_p.read_text(encoding="utf-8") if payload_p.exists() else ""
-        if not payload_text:
-            findings.append(Finding("GAL-INPUT", tid, f"canonical input {payload_rel} is missing"))
-        prompts = _prompts(payload_text)
+    for pack in sorted(packs, key=lambda p: str(p.get("id"))):
+        tid = str(pack.get("id"))
+        canonical = (pack.get("inputs") or {}).get("canonical") or {}
+        payload = payloads.get(canonical.get("path")) or {}
+        if not payload:
+            findings.append(Finding("GAL-INPUT", tid,
+                                    f"canonical input {canonical.get('path')!r} is missing or unreadable"))
 
         locales = {}
         for loc in LOCALES:
@@ -198,53 +190,90 @@ def build_model(repo_root: Path, runner: NodeRunner | None = None) -> tuple[dict
                 findings.append(Finding("GAL-ARTIFACT", f"{tid}/{loc}", f"missing {', '.join(missing)}"))
                 continue
             receipt = _read_json(rcp)
-
-            # --- verification: four independent facts, not the receipt's own word ---------
             prov = receipt.get("provenance") or {}
+            svg_digest = _sha256(svg)
+
+            # --- verification: three facts, none of them the receipt's own word ---------------
+            # There is deliberately no Python schema check here. `generate.mjs verify` is the
+            # canonical owner of the exact receipt schema and of the semantic and geometry checks;
+            # a weaker second opinion in this file would only create a way to pass here and fail
+            # there.
+            recorded = receipt.get("artifactDigest")
             checks = {
                 "runtimeDigest": prov.get("runtimeSurfaceDigest") == live_digest,
-                "receiptSchema": all(k in receipt for k in
-                                     ("consumed", "geometry", "fontDelivery", "treatment", "provenance")),
-                "artifactDigest": (receipt.get("artifactDigest") or _sha256(svg)) == _sha256(svg),
+                # No fallback: an absent artifactDigest is a failure, not a reason to hash the file
+                # and agree with ourselves.
+                "artifactDigest": isinstance(recorded, str) and recorded == svg_digest,
                 "verifier": False,
             }
             ok, out = runner.verify(rcp, svg)
             checks["verifier"] = ok
             for name, passed in checks.items():
-                if not passed:
-                    detail = f"{name} check failed"
-                    if name == "verifier":
-                        detail += f" — {out.splitlines()[-1] if out else 'no output'}"
-                    if name == "runtimeDigest":
-                        detail += (f" — receipt {str(prov.get('runtimeSurfaceDigest'))[:22]}… "
-                                   f"vs live {live_digest[:22]}…")
-                    findings.append(Finding("GAL-VERIFY", f"{tid}/{loc}", detail))
+                if passed:
+                    continue
+                detail = f"{name} check failed"
+                if name == "runtimeDigest":
+                    detail += (f" — receipt {str(prov.get('runtimeSurfaceDigest'))[:22]}… "
+                               f"vs live {live_digest[:22]}…")
+                elif name == "artifactDigest":
+                    detail += (" — receipt records nothing" if recorded is None
+                               else f" — receipt {str(recorded)[:22]}… vs svg {svg_digest[:22]}…")
+                else:
+                    detail += f" — {out.splitlines()[-1] if out else 'no output'}"
+                findings.append(Finding("GAL-VERIFY", f"{tid}/{loc}", detail))
 
-            locales[loc] = {
-                "title": _title(payload_text, loc),
-                "prompt": prompts.get(loc),
-                "svg": f"{EXAMPLES}/{tid}/{tid}.{loc}.svg",
-                "png": f"{EXAMPLES}/{tid}/{tid}.{loc}.png",
-                "receipt": f"{EXAMPLES}/{tid}/{tid}.{loc}.json",
-                "svgDigest": _sha256(svg),
-                "pngDigest": _sha256(png),
-                "consumed": receipt.get("consumed") or [],
+            entry = {
+                "title": (payload.get("title") or {}).get(loc),
+                "prompt": payload.get(f"prompt_{loc}"),
+                # Receipt-owned: what the artifact was actually built as, not what was requested.
+                "preset": receipt.get("preset"),
+                "treatment": (receipt.get("treatment") or {}).get("name"),
+                "fontDelivery": (receipt.get("fontDelivery") or {}).get("mode"),
                 "geometry": receipt.get("geometry"),
+                "geometryExpected": receipt.get("geometryExpected"),
                 "residual": receipt.get("residual"),
-                # Present only when all four facts hold. Absent means unverified, never "assume ok".
+                "residualDisposition": receipt.get("residualDisposition"),
+                "consumed": receipt.get("consumed") or [],
+                "svg": f"{EXAMPLES}/{tid}/{tid}.{loc}.svg",
+                "svgDigest": svg_digest,
+                "receipt": f"{EXAMPLES}/{tid}/{tid}.{loc}.json",
+                # Present only when every fact holds. Absent means unverified — never "assume ok".
                 "verified": all(checks.values()) or None,
             }
+            for field in REQUIRED_LOCALE_FIELDS:
+                if entry.get(field) in (None, "", []):
+                    findings.append(Finding("GAL-FIELD", f"{tid}/{loc}",
+                                            f'required field "{field}" is missing from its authority'))
+            # The render, kept separate from the claim: an inventory entry, not a verified artifact.
+            entry["png"] = {"path": f"{EXAMPLES}/{tid}/{tid}.{loc}.png", "digest": _sha256(png),
+                            "verified": None,
+                            "note": "render of the verified SVG; not itself re-verified"}
+            locales[loc] = entry
 
+        ko, en = locales.get("ko") or {}, locales.get("en") or {}
+        fit = (pack.get("fit") or {}).get("feasibility") or []
         entries.append({
             "id": tid,
-            "selectionSignal": _field(block, "selection_signal"),
-            "spec": _field(block, "spec"),
-            "profile": _field(block, "profile"),
-            "support": _field(block, "support"),
-            "preferredPreset": _field(block, "preferred_preset"),
-            "treatment": (locales.get("ko") or {}).get("treatment")
-                         or _read_json(root / EXAMPLES / tid / f"{tid}.ko.json").get("treatment", {}).get("name")
-                         if (root / EXAMPLES / tid / f"{tid}.ko.json").exists() else None,
+            "selectionSignal": pack.get("selection_signal"),
+            "spec": pack.get("spec"),
+            "profile": pack.get("profile"),
+            "support": pack.get("support"),
+            "presets": pack.get("presets") or [],
+            "preferredPreset": pack.get("preferred_preset"),
+            # Lifted only where the two locales agree; otherwise the locale entries keep their own.
+            "treatment": _parity(ko.get("treatment"), en.get("treatment")),
+            "fontDelivery": _parity(ko.get("fontDelivery"), en.get("fontDelivery")),
+            "preset": _parity(ko.get("preset"), en.get("preset")),
+            # What CP3C's detail view needs to draw the needs-split boundary without re-reading
+            # the manifest: the declared stress scenarios and the fit verdicts around them.
+            "stress": [{"id": s.get("id"), "path": s.get("path"), "preset": s.get("preset"),
+                        "count": s.get("count"), "geometryExpected": s.get("geometry_expected"),
+                        "covers": s.get("covers") or [],
+                        "residualDisposition": s.get("residual_disposition")}
+                       for s in ((pack.get("inputs") or {}).get("stress") or [])],
+            "feasibility": [{"preset": f.get("preset"), "orientation": f.get("orientation"),
+                             "count": f.get("count"), "layout": f.get("layout"),
+                             "result": f.get("result")} for f in fit],
             "locales": locales,
         })
 
@@ -252,7 +281,8 @@ def build_model(repo_root: Path, runner: NodeRunner | None = None) -> tuple[dict
         "schemaVersion": 1,
         "generatedBy": "skillstead_validate gallery",
         "note": "Generated view. Every field is owned by the manifest, an input payload, a receipt "
-                "or an artifact — this file is authority for none of them.",
+                "or an artifact — this file is authority for none of them. `verified` attaches to "
+                "the SVG only; PNGs are a present/digest inventory.",
         "runtimeSurfaceDigest": live_digest,
         "tokens": TOKENS_PATH,
         "typepackCount": len(entries),

--- a/tools/skillstead_validate/gallery.py
+++ b/tools/skillstead_validate/gallery.py
@@ -1,0 +1,289 @@
+"""Gallery model — the join that every human-facing surface is built from.
+
+The repository gallery, the README contact sheets and (later) Wave 2 figures all need the same
+answer: which TypePacks are routable, what do their verified examples look like, and what did the
+receipts actually record. Building that answer three times would let three surfaces drift apart, so
+it is built once, here, and written to `gallery/model.json`.
+
+**The model owns nothing.** It joins four surfaces, each of which stays the authority for its own
+fields:
+
+    manifest.yaml          TypePack identity, selection signal, preset/treatment, example membership
+    input payload (.yaml)  KO/EN prompts and locale copy
+    receipt (.json)        consumed, geometry, residual, fontDelivery, treatment, provenance
+    artifact (.svg/.png)   bytes, and the digests over them
+
+Verification is the part worth being strict about. A receipt says `0 error(s)` about the package it
+was made against, which is not the same claim as "this artifact is verified today". So the model
+never copies a success string; it re-establishes the claim against four independent facts, and an
+example that cannot clear all four gets no verification state at all — the build fails rather than
+publishing an unverifiable example.
+
+This lives at repository level, not inside the package, and that placement is the direction contract
+made concrete: the installed package must run with no knowledge of the repository's presentation
+layer. It is Python because repo CI runs Python — a Node generator under `skills/` would be a gate
+nobody executes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from .findings import Finding
+
+SKILL = "skills/svg-infographic"
+EXAMPLES = "examples/svg-infographic/typepacks"
+MODEL_PATH = "gallery/model.json"
+TOKENS_PATH = "gallery/tokens.json"
+LOCALES = ("ko", "en")
+
+# Tokens the surfaces cannot render without. Missing any of these is a build failure, not a default.
+REQUIRED_TOKEN_KEYS = (
+    "palette.ground", "palette.card", "palette.cardEdge", "palette.ink", "palette.inkMuted",
+    "palette.verified", "shape.cardRadius", "space.base", "space.cardPad",
+    "type.identifier.family", "type.prose.family", "type.caption.family",
+    "grid.galleryMaxWidth", "grid.contactSheet.columns",
+)
+
+
+class GalleryError(Exception):
+    """Raised when the model cannot be built at all (as opposed to a per-example finding)."""
+
+
+@dataclass(frozen=True)
+class NodeRunner:
+    """Runs the package's own Node entrypoints.
+
+    The digest framing and the verifier live in the package. Reimplementing either here would create
+    a second implementation free to drift from the one that actually gates artifacts, so this shells
+    out and consumes the result instead.
+    """
+
+    repo_root: Path
+
+    def _run(self, args: list[str], timeout: int = 120) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["node", *args], cwd=self.repo_root, capture_output=True, text=True,
+            timeout=timeout, env=self._env(),
+        )
+
+    def _env(self) -> dict:
+        import os
+        env = dict(os.environ)
+        env["SVGINFO_EXECUTION_MODE"] = "source-development"
+        return env
+
+    def runtime_surface_digest(self) -> str:
+        r = self._run([f"{SKILL}/scripts/preflight.mjs", "--json"])
+        if r.returncode != 0:
+            raise GalleryError(f"preflight refused (exit {r.returncode}): {r.stderr.strip() or r.stdout.strip()}")
+        try:
+            return json.loads(r.stdout)["digests"]["runtimeSurfaceDigest"]
+        except (json.JSONDecodeError, KeyError) as e:
+            raise GalleryError(f"preflight --json did not carry a runtime digest: {e}") from e
+
+    def verify(self, receipt: Path, svg: Path) -> tuple[bool, str]:
+        r = self._run([f"{SKILL}/scripts/generate.mjs", "verify",
+                       "--receipt", str(receipt), "--svg", str(svg)])
+        out = (r.stdout + r.stderr).strip()
+        return r.returncode == 0 and " 0 error(s)" in out, out
+
+
+def _sha256(p: Path) -> str:
+    return "sha256:" + hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+def _read_json(p: Path) -> dict:
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise GalleryError(f"{p}: unreadable ({e})") from e
+
+
+def _token(tokens: dict, dotted: str):
+    node = tokens
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+# --- manifest reading -------------------------------------------------------------------
+# Only the fields the gallery joins on. The package's own validator owns the full schema; parsing it
+# again in full here would be a second contract.
+
+_ID = re.compile(r"^  - id: (\S+)$", re.M)
+
+
+def _manifest_blocks(text: str) -> dict[str, str]:
+    heads = list(_ID.finditer(text))
+    out = {}
+    for i, m in enumerate(heads):
+        end = heads[i + 1].start() if i + 1 < len(heads) else len(text)
+        out[m.group(1)] = text[m.start():end]
+    return out
+
+
+def _field(block: str, key: str) -> str | None:
+    m = re.search(rf'^    {re.escape(key)}: "?([^"\n]+?)"?$', block, re.M)
+    return m.group(1).strip() if m else None
+
+
+def _routable(block: str) -> bool:
+    return _field(block, "support") != "gated"
+
+
+def _prompts(payload_text: str) -> dict[str, str]:
+    out = {}
+    for loc in LOCALES:
+        m = re.search(rf'^prompt_{loc}:\s*"?(.+?)"?\s*$', payload_text, re.M)
+        if m:
+            out[loc] = m.group(1).strip()
+    return out
+
+
+def _title(payload_text: str, loc: str) -> str | None:
+    """The canonical title for a locale — the artifact's own H1, which is what alt text describes."""
+    m = re.search(r"^title:\n(?:  .+\n)*?  " + loc + r':\s*"?(.+?)"?\s*$', payload_text, re.M)
+    return m.group(1).strip() if m else None
+
+
+def build_model(repo_root: Path, runner: NodeRunner | None = None) -> tuple[dict, list[Finding]]:
+    """Join the four surfaces into the generated view. Findings are fatal to the build."""
+    findings: list[Finding] = []
+    root = repo_root.resolve()
+    runner = runner or NodeRunner(root)
+
+    tokens_p = root / TOKENS_PATH
+    if not tokens_p.exists():
+        raise GalleryError(f"{TOKENS_PATH} is missing — surfaces have no frame vocabulary to render with")
+    tokens = _read_json(tokens_p)
+    for key in REQUIRED_TOKEN_KEYS:
+        if _token(tokens, key) is None:
+            findings.append(Finding("GAL-TOKEN", TOKENS_PATH, f'required token "{key}" is missing'))
+
+    manifest_p = root / SKILL / "references/types/manifest.yaml"
+    try:
+        blocks = _manifest_blocks(manifest_p.read_text(encoding="utf-8"))
+    except OSError as e:
+        raise GalleryError(f"manifest unreadable: {e}") from e
+    routable = {tid: b for tid, b in blocks.items() if _routable(b)}
+    if not routable:
+        raise GalleryError("manifest declares no routable TypePack")
+
+    live_digest = runner.runtime_surface_digest()
+
+    entries = []
+    for tid in sorted(routable):
+        block = routable[tid]
+        payload_rel = _field(block, "path") or f"types/inputs/{tid}.canonical.yaml"
+        payload_p = root / SKILL / "references" / payload_rel
+        payload_text = payload_p.read_text(encoding="utf-8") if payload_p.exists() else ""
+        if not payload_text:
+            findings.append(Finding("GAL-INPUT", tid, f"canonical input {payload_rel} is missing"))
+        prompts = _prompts(payload_text)
+
+        locales = {}
+        for loc in LOCALES:
+            base = root / EXAMPLES / tid / f"{tid}.{loc}"
+            svg, png, rcp = Path(f"{base}.svg"), Path(f"{base}.png"), Path(f"{base}.json")
+            missing = [p.name for p in (svg, png, rcp) if not p.exists()]
+            if missing:
+                findings.append(Finding("GAL-ARTIFACT", f"{tid}/{loc}", f"missing {', '.join(missing)}"))
+                continue
+            receipt = _read_json(rcp)
+
+            # --- verification: four independent facts, not the receipt's own word ---------
+            prov = receipt.get("provenance") or {}
+            checks = {
+                "runtimeDigest": prov.get("runtimeSurfaceDigest") == live_digest,
+                "receiptSchema": all(k in receipt for k in
+                                     ("consumed", "geometry", "fontDelivery", "treatment", "provenance")),
+                "artifactDigest": (receipt.get("artifactDigest") or _sha256(svg)) == _sha256(svg),
+                "verifier": False,
+            }
+            ok, out = runner.verify(rcp, svg)
+            checks["verifier"] = ok
+            for name, passed in checks.items():
+                if not passed:
+                    detail = f"{name} check failed"
+                    if name == "verifier":
+                        detail += f" — {out.splitlines()[-1] if out else 'no output'}"
+                    if name == "runtimeDigest":
+                        detail += (f" — receipt {str(prov.get('runtimeSurfaceDigest'))[:22]}… "
+                                   f"vs live {live_digest[:22]}…")
+                    findings.append(Finding("GAL-VERIFY", f"{tid}/{loc}", detail))
+
+            locales[loc] = {
+                "title": _title(payload_text, loc),
+                "prompt": prompts.get(loc),
+                "svg": f"{EXAMPLES}/{tid}/{tid}.{loc}.svg",
+                "png": f"{EXAMPLES}/{tid}/{tid}.{loc}.png",
+                "receipt": f"{EXAMPLES}/{tid}/{tid}.{loc}.json",
+                "svgDigest": _sha256(svg),
+                "pngDigest": _sha256(png),
+                "consumed": receipt.get("consumed") or [],
+                "geometry": receipt.get("geometry"),
+                "residual": receipt.get("residual"),
+                # Present only when all four facts hold. Absent means unverified, never "assume ok".
+                "verified": all(checks.values()) or None,
+            }
+
+        entries.append({
+            "id": tid,
+            "selectionSignal": _field(block, "selection_signal"),
+            "spec": _field(block, "spec"),
+            "profile": _field(block, "profile"),
+            "support": _field(block, "support"),
+            "preferredPreset": _field(block, "preferred_preset"),
+            "treatment": (locales.get("ko") or {}).get("treatment")
+                         or _read_json(root / EXAMPLES / tid / f"{tid}.ko.json").get("treatment", {}).get("name")
+                         if (root / EXAMPLES / tid / f"{tid}.ko.json").exists() else None,
+            "locales": locales,
+        })
+
+    model = {
+        "schemaVersion": 1,
+        "generatedBy": "skillstead_validate gallery",
+        "note": "Generated view. Every field is owned by the manifest, an input payload, a receipt "
+                "or an artifact — this file is authority for none of them.",
+        "runtimeSurfaceDigest": live_digest,
+        "tokens": TOKENS_PATH,
+        "typepackCount": len(entries),
+        "typepacks": entries,
+    }
+    return model, findings
+
+
+def run_gallery(repo_root: Path, write: bool = False) -> list[Finding]:
+    """`--check` by default; `--write` regenerates. A failing model is never written."""
+    root = repo_root.resolve()
+    try:
+        model, findings = build_model(root)
+    except GalleryError as e:
+        return [Finding("GAL-BUILD", MODEL_PATH, str(e))]
+
+    if findings:
+        # Refusing to write is the point: a model with an unverified example would make the gallery
+        # claim something the artifacts do not support.
+        return findings
+
+    rendered = json.dumps(model, indent=1, ensure_ascii=False) + "\n"
+    target = root / MODEL_PATH
+    if write:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(rendered, encoding="utf-8")
+        return []
+    if not target.exists():
+        return [Finding("GAL-DRIFT", MODEL_PATH, "model is missing — regenerate with `gallery --write`")]
+    if target.read_text(encoding="utf-8") != rendered:
+        return [Finding("GAL-DRIFT", MODEL_PATH,
+                        "model is out of date with the manifest, inputs, receipts or artifacts "
+                        "(regenerate with `gallery --write`)")]
+    return []


### PR DESCRIPTION
## 요약

repository gallery · README contact sheet · Wave 2 figure가 모두 같은 답을 필요로 한다 — 어떤 TypePack이 routable이고, 검증된 example이 무엇이며, receipt가 실제로 무엇을 기록했는가. 세 번 만들면 세 표면이 갈라지므로 한 번만 만들어 `gallery/model.json`에 쓴다.

**model은 아무것도 소유하지 않는다.** 네 표면을 join한 view이며 각 표면이 자기 필드의 authority로 남는다.

| 소유 표면 | 소유 필드 |
| --- | --- |
| `manifest.yaml` | TypePack identity, selection signal, preset·treatment, example membership |
| input payload | KO/EN prompt, locale title |
| receipt | `consumed`, `geometry`, `residual`, `fontDelivery`, `treatment`, `provenance` |
| artifact | bytes와 digest |

## verification은 receipt를 믿지 않는다

receipt의 `0 error(s)`는 **그때 그 package에 대한 주장**이지 "오늘 검증됨"이 아니다. 그래서 문자열을 복사하지 않고 네 가지를 다시 확인한다.

1. receipt `provenance.runtimeSurfaceDigest` = **live** runtime digest
2. receipt가 현재 schema를 만족
3. artifact digest = receipt가 기록한 digest
4. 현재 verifier(`generate.mjs verify`) 통과

하나라도 실패하면 verification 상태를 만들지 않고 **build 자체가 실패**한다. 검증할 수 없는 example을 싣느니 멈춘다.

## 왜 저장소 계층 Python인가

두 계층이 갈린다.

| 계층 | 언어 | 테스트 | CI 실행 |
| --- | --- | --- | --- |
| package (`skills/svg-infographic/`) | Node | `run-tests.sh` | ❌ browser 필요 |
| repository (`tools/`) | Python | `tests/` unittest | ✅ |

package 안에 Node로 두면 package가 자기 밖의 `examples/`·`gallery/`를 읽고 쓰게 되어 **방향 계약이 깨지고**, repo CI는 Python만 돌므로 **아무도 실행하지 않는 gate**가 된다. digest framing과 verifier는 package가 소유하므로 재구현하지 않고 node entrypoint를 호출해 결과만 소비한다 — 두 번째 구현이 표류하는 것을 막는다.

`generate.mjs verify`는 0.16초·browser 불필요라 CI gate로 성립한다.

## negative fixture 15건

합성 데이터가 아니라 **실제 repo 사본에 mutation**을 건다. 손으로 만든 stand-in은 "테스트 작성자가 상상한 모양"에서만 join이 동작함을 증명한다.

| 계열 | 고정한 것 |
| --- | --- |
| 4대조 | stale runtime digest · receipt block 삭제 · artifact 사후 편집 · verifier 실패 |
| write 보호 | 검증 실패 시 기존 model을 건드리지 않음 |
| drift | model 1행 위조 · artifact 1바이트 · receipt 삭제 · model 부재 |
| token | 필수 key 누락 · 파일 부재 |
| 방향 계약 | package가 `gallery/*` 참조 0건 |
| node 부재 | fail-closed (skip 아님) |

verifier 실패 fixture는 artifact와 receipt를 **함께** 바꿔 shape check는 통과시킨 뒤, 입력에서 재계산하는 verifier가 거부하는 것을 본다.

## 검증

```
repo unittest (CI 동일)   Ran 193 tests — OK   (기존 178 + CP3B 15)
gallery --write           9 typepacks, 18/18 verified, 0 finding
gallery --check           drift 0
repo validation (M1)      0 finding
```

`tokens.json`의 `contactSheet.columns: 3`은 `"status": "audition-candidate"`로 표시했다 — CP3D의 Owner 시각 gate 전까지 확정값이 아니다. dark palette는 형제 block 추가로 여는 확장점이며 이번 acceptance 대상이 아니다.

## 후속으로 넘기는 발견 1건

방향 계약을 검사하다 **CP3B와 무관한 기존 위반**을 찾았다. package README 2종이 저장소를 절대 URL로 링크한다(각 3건). 코드 의존이 아니라 문서 링크지만 "package는 외부 URL 없이 독립 실행"에 걸린다. **CP4의 `package → repository 의존 0건` gate가 판정할 사안**이라 이 PR에서는 손대지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)