### PR TITLE
feat(gallery): bilingual Featured와 TypePack catalog를 구성한다 (CP3C)

### DIFF
--- a/gallery/featured.json
+++ b/gallery/featured.json
@@ -1,0 +1,73 @@
+{
+  "$comment": [
+    "Editorial selection for the gallery's featured showcase, and later for the README contact",
+    "sheet. It is a repository-level decision — which existing outputs best show what the skill can",
+    "do — so it lives here rather than in the package or hardcoded in a renderer, and the exporter",
+    "validates it into model.json.featured. One list, consumed by every surface.",
+    "",
+    "JSON rather than YAML on purpose: these captions are prose and will keep acquiring commas and",
+    "punctuation, which the package's minimal YAML subset parses by its own rules. JSON has no such",
+    "ambiguity, and this file needs no help from the package parser.",
+    "",
+    "There is no per-entry size control. The grid gives every artifact the same media viewport",
+    "and fits it with object-fit, so a tall topology and a wide swimlane read as one managed set",
+    "rather than as a layout that varies by entry.",
+    "",
+    "Captions stay qualitative. A caption may not contain digits, because a number here is a claim",
+    "about the artifact that nothing verifies — 'zones, boundaries and routed connectors' is",
+    "observable in the picture; '20+ connectors' is a count no gate ever checked.",
+    "",
+    "This selection is TRANSITIONAL for Wave 1. The final composition, and whether the two evidence",
+    "facets can be unified, are settled after Wave 2 lands its TypePacks — through a replacement",
+    "audition, not automatically. Until then these entries stay, and their legacy provenance and",
+    "absent receipt are stated exactly as the evidence facets report them rather than smoothed over.",
+    "",
+    "Each Wave 2 candidate is judged on its receipt and a visual audition, and replaces an entry only",
+    "when it is genuinely the better showcase. Retaining a legacy entry is a valid outcome and is",
+    "recorded with its reason."
+  ],
+  "schemaVersion": 1,
+  "id": "gallery-featured",
+  "status": "current",
+
+  "note": "Selected for how differently they are shaped, not for how many there are.",
+
+  "entries": [
+    {
+      "slug": "cloud-infra-topology",
+      "name": "Cloud topology",
+      "caption": "zones, boundaries and routed connectors",
+      "reason": "The densest structure the catalog produces — nested zones with routing that has to stay legible."
+    },
+    {
+      "slug": "agent-waiting-swimlane",
+      "name": "Branching swimlane",
+      "caption": "parallel lanes that rejoin",
+      "reason": "Shows branching and rejoin, which a single-axis process flow cannot express."
+    },
+    {
+      "slug": "agent-task-matrix",
+      "name": "Decision matrix",
+      "caption": "two qualitative axes",
+      "reason": "Position carries meaning here, so it demonstrates the axis contract rather than a layout."
+    },
+    {
+      "slug": "zero-trust-onion",
+      "name": "Nested scope",
+      "caption": "concentric trust rings",
+      "reason": "Containment as the relation, with no connectors at all."
+    },
+    {
+      "slug": "before-after-migration",
+      "name": "Before and after",
+      "caption": "mirrored comparison",
+      "reason": "Alignment carries the correspondence between the two sides."
+    },
+    {
+      "slug": "agent-system-sketch",
+      "name": "Sketch treatment",
+      "caption": "handwriting and rough stroke",
+      "reason": "The one surface treatment that is not flat, shown on a structure that is not trivial."
+    }
+  ]
+}

--- a/gallery/index.html
+++ b/gallery/index.html
@@ -1,0 +1,354 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TypePack Gallery</title>
+<!-- GENERATED VIEW — do not edit by hand.
+     Source of truth: gallery/model.json + gallery/tokens.json (+ gallery/featured.json).
+     Regenerate with `python3 -m skillstead_validate gallery --write`;
+     `--check` fails when this file drifts.
+     A single generated HTML entrypoint with no external network dependencies; images are
+     repository-relative SVGs. -->
+<style>
+:root {
+  --ground: #f4f4f6;
+  --card: #ffffff;
+  --card-edge: #e0e0e7;
+  --ink: #17171d;
+  --ink-muted: #6c6c7c;
+  --verified: #1f6f4f;
+  --verified-ground: #e6f2ec;
+  --card-radius: 6px;
+  --image-radius: 4px;
+  --chip-radius: 4px;
+  --card-pad: 20px;
+  --card-gap: 20px;
+  --pair-gap: 16px;
+  --caption-gap: 7px;
+  --font-identifier: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-prose: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-caption: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --max-width: 1180px;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--ground); color: var(--ink);
+  font: 15px/1.65 var(--font-prose);
+  font-variant-numeric: tabular-nums;
+}
+.wrap { max-width: var(--max-width); margin: 0 auto; padding: 3rem 1.25rem 5rem; }
+h1 { font-size: 1.55rem; line-height: 1.25; margin: 0 0 .5rem; letter-spacing: -.015em; text-wrap: balance; }
+.lede { color: var(--ink-muted); margin: 0 0 1rem; max-width: 64ch; }
+h2.sec { font-size: 1.1rem; margin: 3rem 0 .3rem; letter-spacing: -.01em; }
+.sec-note { color: var(--ink-muted); margin: 0 0 .9rem; max-width: 70ch; font-size: 14px; }
+
+.facets { display: flex; flex-wrap: wrap; gap: .35rem; margin: 0 0 1rem; }
+.facet {
+  display: inline-flex; align-items: baseline; gap: .4rem;
+  border: 1px solid var(--card-edge); border-radius: var(--chip-radius);
+  padding: .26rem .55rem; font: 600 11px/1 var(--font-identifier); background: var(--card);
+  color: var(--ink-muted);
+}
+.facet i { font-style: normal; font-weight: 400; }
+.facet.ok { background: var(--verified-ground); color: var(--verified);
+  border-color: color-mix(in srgb, var(--verified) 25%, transparent); }
+
+.switch { display: flex; gap: .3rem; margin: 0 0 1.4rem; }
+.switch button {
+  font: 600 12px/1 var(--font-identifier); letter-spacing: .04em;
+  background: var(--card); color: var(--ink-muted);
+  border: 1px solid var(--card-edge); border-radius: var(--chip-radius);
+  padding: .42rem .7rem; cursor: pointer;
+}
+.switch button[aria-pressed="true"] { color: var(--ink); border-color: var(--ink-muted); }
+.switch button:focus-visible, summary:focus-visible, a:focus-visible {
+  outline: 2px solid var(--verified); outline-offset: 2px;
+}
+
+/* ---- featured ------------------------------------------------------------------------ */
+/* Every entry gets the same cell and the same media viewport. Sizing entries individually made the
+   row read as a layout that varies per artifact; one viewport makes six very differently shaped
+   outputs read as one managed set — which is the claim the section is making. The artifacts keep
+   their own proportions inside it via object-fit, so nothing is cropped or distorted. */
+.featured { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--pair-gap); }
+@media (max-width: 980px) { .featured { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 640px) { .featured { grid-template-columns: minmax(0, 1fr); } }
+.feat {
+  background: var(--card); border: 1px solid var(--card-edge);
+  border-radius: var(--card-radius); padding: 13px;
+}
+.frame {
+  aspect-ratio: 4 / 3; background: #fff; border: 1px solid var(--card-edge);
+  border-radius: var(--image-radius); display: flex; align-items: center; justify-content: center;
+  overflow: hidden; padding: 9px;
+}
+.frame img { max-width: 100%; max-height: 100%; width: auto; height: auto; object-fit: contain; }
+/* The frame links to the artifact itself, so full size works with no scripting at all; when
+   scripting is present the click is intercepted and shown in a dialog instead. */
+a.frame { cursor: zoom-in; text-decoration: none; }
+dialog { border: 0; padding: 0; background: transparent; max-width: 96vw; max-height: 96vh; }
+dialog::backdrop { background: rgba(20, 20, 26, .72); }
+dialog img { max-width: 96vw; max-height: 92vh; background: #fff; border-radius: 6px; display: block; }
+dialog form { text-align: right; margin-top: .5rem; }
+dialog button {
+  font: 600 12px/1 var(--font-identifier); background: var(--card); color: var(--ink);
+  border: 1px solid var(--card-edge); border-radius: var(--chip-radius); padding: .45rem .7rem;
+  cursor: pointer;
+}
+/* Captions wrap to one or two lines depending on the words. Reserving the taller of the two keeps
+   the row of cards level instead of stepping by a line height. */
+.feat .cap {
+  display: flex; justify-content: space-between; align-items: baseline; gap: 8px;
+  margin-top: 10px; min-height: 2.6em;
+}
+.feat .nm { font: 600 13px/1.3 var(--font-identifier); }
+.feat .sub { color: var(--ink-muted); font-size: 12px; text-align: right; }
+/* Featured artifacts are the argument the page opens with, so one locale fills the card rather
+   than two sharing it. With scripting the switch picks which; without it both stack, which is
+   taller but complete. */
+.feat .pair { display: grid; gap: 10px; grid-template-columns: minmax(0, 1fr); }
+.feat figcaption {
+  color: var(--ink-muted); margin-bottom: 5px;
+  font: 600 10px/1 var(--font-caption); letter-spacing: .08em; text-transform: uppercase;
+}
+
+/* ---- catalog ------------------------------------------------------------------------- */
+.catalog { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--pair-gap); }
+@media (max-width: 900px) { .catalog { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 620px) { .catalog { grid-template-columns: minmax(0, 1fr); } }
+article {
+  background: var(--card); border: 1px solid var(--card-edge);
+  border-radius: var(--card-radius); padding: 14px;
+}
+h3 { margin: 0; font: 600 13px/1.3 var(--font-identifier); letter-spacing: -.01em; }
+h3 a { color: inherit; text-decoration: none; }
+h3 a:hover { text-decoration: underline; }
+.signal {
+  color: var(--ink-muted); margin: .35rem 0 .8rem; font-size: 12.5px;
+  display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
+}
+.pair { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+[data-locale="ko"] .catalog .pair, [data-locale="en"] .catalog .pair { grid-template-columns: minmax(0, 1fr); }
+figure { margin: 0; min-width: 0; }
+figcaption {
+  color: var(--ink-muted); margin-bottom: var(--caption-gap);
+  font: 600 10px/1 var(--font-caption); letter-spacing: .07em; text-transform: uppercase;
+}
+details { margin-top: 12px; border-top: 1px solid var(--card-edge); padding-top: 10px; }
+summary { cursor: pointer; color: var(--ink-muted); font: 600 11px/1 var(--font-identifier); letter-spacing: .04em; }
+.detail { margin-top: 11px; display: grid; gap: 12px; }
+.detail h4 {
+  margin: 0 0 5px; font: 600 10px/1 var(--font-caption); letter-spacing: .08em;
+  text-transform: uppercase; color: var(--ink-muted);
+}
+pre {
+  margin: 0; padding: .7rem .8rem; overflow-x: auto; background: var(--ground);
+  border: 1px solid var(--card-edge); border-radius: var(--chip-radius);
+  font: 11px/1.6 var(--font-identifier); white-space: pre;
+}
+.chips { display: flex; flex-wrap: wrap; gap: 5px; }
+.chip {
+  display: inline-flex; align-items: baseline; gap: 5px; background: var(--ground);
+  border: 1px solid var(--card-edge); border-radius: var(--chip-radius);
+  padding: 3px 7px; font: 11px/1.4 var(--font-identifier);
+}
+.chip i { font-style: normal; color: var(--ink-muted); font-size: 10px; }
+table { border-collapse: collapse; width: 100%; font: 11px/1.5 var(--font-identifier); }
+th, td { text-align: left; padding: 3px 8px 3px 0; border-bottom: 1px solid var(--card-edge); }
+th { color: var(--ink-muted); font-weight: 600; }
+td.split { font-weight: 600; }
+.scroll { overflow-x: auto; }
+a { color: var(--ink); }
+.note { color: var(--ink-muted); font-size: 12px; margin: .5rem 0 0; }
+
+/* Nothing is hidden unless JS has set a locale on the root, so the no-script view is complete. */
+[data-locale="ko"] figure[data-loc="en"], [data-locale="en"] figure[data-loc="ko"] { display: none; }
+@media (prefers-reduced-motion: reduce) { * { transition: none !important; } }
+</style>
+<div class="wrap">
+<header>
+  <h1>Diagrams your agent can actually produce</h1>
+  <p class="lede">Every picture below was generated by this skill from a written prompt — no drawing,
+  no hand-tuned SVG. The showcase shows the range; the catalog under it is what you pick from.</p>
+  <div class="switch" id="switch" hidden>
+    <button type="button" data-set="both" aria-pressed="false">Side by side</button>
+    <button type="button" data-set="ko" aria-pressed="true">한국어</button>
+    <button type="button" data-set="en" aria-pressed="false">English</button>
+  </div>
+</header>
+
+<h2 class="sec">What it can draw</h2>
+<p class="sec-note">Six existing outputs, chosen for how differently they are shaped — a cloud
+topology, a branching swimlane, a decision matrix, nested trust rings, a mirrored comparison and the
+sketch treatment. Click any one to see it full size.</p>
+<p class="facets"><span class="facet ok"><i>source gates</i>pass</span><span class="facet none"><i>TypePack receipt</i>none</span></p>
+<div class="featured"><div class="feat"><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><a class="frame" href="../examples/svg-infographic/cloud-infra-topology/cloud-infra-topology.ko.svg" data-full="../examples/svg-infographic/cloud-infra-topology/cloud-infra-topology.ko.svg"><img src="../examples/svg-infographic/cloud-infra-topology/cloud-infra-topology.ko.svg" alt="Cloud topology — zones, boundaries and routed connectors (KO)" loading="lazy"></a></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><a class="frame" href="../examples/svg-infographic/cloud-infra-topology/cloud-infra-topology.en.svg" data-full="../examples/svg-infographic/cloud-infra-topology/cloud-infra-topology.en.svg"><img src="../examples/svg-infographic/cloud-infra-topology/cloud-infra-topology.en.svg" alt="Cloud topology — zones, boundaries and routed connectors (EN)" loading="lazy"></a></figure></div><div class="cap"><span class="nm">Cloud topology</span><span class="sub">zones, boundaries and routed connectors</span></div></div><div class="feat"><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><a class="frame" href="../examples/svg-infographic/agent-waiting-swimlane/agent-waiting-swimlane.ko.svg" data-full="../examples/svg-infographic/agent-waiting-swimlane/agent-waiting-swimlane.ko.svg"><img src="../examples/svg-infographic/agent-waiting-swimlane/agent-waiting-swimlane.ko.svg" alt="Branching swimlane — parallel lanes that rejoin (KO)" loading="lazy"></a></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><a class="frame" href="../examples/svg-infographic/agent-waiting-swimlane/agent-waiting-swimlane.en.svg" data-full="../examples/svg-infographic/agent-waiting-swimlane/agent-waiting-swimlane.en.svg"><img src="../examples/svg-infographic/agent-waiting-swimlane/agent-waiting-swimlane.en.svg" alt="Branching swimlane — parallel lanes that rejoin (EN)" loading="lazy"></a></figure></div><div class="cap"><span class="nm">Branching swimlane</span><span class="sub">parallel lanes that rejoin</span></div></div><div class="feat"><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><a class="frame" href="../examples/svg-infographic/agent-task-matrix/agent-task-matrix.ko.svg" data-full="../examples/svg-infographic/agent-task-matrix/agent-task-matrix.ko.svg"><img src="../examples/svg-infographic/agent-task-matrix/agent-task-matrix.ko.svg" alt="Decision matrix — two qualitative axes (KO)" loading="lazy"></a></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><a class="frame" href="../examples/svg-infographic/agent-task-matrix/agent-task-matrix.en.svg" data-full="../examples/svg-infographic/agent-task-matrix/agent-task-matrix.en.svg"><img src="../examples/svg-infographic/agent-task-matrix/agent-task-matrix.en.svg" alt="Decision matrix — two qualitative axes (EN)" loading="lazy"></a></figure></div><div class="cap"><span class="nm">Decision matrix</span><span class="sub">two qualitative axes</span></div></div><div class="feat"><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><a class="frame" href="../examples/svg-infographic/zero-trust-onion/zero-trust-onion.ko.svg" data-full="../examples/svg-infographic/zero-trust-onion/zero-trust-onion.ko.svg"><img src="../examples/svg-infographic/zero-trust-onion/zero-trust-onion.ko.svg" alt="Nested scope — concentric trust rings (KO)" loading="lazy"></a></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><a class="frame" href="../examples/svg-infographic/zero-trust-onion/zero-trust-onion.en.svg" data-full="../examples/svg-infographic/zero-trust-onion/zero-trust-onion.en.svg"><img src="../examples/svg-infographic/zero-trust-onion/zero-trust-onion.en.svg" alt="Nested scope — concentric trust rings (EN)" loading="lazy"></a></figure></div><div class="cap"><span class="nm">Nested scope</span><span class="sub">concentric trust rings</span></div></div><div class="feat"><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><a class="frame" href="../examples/svg-infographic/before-after-migration/before-after-migration.ko.svg" data-full="../examples/svg-infographic/before-after-migration/before-after-migration.ko.svg"><img src="../examples/svg-infographic/before-after-migration/before-after-migration.ko.svg" alt="Before and after — mirrored comparison (KO)" loading="lazy"></a></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><a class="frame" href="../examples/svg-infographic/before-after-migration/before-after-migration.en.svg" data-full="../examples/svg-infographic/before-after-migration/before-after-migration.en.svg"><img src="../examples/svg-infographic/before-after-migration/before-after-migration.en.svg" alt="Before and after — mirrored comparison (EN)" loading="lazy"></a></figure></div><div class="cap"><span class="nm">Before and after</span><span class="sub">mirrored comparison</span></div></div><div class="feat"><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><a class="frame" href="../examples/svg-infographic/agent-system-sketch/agent-system-sketch.ko.svg" data-full="../examples/svg-infographic/agent-system-sketch/agent-system-sketch.ko.svg"><img src="../examples/svg-infographic/agent-system-sketch/agent-system-sketch.ko.svg" alt="Sketch treatment — handwriting and rough stroke (KO)" loading="lazy"></a></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><a class="frame" href="../examples/svg-infographic/agent-system-sketch/agent-system-sketch.en.svg" data-full="../examples/svg-infographic/agent-system-sketch/agent-system-sketch.en.svg"><img src="../examples/svg-infographic/agent-system-sketch/agent-system-sketch.en.svg" alt="Sketch treatment — handwriting and rough stroke (EN)" loading="lazy"></a></figure></div><div class="cap"><span class="nm">Sketch treatment</span><span class="sub">handwriting and rough stroke</span></div></div></div>
+<p class="note">Hand-authored examples that predate the TypePack receipts. They clear the lint,
+layout and typography gates; no receipt exists for them, which is why the receipt facet reads
+<code>none</code> rather than being left out.</p>
+
+<h2 class="sec">Choose a TypePack</h2>
+<p class="sec-note">Nine minimum-syntax types — the catalog's regression baseline. Each card carries
+the signal that selects it and its Korean and English canonical example; open one for the prompt,
+the command template, and the point where that type stops fitting.</p>
+<p class="facets"><span class="facet ok"><i>source gates</i>pass</span><span class="facet ok"><i>TypePack receipt</i>pass</span></p>
+<p class="note">18/18 TypePack canonical artifacts pass the current package verifier.
+A known topology boundary-rendering limitation is tracked separately.</p>
+
+<div class="catalog"><article id="approval-gate"><h3><a href="#approval-gate">approval-gate</a></h3><p class="signal">A simple request path with one approval gate or checkpoint (a-&gt;b-&gt;c; a full sequence diagram is out of scope)</p><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.svg" alt="approval-gate — 요청은 승인 게이트를 지난다 (KO)" loading="lazy"></div></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/approval-gate/approval-gate.en.svg" alt="approval-gate — Requests pass an approval gate (EN)" loading="lazy"></div></figure></div><details><summary>Prompt, command and limits</summary><div class="detail">
+<div><h4>Canonical prompt</h4><pre>ko: 요청이 승인 게이트를 지나 반영되는 경로를 보여줘. 4:5.
+en: A request passing an approval gate. 4:5.</pre></div>
+<div><h4>Command template</h4><pre># from skills/svg-infographic/
+node scripts/generate.mjs build --typepack approval-gate --case canonical \
+  --locale ko --out OUT.svg --receipt OUT.json
+node scripts/generate.mjs verify --receipt OUT.json --svg OUT.svg</pre></div>
+<div><h4>Receipt facts</h4><div class="chips"><span class="chip"><i>profile</i>constrained-layout</span><span class="chip"><i>preset</i>document-compact</span><span class="chip"><i>treatment</i>flat</span><span class="chip"><i>delivery</i>portable</span><span class="chip"><i>entities</i>4</span></div></div>
+<div><h4>Declared stress scenarios</h4><div class="scroll"><table><tr><th>scenario</th><th>preset</th><th>expected</th></tr><tr><td>stress-cardinality</td><td>presentation-16x9</td><td class="">fits</td></tr><tr><td>stress-copy</td><td>document-compact</td><td class="">fits</td></tr><tr><td>stress-degrade</td><td>social-4x5</td><td class="split">needs-split</td></tr></table></div></div><div><h4>Where it stops fitting</h4><div class="scroll"><table><tr><th>preset</th><th>count</th><th>verdict</th></tr><tr><td>document-compact</td><td>4</td><td class="split">needs-split</td></tr><tr><td>social-4x5</td><td>4</td><td class="split">needs-split</td></tr><tr><td>presentation-16x9</td><td>4</td><td class="">fits</td></tr></table></div><p class="note"><code>needs-split</code> returns a degrade receipt and no artifact — a non-success, not a smaller render.</p></div>
+<div><h4>Sources</h4><p class="note">
+<a href="../skills/svg-infographic/references/types/specs/approval-gate.md"><code>approval-gate.md</code></a> ·
+<a href="../skills/svg-infographic/references/PROMPT-GALLERY.md#approval-gate"><code>PROMPT-GALLERY.md</code></a> ·
+<a href="../examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.json"><code>receipt</code></a>
+</p></div></div></details></article><article id="before-after"><h3><a href="#before-after">before-after</a></h3><p class="signal">Before and after — migration, modernisation, refactor outcome, trade-off comparison</p><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/before-after/before-after.ko.svg" alt="before-after — 자동화가 배포 시간을 줄였다 (KO)" loading="lazy"></div></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/before-after/before-after.en.svg" alt="before-after — Automation cut the delivery time (EN)" loading="lazy"></div></figure></div><details><summary>Prompt, command and limits</summary><div class="detail">
+<div><h4>Canonical prompt</h4><pre>ko: 마이그레이션 전후를 두 항목으로 비교해줘. 4:5.
+en: Compare before and after across two slots. 4:5.</pre></div>
+<div><h4>Command template</h4><pre># from skills/svg-infographic/
+node scripts/generate.mjs build --typepack before-after --case canonical \
+  --locale ko --out OUT.svg --receipt OUT.json
+node scripts/generate.mjs verify --receipt OUT.json --svg OUT.svg</pre></div>
+<div><h4>Receipt facts</h4><div class="chips"><span class="chip"><i>profile</i>constrained-layout</span><span class="chip"><i>preset</i>document-compact</span><span class="chip"><i>treatment</i>flat</span><span class="chip"><i>delivery</i>portable</span><span class="chip"><i>entities</i>2</span></div></div>
+<div><h4>Declared stress scenarios</h4><div class="scroll"><table><tr><th>scenario</th><th>preset</th><th>expected</th></tr><tr><td>stress-cardinality</td><td>document-compact</td><td class="">fits</td></tr><tr><td>stress-copy</td><td>document-compact</td><td class="">fits</td></tr></table></div></div><div><h4>Where it stops fitting</h4><div class="scroll"><table><tr><th>preset</th><th>count</th><th>verdict</th></tr><tr><td>document-compact</td><td>2</td><td class="">fits</td></tr><tr><td>social-4x5</td><td>2</td><td class="">fits</td></tr><tr><td>presentation-16x9</td><td>2</td><td class="">fits</td></tr></table></div><p class="note"><code>needs-split</code> returns a degrade receipt and no artifact — a non-success, not a smaller render.</p></div>
+<div><h4>Sources</h4><p class="note">
+<a href="../skills/svg-infographic/references/types/specs/before-after.md"><code>before-after.md</code></a> ·
+<a href="../skills/svg-infographic/references/PROMPT-GALLERY.md#before-after"><code>PROMPT-GALLERY.md</code></a> ·
+<a href="../examples/svg-infographic/typepacks/before-after/before-after.ko.json"><code>receipt</code></a>
+</p></div></div></details></article><article id="cards-kpi-grid"><h3><a href="#cards-kpi-grid">cards-kpi-grid</a></h3><p class="signal">A few key items or figures summarised as equal cards (feature highlights, principles, status counts, capability summaries; not a chart claiming data accuracy)</p><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.svg" alt="cards-kpi-grid — 핵심 4가지를 한눈에 (KO)" loading="lazy"></div></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.svg" alt="cards-kpi-grid — Four key points at a glance (EN)" loading="lazy"></div></figure></div><details><summary>Prompt, command and limits</summary><div class="detail">
+<div><h4>Canonical prompt</h4><pre>ko: 핵심 4가지를 동등한 카드로 요약해줘. 소셜 포스트용 4:5 비율.
+en: Summarise the four key points as equal cards, 4:5 social post.</pre></div>
+<div><h4>Command template</h4><pre># from skills/svg-infographic/
+node scripts/generate.mjs build --typepack cards-kpi-grid --case canonical \
+  --locale ko --out OUT.svg --receipt OUT.json
+node scripts/generate.mjs verify --receipt OUT.json --svg OUT.svg</pre></div>
+<div><h4>Receipt facts</h4><div class="chips"><span class="chip"><i>profile</i>constrained-layout</span><span class="chip"><i>preset</i>document-compact</span><span class="chip"><i>treatment</i>flat</span><span class="chip"><i>delivery</i>portable</span><span class="chip"><i>entities</i>4</span></div></div>
+<div><h4>Declared stress scenarios</h4><div class="scroll"><table><tr><th>scenario</th><th>preset</th><th>expected</th></tr><tr><td>stress-cardinality</td><td>document-compact</td><td class="">fits</td></tr><tr><td>stress-copy</td><td>document-compact</td><td class="">fits</td></tr><tr><td>stress-degrade</td><td>social-4x5</td><td class="split">needs-split</td></tr></table></div></div><div><h4>Where it stops fitting</h4><div class="scroll"><table><tr><th>preset</th><th>count</th><th>verdict</th></tr><tr><td>document-compact</td><td>6</td><td class="">fits</td></tr><tr><td>social-4x5</td><td>6</td><td class="">fits</td></tr><tr><td>social-4x5</td><td>6</td><td class="split">needs-split</td></tr><tr><td>presentation-16x9</td><td>6</td><td class="">fits</td></tr><tr><td>presentation-16x9</td><td>6</td><td class="">fits</td></tr></table></div><p class="note"><code>needs-split</code> returns a degrade receipt and no artifact — a non-success, not a smaller render.</p></div>
+<div><h4>Sources</h4><p class="note">
+<a href="../skills/svg-infographic/references/types/specs/cards-kpi-grid.md"><code>cards-kpi-grid.md</code></a> ·
+<a href="../skills/svg-infographic/references/PROMPT-GALLERY.md#cards-kpi-grid"><code>PROMPT-GALLERY.md</code></a> ·
+<a href="../examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.json"><code>receipt</code></a>
+</p></div></div></details></article><article id="decision-matrix"><h3><a href="#decision-matrix">decision-matrix</a></h3><p class="signal">Options or items placed by two qualitative axes — a 2x2 priority/decision quadrant, a 3x3 risk grid</p><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.svg" alt="decision-matrix — 두 축이 우선순위를 정한다 (KO)" loading="lazy"></div></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.svg" alt="decision-matrix — Two axes set the priority (EN)" loading="lazy"></div></figure></div><details><summary>Prompt, command and limits</summary><div class="detail">
+<div><h4>Canonical prompt</h4><pre>ko: 두 축으로 옵션을 2×2 사분면에 배치해줘. 4:5.
+en: Place options in a 2×2 matrix. 4:5.</pre></div>
+<div><h4>Command template</h4><pre># from skills/svg-infographic/
+node scripts/generate.mjs build --typepack decision-matrix --case canonical \
+  --locale ko --out OUT.svg --receipt OUT.json
+node scripts/generate.mjs verify --receipt OUT.json --svg OUT.svg</pre></div>
+<div><h4>Receipt facts</h4><div class="chips"><span class="chip"><i>profile</i>constrained-layout</span><span class="chip"><i>preset</i>document-compact</span><span class="chip"><i>treatment</i>flat</span><span class="chip"><i>delivery</i>portable</span><span class="chip"><i>entities</i>4</span></div></div>
+<div><h4>Declared stress scenarios</h4><div class="scroll"><table><tr><th>scenario</th><th>preset</th><th>expected</th></tr><tr><td>stress-cardinality</td><td>presentation-16x9</td><td class="">fits</td></tr><tr><td>stress-degrade</td><td>document-compact</td><td class="split">needs-split</td></tr><tr><td>stress-copy</td><td>document-compact</td><td class="">fits</td></tr></table></div></div><div><h4>Where it stops fitting</h4><div class="scroll"><table><tr><th>preset</th><th>count</th><th>verdict</th></tr><tr><td>document-compact</td><td>9</td><td class="split">needs-split</td></tr><tr><td>social-4x5</td><td>9</td><td class="">fits</td></tr><tr><td>presentation-16x9</td><td>9</td><td class="">fits</td></tr></table></div><p class="note"><code>needs-split</code> returns a degrade receipt and no artifact — a non-success, not a smaller render.</p></div>
+<div><h4>Sources</h4><p class="note">
+<a href="../skills/svg-infographic/references/types/specs/decision-matrix.md"><code>decision-matrix.md</code></a> ·
+<a href="../skills/svg-infographic/references/PROMPT-GALLERY.md#decision-matrix"><code>PROMPT-GALLERY.md</code></a> ·
+<a href="../examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.json"><code>receipt</code></a>
+</p></div></div></details></article><article id="layer-stack"><h3><a href="#layer-stack">layer-stack</a></h3><p class="signal">A hierarchy that stacks on or abstracts the layer beneath it (platform stacks, runtime layers, capability models)</p><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.svg" alt="layer-stack — 플랫폼 역량은 층으로 쌓인다 (KO)" loading="lazy"></div></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/layer-stack/layer-stack.en.svg" alt="layer-stack — Platform capability stacks in layers (EN)" loading="lazy"></div></figure></div><details><summary>Prompt, command and limits</summary><div class="detail">
+<div><h4>Canonical prompt</h4><pre>ko: 플랫폼 역량을 4개 계층으로 쌓아서 보여줘. 4:5.
+en: Show the platform capability as four stacked layers. 4:5.</pre></div>
+<div><h4>Command template</h4><pre># from skills/svg-infographic/
+node scripts/generate.mjs build --typepack layer-stack --case canonical \
+  --locale ko --out OUT.svg --receipt OUT.json
+node scripts/generate.mjs verify --receipt OUT.json --svg OUT.svg</pre></div>
+<div><h4>Receipt facts</h4><div class="chips"><span class="chip"><i>profile</i>constrained-layout</span><span class="chip"><i>preset</i>document-compact</span><span class="chip"><i>treatment</i>flat</span><span class="chip"><i>delivery</i>portable</span><span class="chip"><i>entities</i>12</span></div></div>
+<div><h4>Declared stress scenarios</h4><div class="scroll"><table><tr><th>scenario</th><th>preset</th><th>expected</th></tr><tr><td>stress-cardinality</td><td>presentation-16x9</td><td class="">fits</td></tr><tr><td>stress-copy</td><td>document-compact</td><td class="">fits</td></tr><tr><td>stress-degrade</td><td>social-4x5</td><td class="split">needs-split</td></tr></table></div></div><div><h4>Where it stops fitting</h4><div class="scroll"><table><tr><th>preset</th><th>count</th><th>verdict</th></tr><tr><td>document-compact</td><td>5</td><td class="">fits</td></tr><tr><td>document-compact</td><td>5</td><td class="split">needs-split</td></tr><tr><td>social-4x5</td><td>5</td><td class="">fits</td></tr><tr><td>social-4x5</td><td>5</td><td class="split">needs-split</td></tr><tr><td>presentation-16x9</td><td>5</td><td class="">fits</td></tr><tr><td>presentation-16x9</td><td>5</td><td class="">fits</td></tr></table></div><p class="note"><code>needs-split</code> returns a degrade receipt and no artifact — a non-success, not a smaller render.</p></div>
+<div><h4>Sources</h4><p class="note">
+<a href="../skills/svg-infographic/references/types/specs/layer-stack.md"><code>layer-stack.md</code></a> ·
+<a href="../skills/svg-infographic/references/PROMPT-GALLERY.md#layer-stack"><code>PROMPT-GALLERY.md</code></a> ·
+<a href="../examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.json"><code>receipt</code></a>
+</p></div></div></details></article><article id="nested-scope"><h3><a href="#nested-scope">nested-scope</a></h3><p class="signal">Containment and scope — the inner lives inside the outer (trust zones, scope rings, platform -&gt; app -&gt; feature)</p><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.svg" alt="nested-scope — 신뢰 경계는 안쪽일수록 좁다 (KO)" loading="lazy"></div></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/nested-scope/nested-scope.en.svg" alt="nested-scope — Trust narrows toward the core (EN)" loading="lazy"></div></figure></div><details><summary>Prompt, command and limits</summary><div class="detail">
+<div><h4>Canonical prompt</h4><pre>ko: 신뢰 경계를 3겹 동심 구조로 보여줘. 4:5.
+en: Show the trust boundary as 3 concentric scopes. 4:5.</pre></div>
+<div><h4>Command template</h4><pre># from skills/svg-infographic/
+node scripts/generate.mjs build --typepack nested-scope --case canonical \
+  --locale ko --out OUT.svg --receipt OUT.json
+node scripts/generate.mjs verify --receipt OUT.json --svg OUT.svg</pre></div>
+<div><h4>Receipt facts</h4><div class="chips"><span class="chip"><i>profile</i>constrained-layout</span><span class="chip"><i>preset</i>document-compact</span><span class="chip"><i>treatment</i>flat</span><span class="chip"><i>delivery</i>portable</span><span class="chip"><i>entities</i>3</span></div></div>
+<div><h4>Declared stress scenarios</h4><div class="scroll"><table><tr><th>scenario</th><th>preset</th><th>expected</th></tr><tr><td>stress-cardinality</td><td>document-compact</td><td class="">fits</td></tr><tr><td>stress-copy</td><td>document-compact</td><td class="">fits</td></tr></table></div></div><div><h4>Where it stops fitting</h4><div class="scroll"><table><tr><th>preset</th><th>count</th><th>verdict</th></tr><tr><td>document-compact</td><td>4</td><td class="">fits</td></tr><tr><td>social-4x5</td><td>4</td><td class="">fits</td></tr><tr><td>presentation-16x9</td><td>4</td><td class="">fits</td></tr></table></div><p class="note"><code>needs-split</code> returns a degrade receipt and no artifact — a non-success, not a smaller render.</p></div>
+<div><h4>Sources</h4><p class="note">
+<a href="../skills/svg-infographic/references/types/specs/nested-scope.md"><code>nested-scope.md</code></a> ·
+<a href="../skills/svg-infographic/references/PROMPT-GALLERY.md#nested-scope"><code>PROMPT-GALLERY.md</code></a> ·
+<a href="../examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.json"><code>receipt</code></a>
+</p></div></div></details></article><article id="process-flow"><h3><a href="#process-flow">process-flow</a></h3><p class="signal">Ordered steps or handoffs — processes, pipelines, data flows, review loops</p><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/process-flow/process-flow.ko.svg" alt="process-flow — 배포는 검증을 지나 반영된다 (KO)" loading="lazy"></div></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/process-flow/process-flow.en.svg" alt="process-flow — Delivery ships through verification (EN)" loading="lazy"></div></figure></div><details><summary>Prompt, command and limits</summary><div class="detail">
+<div><h4>Canonical prompt</h4><pre>ko: 배포 절차를 4단계로 위에서 아래로 보여줘. 4:5 세로.
+en: Four top-to-bottom delivery steps. 4:5 portrait.</pre></div>
+<div><h4>Command template</h4><pre># from skills/svg-infographic/
+node scripts/generate.mjs build --typepack process-flow --case canonical \
+  --locale ko --out OUT.svg --receipt OUT.json
+node scripts/generate.mjs verify --receipt OUT.json --svg OUT.svg</pre></div>
+<div><h4>Receipt facts</h4><div class="chips"><span class="chip"><i>profile</i>constrained-layout</span><span class="chip"><i>preset</i>document-compact</span><span class="chip"><i>treatment</i>flat</span><span class="chip"><i>delivery</i>portable</span><span class="chip"><i>entities</i>4</span></div></div>
+<div><h4>Declared stress scenarios</h4><div class="scroll"><table><tr><th>scenario</th><th>preset</th><th>expected</th></tr><tr><td>stress-cardinality</td><td>document-compact</td><td class="">fits</td></tr><tr><td>stress-copy</td><td>document-compact</td><td class="">fits</td></tr><tr><td>stress-degrade</td><td>social-4x5</td><td class="split">needs-split</td></tr></table></div></div><div><h4>Where it stops fitting</h4><div class="scroll"><table><tr><th>preset</th><th>count</th><th>verdict</th></tr><tr><td>document-compact</td><td>5</td><td class="">fits</td></tr><tr><td>social-4x5</td><td>5</td><td class="split">needs-split</td></tr><tr><td>social-4x5</td><td>5</td><td class="">fits</td></tr><tr><td>presentation-16x9</td><td>5</td><td class="">fits</td></tr><tr><td>presentation-16x9</td><td>5</td><td class="">fits</td></tr></table></div><p class="note"><code>needs-split</code> returns a degrade receipt and no artifact — a non-success, not a smaller render.</p></div>
+<div><h4>Sources</h4><p class="note">
+<a href="../skills/svg-infographic/references/types/specs/process-flow.md"><code>process-flow.md</code></a> ·
+<a href="../skills/svg-infographic/references/PROMPT-GALLERY.md#process-flow"><code>PROMPT-GALLERY.md</code></a> ·
+<a href="../examples/svg-infographic/typepacks/process-flow/process-flow.ko.json"><code>receipt</code></a>
+</p></div></div></details></article><article id="roadmap-timeline"><h3><a href="#roadmap-timeline">roadmap-timeline</a></h3><p class="signal">Time or phases — product phases, milestones, rollout waves, a status snapshot over time (evenly spaced, claiming no proportional duration)</p><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.svg" alt="roadmap-timeline — 롤아웃은 단계로 진행한다 (KO)" loading="lazy"></div></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.svg" alt="roadmap-timeline — The rollout proceeds in phases (EN)" loading="lazy"></div></figure></div><details><summary>Prompt, command and limits</summary><div class="detail">
+<div><h4>Canonical prompt</h4><pre>ko: 롤아웃을 4개 단계로 마일스톤 카드와 함께 보여줘. 4:5.
+en: Four rollout phases with milestone cards. 4:5.</pre></div>
+<div><h4>Command template</h4><pre># from skills/svg-infographic/
+node scripts/generate.mjs build --typepack roadmap-timeline --case canonical \
+  --locale ko --out OUT.svg --receipt OUT.json
+node scripts/generate.mjs verify --receipt OUT.json --svg OUT.svg</pre></div>
+<div><h4>Receipt facts</h4><div class="chips"><span class="chip"><i>profile</i>constrained-layout</span><span class="chip"><i>preset</i>document-compact</span><span class="chip"><i>treatment</i>flat</span><span class="chip"><i>delivery</i>portable</span><span class="chip"><i>entities</i>4</span></div></div>
+<div><h4>Declared stress scenarios</h4><div class="scroll"><table><tr><th>scenario</th><th>preset</th><th>expected</th></tr><tr><td>stress-cardinality</td><td>presentation-16x9</td><td class="">fits</td></tr><tr><td>stress-body</td><td>document-compact</td><td class="">fits</td></tr><tr><td>stress-tail-current</td><td>document-compact</td><td class="">fits</td></tr><tr><td>stress-copy</td><td>presentation-16x9</td><td class="">fits</td></tr><tr><td>stress-degrade</td><td>document-compact</td><td class="split">needs-split</td></tr></table></div></div><div><h4>Where it stops fitting</h4><div class="scroll"><table><tr><th>preset</th><th>count</th><th>verdict</th></tr><tr><td>document-compact</td><td>5</td><td class="split">needs-split</td></tr><tr><td>social-4x5</td><td>5</td><td class="split">needs-split</td></tr><tr><td>presentation-16x9</td><td>5</td><td class="">fits</td></tr></table></div><p class="note"><code>needs-split</code> returns a degrade receipt and no artifact — a non-success, not a smaller render.</p></div>
+<div><h4>Sources</h4><p class="note">
+<a href="../skills/svg-infographic/references/types/specs/roadmap-timeline.md"><code>roadmap-timeline.md</code></a> ·
+<a href="../skills/svg-infographic/references/PROMPT-GALLERY.md#roadmap-timeline"><code>PROMPT-GALLERY.md</code></a> ·
+<a href="../examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.json"><code>receipt</code></a>
+</p></div></div></details></article><article id="topology-component"><h3><a href="#topology-component">topology-component</a></h3><p class="signal">Systems or components and their connections — request paths, cloud/network zones, service architecture with a system boundary</p><div class="pair"><figure data-loc="ko"><figcaption>한국어</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/topology-component/topology-component.ko.svg" alt="topology-component — 요청은 zone을 따라 흐른다 (KO)" loading="lazy"></div></figure><figure data-loc="en"><figcaption>ENGLISH</figcaption><div class="frame"><img src="../examples/svg-infographic/typepacks/topology-component/topology-component.en.svg" alt="topology-component — Requests flow across the zones (EN)" loading="lazy"></div></figure></div><details><summary>Prompt, command and limits</summary><div class="detail">
+<div><h4>Canonical prompt</h4><pre>ko: 요청 경로를 3개 zone으로 나눠 컴포넌트와 연결을 보여줘. 4:5.
+en: Show the request path across three zones with components and links. 4:5.</pre></div>
+<div><h4>Command template</h4><pre># from skills/svg-infographic/
+node scripts/generate.mjs build --typepack topology-component --case canonical \
+  --locale ko --out OUT.svg --receipt OUT.json
+node scripts/generate.mjs verify --receipt OUT.json --svg OUT.svg</pre></div>
+<div><h4>Receipt facts</h4><div class="chips"><span class="chip"><i>profile</i>editorial-composition</span><span class="chip"><i>preset</i>social-4x5</span><span class="chip"><i>treatment</i>flat</span><span class="chip"><i>delivery</i>portable</span><span class="chip"><i>entities</i>12</span></div></div>
+<div><h4>Declared stress scenarios</h4><div class="scroll"><table><tr><th>scenario</th><th>preset</th><th>expected</th></tr><tr><td>stress-cardinality</td><td>social-4x5</td><td class="">fits</td></tr><tr><td>stress-copy</td><td>social-4x5</td><td class="">fits</td></tr></table></div></div><div><h4>Where it stops fitting</h4><div class="scroll"><table><tr><th>preset</th><th>count</th><th>verdict</th></tr><tr><td>social-4x5</td><td>4</td><td class="">fits</td></tr><tr><td>presentation-16x9</td><td>4</td><td class="">fits</td></tr></table></div><p class="note"><code>needs-split</code> returns a degrade receipt and no artifact — a non-success, not a smaller render.</p></div><div><h4>Known limitation</h4><p class="note">The receipt counts <code>boundary</code> as consumed, but the current package does not draw it. Tracked separately from this gallery.</p></div>
+<div><h4>Sources</h4><p class="note">
+<a href="../skills/svg-infographic/references/types/specs/topology-component.md"><code>topology-component.md</code></a> ·
+<a href="../skills/svg-infographic/references/PROMPT-GALLERY.md#topology-component"><code>PROMPT-GALLERY.md</code></a> ·
+<a href="../examples/svg-infographic/typepacks/topology-component/topology-component.ko.json"><code>receipt</code></a>
+</p></div></div></details></article></div>
+</div>
+<dialog id="zoom"><img alt=""><form method="dialog"><button>Close</button></form></dialog>
+<script>
+// Full size is a plain link by default, so it works with no scripting. Where scripting exists the
+// click is intercepted and shown in place instead of navigating away from the gallery.
+(function () {
+  var dlg = document.getElementById("zoom");
+  if (!dlg || !dlg.showModal) return;
+  document.addEventListener("click", function (ev) {
+    var a = ev.target.closest("a.frame[data-full]");
+    if (!a) return;
+    ev.preventDefault();
+    dlg.querySelector("img").src = a.dataset.full;
+    dlg.querySelector("img").alt = a.querySelector("img").alt;
+    dlg.showModal();
+  });
+})();
+// The locale switch is the only thing that needs scripting, so it stays hidden until scripting is
+// present. Without it both locales are already on screen and every detail still opens.
+(function () {
+  var bar = document.getElementById("switch");
+  if (!bar) return;
+  bar.hidden = false;
+  function setLocale(mode) {
+    document.documentElement.dataset.locale = mode === "both" ? "" : mode;
+    bar.querySelectorAll("button").forEach(function (x) {
+      x.setAttribute("aria-pressed", String(x.dataset.set === mode));
+    });
+  }
+  // With scripting, open on one locale so a featured artifact fills its card. "Side by side" is one
+  // click away, and the no-script view already shows both.
+  setLocale("ko");
+  bar.addEventListener("click", function (ev) {
+    var b = ev.target.closest("button[data-set]");
+    if (b) setLocale(b.dataset.set);
+  });
+})();
+</script>
+</html>

--- a/gallery/model.json
+++ b/gallery/model.json
@@ -105,10 +105,16 @@
       "node-3",
       "gate-1"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.svg",
      "svgDigest": "sha256:166a397c33345f406e9df710751b05bd5fe49db0616059111a26813448284563",
      "receipt": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.png",
       "digest": "sha256:590a0906f4f12953b0905d57fa4d2d4f489520cfb5c76393de9ece386d27bc31",
@@ -135,10 +141,16 @@
       "node-3",
       "gate-1"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.svg",
      "svgDigest": "sha256:9f1e8dd31082b30537ae9d22cacb731b27fd25fa0cf92b0c9f030681a4764e9b",
      "receipt": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/approval-gate/approval-gate.en.png",
       "digest": "sha256:176ad2f0fac47379f2b1953c913f5cfc51863d002897b471fb8a1a541dbe384f",
@@ -230,10 +242,16 @@
       "before",
       "after"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/before-after/before-after.ko.svg",
      "svgDigest": "sha256:e15b0bd322c545023f9383c815b68b71bede0d85b8e67b1c60c80f1fc410a5ee",
      "receipt": "examples/svg-infographic/typepacks/before-after/before-after.ko.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/before-after/before-after.ko.png",
       "digest": "sha256:c5c4d1cfdfa55bf102a4dd202882250e8136ee522b0586a3fa4e20af153f98bb",
@@ -258,10 +276,16 @@
       "before",
       "after"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/before-after/before-after.en.svg",
      "svgDigest": "sha256:f6d7bc171359e34ab9cba5f3fd4b43d196be42dd5ab7801595593d3136bb61a5",
      "receipt": "examples/svg-infographic/typepacks/before-after/before-after.en.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/before-after/before-after.en.png",
       "digest": "sha256:2f787ee4d20cf183331f0b5f14ab31c3b2397e59d1ff3c050f06337b821037bc",
@@ -379,10 +403,16 @@
       "cost",
       "security"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.svg",
      "svgDigest": "sha256:016f3f30774aa45dbebd78418edd26bf0a729bd75a68bb568d6e0561369b83a7",
      "receipt": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.png",
       "digest": "sha256:4c754a0208b2922c8d5844c1f282efedcef610bec53bf39ce9b969c2db8132f5",
@@ -409,10 +439,16 @@
       "cost",
       "security"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.svg",
      "svgDigest": "sha256:33fec63cada3ba543471a59b08c226f3d8f11e5fb5f24450ba9575687d5fe243",
      "receipt": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.png",
       "digest": "sha256:697e277b0da4a6ceef5f069e2ce10cc1afce8a39a7a5837a1ca934b1ce9a8888",
@@ -519,10 +555,16 @@
       "cell-3",
       "cell-4"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.svg",
      "svgDigest": "sha256:1c6c06d5c73694d89fa5c63602083cab3940e5395a3dcaa7ac4cf9a593d0d99b",
      "receipt": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.png",
       "digest": "sha256:8027994556216b8a4b469ff9acbd8f910a761fb4712dcda5d2de9d9fce6e126d",
@@ -549,10 +591,16 @@
       "cell-3",
       "cell-4"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.svg",
      "svgDigest": "sha256:d29504aed3cf3aa04f541ba0127095b9ca7287d736477b115a288ef62782aa25",
      "receipt": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.png",
       "digest": "sha256:e56448f49b399c31f312a777a1529dc195e40c70cd286ea218a235b190102908",
@@ -690,10 +738,16 @@
       "layer-4-chip-1",
       "layer-4-chip-2"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.svg",
      "svgDigest": "sha256:9d84f282db9f8055891d3659fce3aec5dc4e28b7bf90eaee1d3af04ca2af2f76",
      "receipt": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.png",
       "digest": "sha256:db1abf971502ac2ca523a9510159b11e4b672d84c4fb321fb5d1382486b500b8",
@@ -728,10 +782,16 @@
       "layer-4-chip-1",
       "layer-4-chip-2"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.svg",
      "svgDigest": "sha256:8bd40672c183d3bf17d67039f33d4d451a5e33d7fcd34986af855458ca1fa152",
      "receipt": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/layer-stack/layer-stack.en.png",
       "digest": "sha256:d076a3a6245f4c0f1db383b5fb5bbf5d505b5d9e2788bec563d746a258650978",
@@ -823,10 +883,16 @@
       "ring-2",
       "ring-3"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.svg",
      "svgDigest": "sha256:f7938cfdca961c6d3fbc145b69f1140c4fd9ae4145ae93c03ba83b8529a305eb",
      "receipt": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.png",
       "digest": "sha256:4da96b21c365503d51f2930e7b69cba2a54d9190004e01ab302c9e5c0eae9480",
@@ -852,10 +918,16 @@
       "ring-2",
       "ring-3"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.svg",
      "svgDigest": "sha256:e9d4aff3855882f3750d79d7b61f64d114cea26b597567af4ffeb8b003220d70",
      "receipt": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/nested-scope/nested-scope.en.png",
       "digest": "sha256:a6b7c710d7982d59125cf39173a1c71e583fea73334bb3597586019d07feeac7",
@@ -973,10 +1045,16 @@
       "step-3",
       "step-4"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.svg",
      "svgDigest": "sha256:82534f5de711142cd0520345352bf67749d8c38b1175724a145c23164ec84acf",
      "receipt": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/process-flow/process-flow.ko.png",
       "digest": "sha256:e23f8c583f482b86946e177ecef8818d6a126a643b691cfbaf34b635be2eb8ae",
@@ -1003,10 +1081,16 @@
       "step-3",
       "step-4"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/process-flow/process-flow.en.svg",
      "svgDigest": "sha256:d8b09a5dcfdd2e63c91ba2cc9b52b049f71a9fa054bb285992760db5756d0173",
      "receipt": "examples/svg-infographic/typepacks/process-flow/process-flow.en.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/process-flow/process-flow.en.png",
       "digest": "sha256:59f6fdce18ea8eb42068a8dd877a23e97965067f18248ccf924d57b3bed90871",
@@ -1141,10 +1225,16 @@
       "phase-3",
       "phase-4"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.svg",
      "svgDigest": "sha256:a4ff21b816ed5d08a383378af4b37e0cd5fd46629690b08273fd717fff1d0b6f",
      "receipt": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.png",
       "digest": "sha256:d0487c41a418f011ee6ad72ca87bc8f300918ce4ae7f67aca4bc960a18837e4c",
@@ -1171,10 +1261,16 @@
       "phase-3",
       "phase-4"
      ],
+     "unrendered": null,
      "svg": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.svg",
      "svgDigest": "sha256:500867f18825febe5413be4370226b9f8f74e8ab51d0fd33ef3454445b1a6fe5",
      "receipt": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.png",
       "digest": "sha256:5d56d66234881e0a4f37b0fbe2bc3f77da79f270b64686eed7d932f11d4d94b0",
@@ -1283,10 +1379,18 @@
       "e2",
       "boundary"
      ],
+     "unrendered": [
+      "boundary"
+     ],
      "svg": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.svg",
      "svgDigest": "sha256:308a08f6ed81c8d93da91aeb94aeca632df665214f8a49d5e913189363cbd0b1",
      "receipt": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/topology-component/topology-component.ko.png",
       "digest": "sha256:81db3828ccbb6c5b1c270c9028a432c2a2e57a931876e449f0afee4a0fb548ca",
@@ -1334,10 +1438,18 @@
       "e2",
       "boundary"
      ],
+     "unrendered": [
+      "boundary"
+     ],
      "svg": "examples/svg-infographic/typepacks/topology-component/topology-component.en.svg",
      "svgDigest": "sha256:eef5808edf3e5c021e70b82d9bae2edc8831d0ce31bb75aff819a90fd5de7cc7",
      "receipt": "examples/svg-infographic/typepacks/topology-component/topology-component.en.json",
      "verified": true,
+     "evidence": {
+      "sourceGates": "pass",
+      "typePackReceipt": "pass",
+      "dataAccuracy": "not-applicable"
+     },
      "png": {
       "path": "examples/svg-infographic/typepacks/topology-component/topology-component.en.png",
       "digest": "sha256:6bdac61d7a1c009f8c7565faeb7da53b8d065a9c23f49b7e82dcdd5d4bd5eed2",
@@ -1347,5 +1459,137 @@
     }
    }
   }
- ]
+ ],
+ "featured": {
+  "source": "gallery/featured.json",
+  "note": "Editorial selection, transitional for Wave 1. The final composition and any unification of the evidence facets are settled after Wave 2 through a replacement audition, not automatically — a candidate replaces an entry only when a receipt check and a visual audition find it the better showcase, and retaining an entry is a valid, recorded outcome. Until then the legacy provenance and absent receipt stand as the facets report them.",
+  "entries": [
+   {
+    "slug": "cloud-infra-topology",
+    "name": "Cloud topology",
+    "caption": "zones, boundaries and routed connectors",
+    "reason": "The densest structure the catalog produces — nested zones with routing that has to stay legible.",
+    "artifacts": {
+     "ko": {
+      "svg": "examples/svg-infographic/cloud-infra-topology/cloud-infra-topology.ko.svg",
+      "svgDigest": "sha256:baa2fc0676ec4656a402db24c5c80f6d6b6f2074f99b23bb8f8683393c930657"
+     },
+     "en": {
+      "svg": "examples/svg-infographic/cloud-infra-topology/cloud-infra-topology.en.svg",
+      "svgDigest": "sha256:6ce6cce45d657ece4897bae64c13dcf56b2673471364847d0980942ea280f8c5"
+     }
+    },
+    "evidence": {
+     "sourceGates": "pass",
+     "typePackReceipt": "none",
+     "dataAccuracy": "not-applicable"
+    }
+   },
+   {
+    "slug": "agent-waiting-swimlane",
+    "name": "Branching swimlane",
+    "caption": "parallel lanes that rejoin",
+    "reason": "Shows branching and rejoin, which a single-axis process flow cannot express.",
+    "artifacts": {
+     "ko": {
+      "svg": "examples/svg-infographic/agent-waiting-swimlane/agent-waiting-swimlane.ko.svg",
+      "svgDigest": "sha256:cd5c9ea2b4fb8d916bc2452b2d89e6f8048b4e752c62c7a84f706b0e5c8d3ccd"
+     },
+     "en": {
+      "svg": "examples/svg-infographic/agent-waiting-swimlane/agent-waiting-swimlane.en.svg",
+      "svgDigest": "sha256:502bd98a5fca9c2e049a962c79bac8a7a1a5948571d93ae45263756124a4a1cc"
+     }
+    },
+    "evidence": {
+     "sourceGates": "pass",
+     "typePackReceipt": "none",
+     "dataAccuracy": "not-applicable"
+    }
+   },
+   {
+    "slug": "agent-task-matrix",
+    "name": "Decision matrix",
+    "caption": "two qualitative axes",
+    "reason": "Position carries meaning here, so it demonstrates the axis contract rather than a layout.",
+    "artifacts": {
+     "ko": {
+      "svg": "examples/svg-infographic/agent-task-matrix/agent-task-matrix.ko.svg",
+      "svgDigest": "sha256:c1f77b769ea27158ea520c33a42e6f01e93b72b10cba1d4e806cb47ba3965494"
+     },
+     "en": {
+      "svg": "examples/svg-infographic/agent-task-matrix/agent-task-matrix.en.svg",
+      "svgDigest": "sha256:38217df80a418db993bba234de96d149875c4097e38a7a527713101a015ac654"
+     }
+    },
+    "evidence": {
+     "sourceGates": "pass",
+     "typePackReceipt": "none",
+     "dataAccuracy": "not-applicable"
+    }
+   },
+   {
+    "slug": "zero-trust-onion",
+    "name": "Nested scope",
+    "caption": "concentric trust rings",
+    "reason": "Containment as the relation, with no connectors at all.",
+    "artifacts": {
+     "ko": {
+      "svg": "examples/svg-infographic/zero-trust-onion/zero-trust-onion.ko.svg",
+      "svgDigest": "sha256:5417f8005fac0c3e60f0ea3c8403720711e684db6ef7f4888fbd2cb9ba0de21e"
+     },
+     "en": {
+      "svg": "examples/svg-infographic/zero-trust-onion/zero-trust-onion.en.svg",
+      "svgDigest": "sha256:32191b7b7086e7ccb87b1fe3530df6b1e37e4f441fc880d2638b0486b9add0f0"
+     }
+    },
+    "evidence": {
+     "sourceGates": "pass",
+     "typePackReceipt": "none",
+     "dataAccuracy": "not-applicable"
+    }
+   },
+   {
+    "slug": "before-after-migration",
+    "name": "Before and after",
+    "caption": "mirrored comparison",
+    "reason": "Alignment carries the correspondence between the two sides.",
+    "artifacts": {
+     "ko": {
+      "svg": "examples/svg-infographic/before-after-migration/before-after-migration.ko.svg",
+      "svgDigest": "sha256:89be1ec0271fc2486c1576c7f1bde84fb6c753fb1d90c2cee7b6f36ecc4f854b"
+     },
+     "en": {
+      "svg": "examples/svg-infographic/before-after-migration/before-after-migration.en.svg",
+      "svgDigest": "sha256:820c4c3cf06766a3d6a40556e390079e9d48e665dfb2e74cd061f187f781a41b"
+     }
+    },
+    "evidence": {
+     "sourceGates": "pass",
+     "typePackReceipt": "none",
+     "dataAccuracy": "not-applicable"
+    }
+   },
+   {
+    "slug": "agent-system-sketch",
+    "name": "Sketch treatment",
+    "caption": "handwriting and rough stroke",
+    "reason": "The one surface treatment that is not flat, shown on a structure that is not trivial.",
+    "artifacts": {
+     "ko": {
+      "svg": "examples/svg-infographic/agent-system-sketch/agent-system-sketch.ko.svg",
+      "svgDigest": "sha256:7c6a3123760e6833fcfadb66d66f5a2210fd3bc674525bc73bea80a726cab5e1"
+     },
+     "en": {
+      "svg": "examples/svg-infographic/agent-system-sketch/agent-system-sketch.en.svg",
+      "svgDigest": "sha256:e05ff70819c72dcbb2f4becf9c330eb646650c590b6be51bca1fe50b57e3ac3f"
+     }
+    },
+    "evidence": {
+     "sourceGates": "pass",
+     "typePackReceipt": "none",
+     "dataAccuracy": "not-applicable"
+    }
+   }
+  ]
+ }
 }

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -24,6 +24,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
 from skillstead_validate.gallery import (  # noqa: E402
     EXAMPLES, MODEL_PATH, TOKENS_PATH, GalleryError, NodeRunner, build_model, run_gallery,
 )
+from skillstead_validate.gallery_html import GALLERY_HTML, render  # noqa: E402
+
+FEATURED = "gallery/featured.json"
 
 REPO = Path(__file__).resolve().parent.parent
 NODE = shutil.which("node")
@@ -264,6 +267,238 @@ class GalleryModelFixtures(unittest.TestCase):
     def test_missing_model_is_caught(self):
         (self.repo / MODEL_PATH).unlink()
         self.assertIn("GAL-DRIFT", self.checks())
+
+    # ---- the rendered page ---------------------------------------------------------------
+
+    def test_page_is_regenerated_with_the_model(self):
+        """Both outputs come from one command, so neither can be refreshed while the other rots."""
+        self.assertEqual(self.checks(), set())
+        page = (self.repo / GALLERY_HTML)
+        self.assertTrue(page.exists())
+        page.write_text(page.read_text(encoding="utf-8") + "<!-- hand edit -->\n", encoding="utf-8")
+        findings = run_gallery(self.repo)
+        self.assertIn("GAL-DRIFT", {f.check for f in findings})
+        self.assertTrue(any(GALLERY_HTML in f.subject for f in findings), findings)
+
+    def test_a_token_change_moves_the_page(self):
+        """Tokens are the source the page renders from, not a document describing it."""
+        before = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        p = self.repo / TOKENS_PATH
+        t = json.loads(p.read_text())
+        t["palette"]["ground"] = "#123456"
+        p.write_text(json.dumps(t, indent=1), encoding="utf-8")
+        self.assertIn("GAL-DRIFT", {f.check for f in run_gallery(self.repo)})
+        self.assertEqual(run_gallery(self.repo, write=True), [])
+        after = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        self.assertNotEqual(before, after)
+        self.assertIn("#123456", after)
+
+    def test_page_makes_no_external_request(self):
+        h = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        self.assertNotIn("http://", h)
+        self.assertNotIn("https://", h)
+        self.assertNotIn("@import", h)
+
+    def test_page_shows_both_locales_without_scripting(self):
+        """The no-JS state is the complete view. Nothing is hidden unless scripting has put a locale
+        on the root, the switch never appears without scripting, and detail opens on its own — so
+        both sections and every prompt remain reachable."""
+        h = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        self.assertIn('id="switch" hidden', h)
+        for rule in ('[data-locale="ko"] figure[data-loc="en"]', '[data-locale="en"] figure[data-loc="ko"]'):
+            self.assertIn(rule, h)
+        self.assertEqual(h.count("<details>"), 9)
+
+    def test_featured_switches_locale_with_the_catalog(self):
+        """The switch is one control for the whole page: featured artifacts carry data-loc exactly
+        as catalog thumbnails do, so a locale choice cannot apply to one section only."""
+        h = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        import re
+        feat = re.search(r'<div class="featured">(.*?)</div>\s*<p class="note">', h, re.S).group(1)
+        self.assertEqual(feat.count('data-loc="ko"'), 6)
+        self.assertEqual(feat.count('data-loc="en"'), 6)
+
+    def test_page_alt_text_names_the_type_and_the_artifact(self):
+        """Alt text describes the picture. The selection signal says when to reach for the type,
+        which is a different sentence and would not describe anything."""
+        import re
+        model, _ = build_model(self.repo)
+        h = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        # Content images only. The zoom dialog holds an empty placeholder whose src and alt are
+        # both copied from the clicked image, so it describes nothing until it has something to
+        # describe — asserted separately below rather than counted here.
+        content, _, shell = h.partition("<dialog")
+        alts = re.findall(r'alt="([^"]*)"', content)
+        expected = 2 * (len(model["typepacks"]) + len(model["featured"]["entries"]))
+        self.assertEqual(len(alts), expected, "every image in both sections needs alt text")
+        self.assertFalse([a for a in alts if not a.strip()])
+        self.assertIn('alt = a.querySelector("img").alt', shell,
+                      "the zoom placeholder must take the alt of the image it is showing")
+        for t in model["typepacks"]:
+            for loc, e in t["locales"].items():
+                self.assertIn(f'{t["id"]} — {e["title"]} ({loc.upper()})', alts)
+            signal = (t.get("selectionSignal") or "")[:25]
+            self.assertFalse([a for a in alts if signal and signal in a],
+                             f'{t["id"]}: the selection signal must not be used as alt text')
+        for f in model["featured"]["entries"]:
+            for loc in ("ko", "en"):
+                self.assertIn(f'{f["name"]} — {f["caption"]} ({loc.upper()})', alts,
+                              f'{f["slug"]}/{loc}: featured alt text describes the picture too')
+
+    def test_page_shows_the_verified_svg_not_the_png(self):
+        h = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        import re
+        model, _ = build_model(self.repo)
+        srcs = re.findall(r'<img src="([^"]+)"', h)
+        self.assertEqual(len(srcs), 2 * (len(model["typepacks"]) + len(model["featured"]["entries"])))
+        self.assertTrue(all(s.endswith(".svg") for s in srcs),
+                        "the SVG is what the gates and the verifier re-checked")
+
+    def test_page_links_resolve(self):
+        import os, re
+        h = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        links = set(re.findall(r'(?:src|href)="(\.\./[^"#]+)(?:#[^"]*)?"', h))
+        missing = [l for l in sorted(links) if not (self.repo / "gallery" / l).exists()]
+        self.assertEqual(missing, [], "repository -> package relative links must resolve")
+
+    # ---- featured: an editorial list with only the claim its evidence supports -----------
+
+    def test_featured_comes_from_the_editorial_file(self):
+        model, _ = build_model(self.repo)
+        declared = json.loads((self.repo / FEATURED).read_text())["entries"]
+        got = model["featured"]["entries"]
+        self.assertEqual([e["slug"] for e in got], [e["slug"] for e in declared],
+                         "the model must publish exactly what the editorial file selects")
+        for e in got:
+            self.assertTrue(e["artifacts"].get("ko") and e["artifacts"].get("en"))
+            self.assertTrue(e["reason"], f'{e["slug"]}: a selection without a reason is not editorial')
+
+    def test_featured_claims_only_the_gates_it_passes(self):
+        """These predate the TypePack receipts. Saying so explicitly is the point — `none` is a
+        verdict, not a missing field."""
+        model, _ = build_model(self.repo)
+        for e in model["featured"]["entries"]:
+            self.assertEqual(e["evidence"]["sourceGates"], "pass")
+            self.assertEqual(e["evidence"]["typePackReceipt"], "none")
+            self.assertEqual(e["evidence"]["dataAccuracy"], "not-applicable")
+
+    def test_featured_verified_count_is_not_mixed_into_the_typepack_count(self):
+        h = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        model, _ = build_model(self.repo)
+        n = sum(1 for t in model["typepacks"] for e in t["locales"].values() if e["verified"])
+        self.assertIn(f"{n}/{n} TypePack canonical artifacts pass", h)
+        self.assertNotIn(f"{n + len(model['featured']['entries'])}/", h)
+
+    def test_the_catalog_count_does_not_claim_semantic_completeness(self):
+        """Passing the verifier is not the same as drawing everything the receipt counts."""
+        h = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        self.assertNotIn("TypePack canonical examples verified", h)
+        self.assertIn("pass the current package verifier", h)
+        self.assertIn("tracked separately", h)
+
+    def test_an_entity_the_artifact_never_draws_is_reported_not_hidden(self):
+        """The verifier exempts one id from its own artifact check; the model reports the gap."""
+        model, _ = build_model(self.repo)
+        gaps = {(t["id"], loc): e["unrendered"]
+                for t in model["typepacks"] for loc, e in t["locales"].items()
+                if e.get("unrendered")}
+        self.assertTrue(gaps, "the known boundary gap disappeared without the model noticing")
+        for ids in gaps.values():
+            self.assertEqual(ids, ["boundary"], gaps)
+
+        h = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        # Shown on exactly the packs that have a gap — not on every card, and not nowhere.
+        self.assertEqual(h.count("Known limitation"),
+                         len({tid for tid, _ in gaps}), gaps)
+        self.assertIn("does not draw it", h)
+
+    def test_a_pack_with_nothing_unrendered_carries_no_limitation_note(self):
+        """The note is derived, so it must vanish on its own once the entity is drawn."""
+        tid = "topology-component"
+        for loc in ("ko", "en"):
+            svg = self.repo / EXAMPLES / tid / f"{tid}.{loc}.svg"
+            t = svg.read_text(encoding="utf-8")
+            # Stand in for the fix: give the artifact the entity it was already credited with.
+            svg.write_text(t.replace("</svg>", '<g data-entity="boundary"></g></svg>'),
+                           encoding="utf-8")
+        # The edit invalidates the artifact digest, so this pack also stops being verified. That
+        # is a side effect of the stand-in, not the subject: what is asserted is only that the
+        # note follows the gap.
+        model, _ = build_model(self.repo)
+        pack = next(t for t in model["typepacks"] if t["id"] == tid)
+        self.assertIsNone(pack["locales"]["ko"].get("unrendered"))
+        tokens = json.loads((self.repo / TOKENS_PATH).read_text(encoding="utf-8"))
+        self.assertNotIn("Known limitation", render(model, tokens))
+
+    def test_a_caption_carrying_a_number_is_refused(self):
+        """A count in a caption is a claim about the artifact that no gate checks."""
+        p = self.repo / FEATURED
+        d = json.loads(p.read_text())
+        d["entries"][0]["caption"] = "20+ connectors"
+        p.write_text(json.dumps(d, indent=1, ensure_ascii=False), encoding="utf-8")
+        findings = run_gallery(self.repo)
+        self.assertIn("GAL-FEATURED", {f.check for f in findings})
+        self.assertTrue(any("digit" in f.detail for f in findings), findings)
+
+    def test_a_featured_entry_pointing_nowhere_is_refused(self):
+        p = self.repo / FEATURED
+        d = json.loads(p.read_text())
+        d["entries"][0]["slug"] = "no-such-example"
+        p.write_text(json.dumps(d, indent=1, ensure_ascii=False), encoding="utf-8")
+        self.assertIn("GAL-FEATURED", {f.check for f in run_gallery(self.repo)})
+
+    def test_a_featured_artifact_failing_the_gates_is_refused(self):
+        """The one claim featured entries make has to be re-established, not asserted.
+
+        The mutation has to be something a gate genuinely rejects: an element outside the viewBox is
+        an E-BOUNDS error the linter owns. An earlier attempt appended an empty rect, which changed
+        the bytes without violating anything — the build then failed on drift instead, which would
+        have let this test pass while proving nothing about the gates.
+        """
+        svg = self.repo / "examples/svg-infographic/zero-trust-onion/zero-trust-onion.ko.svg"
+        svg.write_text(
+            svg.read_text(encoding="utf-8").replace(
+                "</svg>", '<rect x="9000" y="9000" width="200" height="200" fill="#000"/></svg>'),
+            encoding="utf-8")
+        findings = run_gallery(self.repo)
+        self.assertIn("GAL-FEATURED", {f.check for f in findings})
+        self.assertTrue(any("source gates failed" in f.detail for f in findings), findings)
+
+    def test_editorial_file_missing_fails_the_build(self):
+        (self.repo / FEATURED).unlink()
+        self.assertIn("GAL-FEATURED", {f.check for f in run_gallery(self.repo)})
+
+    # ---- evidence is facets, not a ranking ----------------------------------------------
+
+    def test_evidence_is_three_independent_facets(self):
+        """Nothing in the model orders these. A chart will add a data-accuracy verdict without
+        becoming 'more verified' than a diagram that never had one to give."""
+        model, _ = build_model(self.repo)
+        holders = [e for t in model["typepacks"] for e in t["locales"].values()]
+        holders += model["featured"]["entries"]
+        allowed = {"pass", "none", "not-applicable"}
+        for h in holders:
+            ev = h["evidence"]
+            self.assertEqual(set(ev), {"sourceGates", "typePackReceipt", "dataAccuracy"})
+            for k, v in ev.items():
+                self.assertIn(v, allowed, f"{k}={v}")
+        # The two groups differ in exactly one facet, which is the distinction worth carrying.
+        tp = model["typepacks"][0]["locales"]["ko"]["evidence"]
+        ft = model["featured"]["entries"][0]["evidence"]
+        self.assertEqual(tp["sourceGates"], ft["sourceGates"])
+        self.assertNotEqual(tp["typePackReceipt"], ft["typePackReceipt"])
+
+    def test_page_prints_facets_and_not_a_tier(self):
+        import re
+        h = (self.repo / GALLERY_HTML).read_text(encoding="utf-8")
+        self.assertIn("source gates", h)
+        self.assertIn("TypePack receipt", h)
+        # not-applicable facets are omitted rather than shown as an empty claim
+        self.assertNotIn("not-applicable", h)
+        # No ranking vocabulary around the evidence. Matched as ordinals rather than as substrings:
+        # "degrade receipt" is the generator's own term and contains "grade".
+        self.assertNotIn("tier", h.lower())
+        self.assertIsNone(re.search(r"\b(grade|level|rank)\s*\d", h, re.I))
 
     # ---- tokens ------------------------------------------------------------------------
 

--- a/tools/gallery_export.mjs
+++ b/tools/gallery_export.mjs
@@ -37,4 +37,46 @@ for (const p of packs) {
   }
 }
 
-process.stdout.write(JSON.stringify({ schemaVersion: 1, typepacks: packs, payloads }, null, 1) + "\n");
+// --- featured: the repository's editorial selection ------------------------------------
+// Validated here so a bad entry fails the build rather than rendering a broken card. The rules are
+// deliberately few: the artifact must exist in both locales, and a caption may not carry digits —
+// a number in a caption is a claim about the picture that no gate verifies.
+const featuredPath = path.join(root, "gallery", "featured.json");
+const featured = { source: "gallery/featured.json", entries: [], errors: [] };
+if (!existsSync(featuredPath)) {
+  featured.errors.push("gallery/featured.json is missing — the featured showcase has no source");
+} else {
+  let doc;
+  try { doc = JSON.parse(readFileSync(featuredPath, "utf8")); }
+  catch (e) { featured.errors.push(`gallery/featured.json is unreadable: ${e.message}`); doc = null; }
+  const seen = new Set();
+  for (const entry of (doc?.entries ?? [])) {
+    const slug = String(entry.slug ?? "");
+    if (!slug) { featured.errors.push("featured entry has no slug"); continue; }
+    if (seen.has(slug)) { featured.errors.push(`featured "${slug}" is listed twice`); continue; }
+    seen.add(slug);
+    for (const field of ["name", "caption", "reason"])
+      if (!entry[field]) featured.errors.push(`featured "${slug}" is missing ${field}`);
+    if (/\d/.test(String(entry.caption ?? "")))
+      featured.errors.push(`featured "${slug}" caption carries a digit — captions stay qualitative `
+        + `because a count is a claim no gate checks (got "${entry.caption}")`);
+    if (entry.span !== undefined)
+      featured.errors.push(`featured "${slug}" declares span — the grid sizes every entry the same, `
+        + `so a per-entry size control would be a field nothing reads`);
+    const dir = path.join(root, "examples", "svg-infographic", slug);
+    const art = {};
+    for (const loc of ["ko", "en"]) {
+      const rel = `examples/svg-infographic/${slug}/${slug}.${loc}.svg`;
+      if (!existsSync(path.join(root, rel))) featured.errors.push(`featured "${slug}": ${rel} is missing`);
+      else art[loc] = rel;
+    }
+    // Recorded, not required: these are hand-authored examples that predate the TypePack receipts.
+    const receipt = existsSync(path.join(dir, `${slug}.ko.json`));
+    featured.entries.push({ slug, name: entry.name, caption: entry.caption, reason: entry.reason,
+                            artifacts: art, hasReceipt: receipt });
+  }
+  if (!featured.entries.length && !featured.errors.length)
+    featured.errors.push("gallery/featured.json declares no entry");
+}
+
+process.stdout.write(JSON.stringify({ schemaVersion: 1, typepacks: packs, payloads, featured }, null, 1) + "\n");

--- a/tools/skillstead_validate/gallery.py
+++ b/tools/skillstead_validate/gallery.py
@@ -41,11 +41,13 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
 from .findings import Finding
+from .gallery_html import GALLERY_HTML, render as render_html
 
 SKILL = "skills/svg-infographic"
 EXAMPLES = "examples/svg-infographic/typepacks"
@@ -114,11 +116,30 @@ class NodeRunner:
         except (json.JSONDecodeError, KeyError) as e:
             raise GalleryError(f"preflight --json did not carry a runtime digest: {e}") from e
 
+    def source_gates(self, svg: Path) -> tuple[bool, str]:
+        """The three checks any artifact must pass regardless of how it was authored.
+
+        Featured examples predate the TypePack receipts, so this is the whole of what can be
+        claimed about them — which makes running it, rather than asserting it, the point.
+        """
+        for tool, args in ((f"{SKILL}/scripts/check-svg.mjs", []),
+                           (f"{SKILL}/scripts/check-layout.mjs", []),
+                           (f"{SKILL}/scripts/skin.mjs", ["typography-check"])):
+            r = self._run([tool, *args, str(svg)])
+            if r.returncode != 0:
+                return False, f"{Path(tool).name} exit {r.returncode}: {(r.stdout + r.stderr).strip()[:200]}"
+        return True, ""
+
     def verify(self, receipt: Path, svg: Path) -> tuple[bool, str]:
         r = self._run([f"{SKILL}/scripts/generate.mjs", "verify",
                        "--receipt", str(receipt), "--svg", str(svg)])
         out = (r.stdout + r.stderr).strip()
         return r.returncode == 0 and " 0 error(s)" in out, out
+
+
+def _rendered_entities(svg: Path) -> set:
+    """Entity ids the artifact actually carries, by the same marker the verifier reads."""
+    return set(re.findall(r'data-entity="([^"]+)"', svg.read_text(encoding="utf-8")))
 
 
 def _sha256(p: Path) -> str:
@@ -139,6 +160,16 @@ def _token(tokens: dict, dotted: str):
             return None
         node = node[part]
     return node
+
+
+# Evidence is three independent questions, not a ladder. An artifact can pass the source gates and
+# have no receipt; a chart will one day have a receipt AND a data-accuracy verdict. Ranking them
+# would force "chart is more verified than a diagram", which is not what any of these mean.
+#   pass            the check ran and succeeded
+#   none            the check applies but no evidence exists for this artifact
+#   not-applicable  the check does not apply to this kind of artifact
+def _facets(source_gates: str, receipt: str, data_accuracy: str = "not-applicable") -> dict:
+    return {"sourceGates": source_gates, "typePackReceipt": receipt, "dataAccuracy": data_accuracy}
 
 
 def _parity(ko, en):
@@ -234,11 +265,21 @@ def build_model(repo_root: Path, runner: NodeRunner | None = None) -> tuple[dict
                 "residual": receipt.get("residual"),
                 "residualDisposition": receipt.get("residualDisposition"),
                 "consumed": receipt.get("consumed") or [],
+                # Entities the receipt counts as consumed that the artifact never draws. Derived,
+                # not declared: `generate.mjs verify` exempts one id from this same check, so the
+                # gap it permits is reported here rather than described in prose that would go
+                # stale the moment the exemption is removed and the artifacts are regenerated.
+                "unrendered": [c for c in (receipt.get("consumed") or [])
+                               if c not in _rendered_entities(svg)] or None,
                 "svg": f"{EXAMPLES}/{tid}/{tid}.{loc}.svg",
                 "svgDigest": svg_digest,
                 "receipt": f"{EXAMPLES}/{tid}/{tid}.{loc}.json",
                 # Present only when every fact holds. Absent means unverified — never "assume ok".
                 "verified": all(checks.values()) or None,
+                # The same claim expressed as facets, so a surface can say what was and was not
+                # checked instead of collapsing it to one word.
+                "evidence": _facets("pass" if all(checks.values()) else "none",
+                                    "pass" if all(checks.values()) else "none"),
             }
             for field in REQUIRED_LOCALE_FIELDS:
                 if entry.get(field) in (None, "", []):
@@ -277,6 +318,31 @@ def build_model(repo_root: Path, runner: NodeRunner | None = None) -> tuple[dict
             "locales": locales,
         })
 
+    # --- featured: the editorial selection, with only the claim its evidence supports ----------
+    fx = export.get("featured") or {}
+    for err in fx.get("errors") or []:
+        findings.append(Finding("GAL-FEATURED", "gallery/featured.json", err))
+    featured = []
+    for entry in fx.get("entries") or []:
+        arts, gates_ok, detail = {}, True, ""
+        for loc, rel in (entry.get("artifacts") or {}).items():
+            svg = root / rel
+            ok, why = runner.source_gates(svg)
+            if not ok:
+                gates_ok = False
+                detail = why
+                findings.append(Finding("GAL-FEATURED", f'{entry["slug"]}/{loc}',
+                                        f"source gates failed — {why}"))
+            arts[loc] = {"svg": rel, "svgDigest": _sha256(svg)}
+        featured.append({
+            "slug": entry["slug"], "name": entry.get("name"), "caption": entry.get("caption"),
+            "reason": entry.get("reason"),
+            "artifacts": arts,
+            # Hand-authored, predating the TypePack receipts: the gates are the whole claim.
+            "evidence": _facets("pass" if gates_ok else "none",
+                                "pass" if entry.get("hasReceipt") else "none"),
+        })
+
     model = {
         "schemaVersion": 1,
         "generatedBy": "skillstead_validate gallery",
@@ -287,6 +353,16 @@ def build_model(repo_root: Path, runner: NodeRunner | None = None) -> tuple[dict
         "tokens": TOKENS_PATH,
         "typepackCount": len(entries),
         "typepacks": entries,
+        "featured": {
+            "source": fx.get("source", "gallery/featured.json"),
+            "note": "Editorial selection, transitional for Wave 1. The final composition and any "
+                    "unification of the evidence facets are settled after Wave 2 through a "
+                    "replacement audition, not automatically — a candidate replaces an entry only "
+                    "when a receipt check and a visual audition find it the better showcase, and "
+                    "retaining an entry is a valid, recorded outcome. Until then the legacy "
+                    "provenance and absent receipt stand as the facets report them.",
+            "entries": featured,
+        },
     }
     return model, findings
 
@@ -304,16 +380,28 @@ def run_gallery(repo_root: Path, write: bool = False) -> list[Finding]:
         # claim something the artifacts do not support.
         return findings
 
-    rendered = json.dumps(model, indent=1, ensure_ascii=False) + "\n"
-    target = root / MODEL_PATH
+    tokens = _read_json(root / TOKENS_PATH)
+    # The model and the page are generated together on purpose: regenerating one and forgetting the
+    # other is exactly the drift this command exists to prevent.
+    outputs = {
+        MODEL_PATH: json.dumps(model, indent=1, ensure_ascii=False) + "\n",
+        GALLERY_HTML: render_html(model, tokens),
+    }
+
     if write:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(rendered, encoding="utf-8")
+        for rel, text in outputs.items():
+            target = root / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(text, encoding="utf-8")
         return []
-    if not target.exists():
-        return [Finding("GAL-DRIFT", MODEL_PATH, "model is missing — regenerate with `gallery --write`")]
-    if target.read_text(encoding="utf-8") != rendered:
-        return [Finding("GAL-DRIFT", MODEL_PATH,
-                        "model is out of date with the manifest, inputs, receipts or artifacts "
-                        "(regenerate with `gallery --write`)")]
-    return []
+
+    drift: list[Finding] = []
+    for rel, text in outputs.items():
+        target = root / rel
+        if not target.exists():
+            drift.append(Finding("GAL-DRIFT", rel, "missing — regenerate with `gallery --write`"))
+        elif target.read_text(encoding="utf-8") != text:
+            drift.append(Finding("GAL-DRIFT", rel,
+                                 "out of date with the manifest, inputs, receipts, artifacts or "
+                                 "tokens (regenerate with `gallery --write`)"))
+    return drift

--- a/tools/skillstead_validate/gallery_html.py
+++ b/tools/skillstead_validate/gallery_html.py
@@ -1,0 +1,400 @@
+"""The repository gallery — a human-facing page rendered from the gallery model.
+
+This is not the review sheet reproduced for the public. A review sheet answers "did everything
+pass", so it puts verification on every card. A reader arriving here is asking something else —
+"can this thing draw what I need, and which type do I pick" — so the page answers in that order:
+
+    featured   six existing outputs, shaped as differently as the catalog can manage
+    catalog    the nine TypePacks, compact enough to scan in one screen
+
+Evidence is reported as three independent facets rather than a single word or a ranking. An artifact
+can clear the source gates and have no receipt; a chart will one day carry a receipt *and* a
+data-accuracy verdict. Collapsing that into "more verified" would say something none of the checks
+mean. Each facet reads pass / none / not-applicable, and the page prints only the facets that
+actually apply to what it is showing.
+
+Both sections switch locale together, and both stay fully visible without scripting: the switch is
+hidden until JS reveals it, and `<details>` opens on its own. The fallback is the whole page, not a
+reduced one.
+
+Everything is derived — copy from the payloads through the model, geometry facts from the receipts,
+the featured selection from `gallery/featured.json`, and every colour, radius and step from
+`gallery/tokens.json`.
+
+Images point at the **SVG**, because that is what the gates and the verifier re-checked. The featured
+artifacts differ widely in aspect ratio, and the section's claim is that they are one managed set, so
+every one gets the same media viewport and keeps its own proportions inside it. Each frame is a link
+to the artifact, which gives full size with no scripting; where scripting exists the click opens a
+dialog instead.
+"""
+
+from __future__ import annotations
+
+import html
+from pathlib import Path
+
+GALLERY_HTML = "gallery/index.html"
+LOCALE_LABEL = {"ko": "한국어", "en": "ENGLISH"}
+FACET_LABEL = {"sourceGates": "source gates", "typePackReceipt": "TypePack receipt",
+               "dataAccuracy": "data accuracy"}
+
+
+def _e(v) -> str:
+    return html.escape("" if v is None else str(v), quote=True)
+
+
+def _facet_line(evidence: dict, show: tuple[str, ...]) -> str:
+    """Print the facets that apply, each with its own verdict. `not-applicable` stays unprinted —
+    naming a check that does not apply tells the reader nothing and crowds the ones that do."""
+    parts = []
+    for key in show:
+        val = (evidence or {}).get(key)
+        if val in (None, "not-applicable"):
+            continue
+        cls = "ok" if val == "pass" else "none"
+        parts.append(f'<span class="facet {cls}"><i>{_e(FACET_LABEL[key])}</i>{_e(val)}</span>')
+    return f'<p class="facets">{"".join(parts)}</p>' if parts else ""
+
+
+def _css(t: dict) -> str:
+    p, sh, sp, ty, g = (t[k] for k in ("palette", "shape", "space", "type", "grid"))
+    return f""":root {{
+  --ground: {p['ground']};
+  --card: {p['card']};
+  --card-edge: {p['cardEdge']};
+  --ink: {p['ink']};
+  --ink-muted: {p['inkMuted']};
+  --verified: {p['verified']};
+  --verified-ground: {p['verifiedGround']};
+  --card-radius: {sh['cardRadius']}px;
+  --image-radius: {sh['imageRadius']}px;
+  --chip-radius: {sh['chipRadius']}px;
+  --card-pad: {sp['cardPad']}px;
+  --card-gap: {sp['cardGap']}px;
+  --pair-gap: {sp['pairGap']}px;
+  --caption-gap: {sp['captionGap']}px;
+  --font-identifier: {ty['identifier']['family']};
+  --font-prose: {ty['prose']['family']};
+  --font-caption: {ty['caption']['family']};
+  --max-width: {g['galleryMaxWidth']}px;
+}}
+* {{ box-sizing: border-box; }}
+body {{
+  margin: 0; background: var(--ground); color: var(--ink);
+  font: {ty['prose']['size']}px/{ty['prose']['lineHeight']} var(--font-prose);
+  font-variant-numeric: tabular-nums;
+}}
+.wrap {{ max-width: var(--max-width); margin: 0 auto; padding: 3rem 1.25rem 5rem; }}
+h1 {{ font-size: 1.55rem; line-height: 1.25; margin: 0 0 .5rem; letter-spacing: -.015em; text-wrap: balance; }}
+.lede {{ color: var(--ink-muted); margin: 0 0 1rem; max-width: 64ch; }}
+h2.sec {{ font-size: 1.1rem; margin: 3rem 0 .3rem; letter-spacing: -.01em; }}
+.sec-note {{ color: var(--ink-muted); margin: 0 0 .9rem; max-width: 70ch; font-size: 14px; }}
+
+.facets {{ display: flex; flex-wrap: wrap; gap: .35rem; margin: 0 0 1rem; }}
+.facet {{
+  display: inline-flex; align-items: baseline; gap: .4rem;
+  border: 1px solid var(--card-edge); border-radius: var(--chip-radius);
+  padding: .26rem .55rem; font: 600 11px/1 var(--font-identifier); background: var(--card);
+  color: var(--ink-muted);
+}}
+.facet i {{ font-style: normal; font-weight: 400; }}
+.facet.ok {{ background: var(--verified-ground); color: var(--verified);
+  border-color: color-mix(in srgb, var(--verified) 25%, transparent); }}
+
+.switch {{ display: flex; gap: .3rem; margin: 0 0 1.4rem; }}
+.switch button {{
+  font: 600 12px/1 var(--font-identifier); letter-spacing: .04em;
+  background: var(--card); color: var(--ink-muted);
+  border: 1px solid var(--card-edge); border-radius: var(--chip-radius);
+  padding: .42rem .7rem; cursor: pointer;
+}}
+.switch button[aria-pressed="true"] {{ color: var(--ink); border-color: var(--ink-muted); }}
+.switch button:focus-visible, summary:focus-visible, a:focus-visible {{
+  outline: 2px solid var(--verified); outline-offset: 2px;
+}}
+
+/* ---- featured ------------------------------------------------------------------------ */
+/* Every entry gets the same cell and the same media viewport. Sizing entries individually made the
+   row read as a layout that varies per artifact; one viewport makes six very differently shaped
+   outputs read as one managed set — which is the claim the section is making. The artifacts keep
+   their own proportions inside it via object-fit, so nothing is cropped or distorted. */
+.featured {{ display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--pair-gap); }}
+@media (max-width: 980px) {{ .featured {{ grid-template-columns: repeat(2, minmax(0, 1fr)); }} }}
+@media (max-width: 640px) {{ .featured {{ grid-template-columns: minmax(0, 1fr); }} }}
+.feat {{
+  background: var(--card); border: 1px solid var(--card-edge);
+  border-radius: var(--card-radius); padding: 13px;
+}}
+.frame {{
+  aspect-ratio: 4 / 3; background: #fff; border: 1px solid var(--card-edge);
+  border-radius: var(--image-radius); display: flex; align-items: center; justify-content: center;
+  overflow: hidden; padding: 9px;
+}}
+.frame img {{ max-width: 100%; max-height: 100%; width: auto; height: auto; object-fit: contain; }}
+/* The frame links to the artifact itself, so full size works with no scripting at all; when
+   scripting is present the click is intercepted and shown in a dialog instead. */
+a.frame {{ cursor: zoom-in; text-decoration: none; }}
+dialog {{ border: 0; padding: 0; background: transparent; max-width: 96vw; max-height: 96vh; }}
+dialog::backdrop {{ background: rgba(20, 20, 26, .72); }}
+dialog img {{ max-width: 96vw; max-height: 92vh; background: #fff; border-radius: 6px; display: block; }}
+dialog form {{ text-align: right; margin-top: .5rem; }}
+dialog button {{
+  font: 600 12px/1 var(--font-identifier); background: var(--card); color: var(--ink);
+  border: 1px solid var(--card-edge); border-radius: var(--chip-radius); padding: .45rem .7rem;
+  cursor: pointer;
+}}
+/* Captions wrap to one or two lines depending on the words. Reserving the taller of the two keeps
+   the row of cards level instead of stepping by a line height. */
+.feat .cap {{
+  display: flex; justify-content: space-between; align-items: baseline; gap: 8px;
+  margin-top: 10px; min-height: 2.6em;
+}}
+.feat .nm {{ font: 600 13px/1.3 var(--font-identifier); }}
+.feat .sub {{ color: var(--ink-muted); font-size: 12px; text-align: right; }}
+/* Featured artifacts are the argument the page opens with, so one locale fills the card rather
+   than two sharing it. With scripting the switch picks which; without it both stack, which is
+   taller but complete. */
+.feat .pair {{ display: grid; gap: 10px; grid-template-columns: minmax(0, 1fr); }}
+.feat figcaption {{
+  color: var(--ink-muted); margin-bottom: 5px;
+  font: 600 10px/1 var(--font-caption); letter-spacing: .08em; text-transform: uppercase;
+}}
+
+/* ---- catalog ------------------------------------------------------------------------- */
+.catalog {{ display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--pair-gap); }}
+@media (max-width: 900px) {{ .catalog {{ grid-template-columns: repeat(2, minmax(0, 1fr)); }} }}
+@media (max-width: 620px) {{ .catalog {{ grid-template-columns: minmax(0, 1fr); }} }}
+article {{
+  background: var(--card); border: 1px solid var(--card-edge);
+  border-radius: var(--card-radius); padding: 14px;
+}}
+h3 {{ margin: 0; font: 600 13px/1.3 var(--font-identifier); letter-spacing: -.01em; }}
+h3 a {{ color: inherit; text-decoration: none; }}
+h3 a:hover {{ text-decoration: underline; }}
+.signal {{
+  color: var(--ink-muted); margin: .35rem 0 .8rem; font-size: 12.5px;
+  display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
+}}
+.pair {{ display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }}
+[data-locale="ko"] .catalog .pair, [data-locale="en"] .catalog .pair {{ grid-template-columns: minmax(0, 1fr); }}
+figure {{ margin: 0; min-width: 0; }}
+figcaption {{
+  color: var(--ink-muted); margin-bottom: var(--caption-gap);
+  font: 600 10px/1 var(--font-caption); letter-spacing: .07em; text-transform: uppercase;
+}}
+details {{ margin-top: 12px; border-top: 1px solid var(--card-edge); padding-top: 10px; }}
+summary {{ cursor: pointer; color: var(--ink-muted); font: 600 11px/1 var(--font-identifier); letter-spacing: .04em; }}
+.detail {{ margin-top: 11px; display: grid; gap: 12px; }}
+.detail h4 {{
+  margin: 0 0 5px; font: 600 10px/1 var(--font-caption); letter-spacing: .08em;
+  text-transform: uppercase; color: var(--ink-muted);
+}}
+pre {{
+  margin: 0; padding: .7rem .8rem; overflow-x: auto; background: var(--ground);
+  border: 1px solid var(--card-edge); border-radius: var(--chip-radius);
+  font: 11px/1.6 var(--font-identifier); white-space: pre;
+}}
+.chips {{ display: flex; flex-wrap: wrap; gap: 5px; }}
+.chip {{
+  display: inline-flex; align-items: baseline; gap: 5px; background: var(--ground);
+  border: 1px solid var(--card-edge); border-radius: var(--chip-radius);
+  padding: 3px 7px; font: 11px/1.4 var(--font-identifier);
+}}
+.chip i {{ font-style: normal; color: var(--ink-muted); font-size: 10px; }}
+table {{ border-collapse: collapse; width: 100%; font: 11px/1.5 var(--font-identifier); }}
+th, td {{ text-align: left; padding: 3px 8px 3px 0; border-bottom: 1px solid var(--card-edge); }}
+th {{ color: var(--ink-muted); font-weight: 600; }}
+td.split {{ font-weight: 600; }}
+.scroll {{ overflow-x: auto; }}
+a {{ color: var(--ink); }}
+.note {{ color: var(--ink-muted); font-size: 12px; margin: .5rem 0 0; }}
+
+/* Nothing is hidden unless JS has set a locale on the root, so the no-script view is complete. */
+[data-locale="ko"] figure[data-loc="en"], [data-locale="en"] figure[data-loc="ko"] {{ display: none; }}
+@media (prefers-reduced-motion: reduce) {{ * {{ transition: none !important; }} }}"""
+
+
+def _frame(src: str, alt: str, zoom: bool = False) -> str:
+    img = f'<img src="{_e(src)}" alt="{_e(alt)}" loading="lazy">'
+    if not zoom:
+        return f'<div class="frame">{img}</div>'
+    return f'<a class="frame" href="{_e(src)}" data-full="{_e(src)}">{img}</a>'
+
+
+def _featured_card(f: dict) -> str:
+    figs = ""
+    for loc in ("ko", "en"):
+        art = (f.get("artifacts") or {}).get(loc)
+        if not art:
+            continue
+        alt = f'{f.get("name")} — {f.get("caption")} ({loc.upper()})'
+        figs += (f'<figure data-loc="{loc}"><figcaption>{_e(LOCALE_LABEL[loc])}</figcaption>'
+                 f'{_frame("../" + art["svg"], alt, zoom=True)}</figure>')
+    return (f'<div class="feat"><div class="pair">{figs}</div>'
+            f'<div class="cap"><span class="nm">{_e(f.get("name"))}</span>'
+            f'<span class="sub">{_e(f.get("caption"))}</span></div></div>')
+
+
+def _detail(t: dict) -> str:
+    ko, en = t["locales"]["ko"], t["locales"]["en"]
+    facts = [("profile", t.get("profile")), ("preset", t.get("preset")),
+             ("treatment", t.get("treatment")), ("delivery", t.get("fontDelivery")),
+             ("entities", len(ko.get("consumed") or []))]
+    chips = "".join(f'<span class="chip"><i>{_e(k)}</i>{_e(v)}</span>' for k, v in facts if v not in (None, ""))
+
+    rows = "".join(
+        f'<tr><td>{_e(f.get("preset"))}</td><td>{_e(f.get("count"))}</td>'
+        f'<td class="{"split" if f.get("result") == "needs-split" else ""}">{_e(f.get("result"))}</td></tr>'
+        for f in (t.get("feasibility") or []))
+    boundary = (f'<div><h4>Where it stops fitting</h4><div class="scroll"><table>'
+                f'<tr><th>preset</th><th>count</th><th>verdict</th></tr>{rows}</table></div>'
+                f'<p class="note"><code>needs-split</code> returns a degrade receipt and no artifact '
+                f'— a non-success, not a smaller render.</p></div>') if rows else ""
+
+    stress = ""
+    if t.get("stress"):
+        items = "".join(
+            f'<tr><td>{_e(str(s.get("id", "")).replace(t["id"] + "-", ""))}</td>'
+            f'<td>{_e(s.get("preset"))}</td>'
+            f'<td class="{"split" if s.get("geometryExpected") == "needs-split" else ""}">'
+            f'{_e(s.get("geometryExpected"))}</td></tr>' for s in t["stress"])
+        stress = (f'<div><h4>Declared stress scenarios</h4><div class="scroll"><table>'
+                  f'<tr><th>scenario</th><th>preset</th><th>expected</th></tr>{items}</table></div></div>')
+
+    # A template, not a runnable line: the output paths are placeholders and it runs from the
+    # package directory, so both are stated rather than implied.
+    cmd = (f'# from skills/svg-infographic/\n'
+           f'node scripts/generate.mjs build --typepack {t["id"]} --case canonical \\\n'
+           f'  --locale ko --out OUT.svg --receipt OUT.json\n'
+           f'node scripts/generate.mjs verify --receipt OUT.json --svg OUT.svg')
+
+    # Shown only where it is true, and derived from the model rather than asserted here, so the
+    # note disappears on its own once the renderer draws the entity and the artifacts regenerate.
+    unrendered = sorted({e for loc in ("ko", "en") for e in (t["locales"][loc].get("unrendered") or [])})
+    limit = (f'<div><h4>Known limitation</h4><p class="note">The receipt counts '
+             + ", ".join(f"<code>{_e(u)}</code>" for u in unrendered)
+             + f' as consumed, but the current package does not draw '
+             + ("it" if len(unrendered) == 1 else "them")
+             + '. Tracked separately from this gallery.</p></div>') if unrendered else ""
+
+    spec = str(t.get("spec") or "")
+    return f"""<details><summary>Prompt, command and limits</summary><div class="detail">
+<div><h4>Canonical prompt</h4><pre>ko: {_e(ko.get('prompt'))}
+en: {_e(en.get('prompt'))}</pre></div>
+<div><h4>Command template</h4><pre>{_e(cmd)}</pre></div>
+<div><h4>Receipt facts</h4><div class="chips">{chips}</div></div>
+{stress}{boundary}{limit}
+<div><h4>Sources</h4><p class="note">
+<a href="../skills/svg-infographic/references/{_e(spec)}"><code>{_e(Path(spec).name)}</code></a> ·
+<a href="../skills/svg-infographic/references/PROMPT-GALLERY.md#{_e(t['id'])}"><code>PROMPT-GALLERY.md</code></a> ·
+<a href="../{_e(ko.get('receipt'))}"><code>receipt</code></a>
+</p></div></div></details>"""
+
+
+def _catalog_card(t: dict) -> str:
+    figs = ""
+    for loc in ("ko", "en"):
+        e = t["locales"][loc]
+        alt = f'{t["id"]} — {e.get("title")} ({loc.upper()})'
+        figs += (f'<figure data-loc="{loc}"><figcaption>{_e(LOCALE_LABEL[loc])}</figcaption>'
+                 f'{_frame("../" + e["svg"], alt)}</figure>')
+    return (f'<article id="{_e(t["id"])}"><h3><a href="#{_e(t["id"])}">{_e(t["id"])}</a></h3>'
+            f'<p class="signal">{_e(t.get("selectionSignal"))}</p>'
+            f'<div class="pair">{figs}</div>{_detail(t)}</article>')
+
+
+def render(model: dict, tokens: dict) -> str:
+    packs = model.get("typepacks") or []
+    feat = (model.get("featured") or {}).get("entries") or []
+    verified = sum(1 for t in packs for e in t["locales"].values() if e.get("verified"))
+    total = sum(len(t["locales"]) for t in packs)
+
+    # Featured facets are reported once for the section: every entry carries the same shape of
+    # evidence, and repeating it per card would be six copies of one sentence.
+    feat_ev = feat[0]["evidence"] if feat else {}
+
+    return f"""<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TypePack Gallery</title>
+<!-- GENERATED VIEW — do not edit by hand.
+     Source of truth: gallery/model.json + gallery/tokens.json (+ gallery/featured.json).
+     Regenerate with `python3 -m skillstead_validate gallery --write`;
+     `--check` fails when this file drifts.
+     A single generated HTML entrypoint with no external network dependencies; images are
+     repository-relative SVGs. -->
+<style>
+{_css(tokens)}
+</style>
+<div class="wrap">
+<header>
+  <h1>Diagrams your agent can actually produce</h1>
+  <p class="lede">Every picture below was generated by this skill from a written prompt — no drawing,
+  no hand-tuned SVG. The showcase shows the range; the catalog under it is what you pick from.</p>
+  <div class="switch" id="switch" hidden>
+    <button type="button" data-set="both" aria-pressed="false">Side by side</button>
+    <button type="button" data-set="ko" aria-pressed="true">한국어</button>
+    <button type="button" data-set="en" aria-pressed="false">English</button>
+  </div>
+</header>
+
+<h2 class="sec">What it can draw</h2>
+<p class="sec-note">Six existing outputs, chosen for how differently they are shaped — a cloud
+topology, a branching swimlane, a decision matrix, nested trust rings, a mirrored comparison and the
+sketch treatment. Click any one to see it full size.</p>
+{_facet_line(feat_ev, ("sourceGates", "typePackReceipt"))}
+<div class="featured">{"".join(_featured_card(f) for f in feat)}</div>
+<p class="note">Hand-authored examples that predate the TypePack receipts. They clear the lint,
+layout and typography gates; no receipt exists for them, which is why the receipt facet reads
+<code>none</code> rather than being left out.</p>
+
+<h2 class="sec">Choose a TypePack</h2>
+<p class="sec-note">Nine minimum-syntax types — the catalog's regression baseline. Each card carries
+the signal that selects it and its Korean and English canonical example; open one for the prompt,
+the command template, and the point where that type stops fitting.</p>
+{_facet_line((packs[0]["locales"]["ko"]["evidence"] if packs else {}), ("sourceGates", "typePackReceipt"))}
+<p class="note">{verified}/{total} TypePack canonical artifacts pass the current package verifier.
+A known topology boundary-rendering limitation is tracked separately.</p>
+
+<div class="catalog">{"".join(_catalog_card(t) for t in packs)}</div>
+</div>
+<dialog id="zoom"><img alt=""><form method="dialog"><button>Close</button></form></dialog>
+<script>
+// Full size is a plain link by default, so it works with no scripting. Where scripting exists the
+// click is intercepted and shown in place instead of navigating away from the gallery.
+(function () {{
+  var dlg = document.getElementById("zoom");
+  if (!dlg || !dlg.showModal) return;
+  document.addEventListener("click", function (ev) {{
+    var a = ev.target.closest("a.frame[data-full]");
+    if (!a) return;
+    ev.preventDefault();
+    dlg.querySelector("img").src = a.dataset.full;
+    dlg.querySelector("img").alt = a.querySelector("img").alt;
+    dlg.showModal();
+  }});
+}})();
+// The locale switch is the only thing that needs scripting, so it stays hidden until scripting is
+// present. Without it both locales are already on screen and every detail still opens.
+(function () {{
+  var bar = document.getElementById("switch");
+  if (!bar) return;
+  bar.hidden = false;
+  function setLocale(mode) {{
+    document.documentElement.dataset.locale = mode === "both" ? "" : mode;
+    bar.querySelectorAll("button").forEach(function (x) {{
+      x.setAttribute("aria-pressed", String(x.dataset.set === mode));
+    }});
+  }}
+  // With scripting, open on one locale so a featured artifact fills its card. "Side by side" is one
+  // click away, and the no-script view already shows both.
+  setLocale("ko");
+  bar.addEventListener("click", function (ev) {{
+    var b = ev.target.closest("button[data-set]");
+    if (b) setLocale(b.dataset.set);
+  }});
+}})();
+</script>
+</html>
+"""


### PR DESCRIPTION
## 요약

`gallery/model.json`에서 KO·EN·side-by-side bilingual gallery page를 생성한다. Featured showcase와
9종 TypePack catalog의 2계층 구조이며, package 표면은 건드리지 않는다(`skills/`·`examples/` diff 0).

## 무엇이 들어갔나

- **`gallery/featured.json`** — Featured 선정의 repository-level editorial SSoT. 어떤 산출물이 이
  skill의 범위를 가장 잘 보여주는지는 저장소 판단이라 package나 renderer 상수가 아니라 여기 있다.
  entry별 크기 제어(`span`)는 두지 않는다 — grid가 모든 artifact에 같은 media viewport를 주므로
  entry마다 크기가 달라지면 "관리된 한 세트"라는 주장 자체가 흔들린다. exporter가 `span` 선언을
  **error**로 거부한다. caption에 숫자를 쓰는 것도 거부한다: 검증되지 않은 수치는 artifact에 대한
  주장이기 때문이다.
- **`tools/gallery_export.mjs`** — featured 검증(slug 존재, KO/EN 자산, 필수 필드, 중복). package의
  `parseYaml`을 그대로 import하므로 두 번째 YAML parser가 생기지 않는다.
- **`tools/skillstead_validate/gallery_html.py`** — renderer. 균일 3×2 Featured grid,
  `object-fit: contain`, 3→2→1 반응형. frame이 artifact 링크라 **스크립트 없이도 전체 크기**를 볼 수
  있고, 스크립트가 있으면 `<dialog>`로 가로챈다.
- **`gallery/index.html`** — 생성 산출물. `--check`가 drift를 막는다.

## 증거 표기

evidence는 등급이 아니라 **facet**이다. legacy showcase는 `sourceGates: pass` /
`typePackReceipt: none`, canonical artifact는 둘 다 `pass`다. receipt가 없는 것을 "낮은 등급"이 아니라
**없음**으로 적는다.

catalog 요약은 검증기가 실제로 보장하는 것만 말한다 — `18/18 TypePack canonical artifacts pass the
current package verifier. A known topology boundary-rendering limitation is tracked separately.`

## 알려진 한계 표시

`topology-component` detail에 known limitation을 붙였다. receipt가 `boundary`를 consumed로 집계하지만
현재 package가 그리지 않는다. 이 표시는 하드코딩이 아니라 receipt의 `consumed`와 artifact의
`data-entity`를 대조해 **파생**하므로, 결함이 고쳐지고 artifact가 재생성되면 스스로 사라진다.
결함 자체는 이 PR 밖의 독립 PATCH로 분리했다 — `generate.mjs`(runtime surface)를 바꾸면 18 receipt가
stale해지고 54 artifact 재생성이 따르므로, presentation 변경과 성질이 다르다.

## 검증

```
gallery --check (drift) : 0 finding(s)
repo validation         : 0 finding(s)
full unittest           : Ran 222 tests — OK
no-JS                   : featured 6/6, catalog 9/9, details 9
외부 참조(http/cdn)     : 0건
package/example diff    : 0건
```

## 범위 밖

Wave 1의 **transitional** gallery다. Featured 최종 구성과 evidence 수준 통합은 Wave 2 TypePack 완료 후
replacement audition에서 다시 확정한다. showcase entrypoint, receipt provenance, 신규 TypePack은 열지
않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)