### PR TITLE
chore(ci): base에서 package suite를 동일 조건으로 한 번 실행한다

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,6 +26,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The package's own suite subsets fonts, and its subsetter-dependent fixtures used to skip
+      # themselves silently when the toolchain was absent — which is what CI looked like, so those
+      # fixtures had never run here. The pins match references/delivery/font-delivery-v1.yaml; a
+      # mismatch is refused by the wrapper itself, so drift cannot pass as an acceptance build.
+      - name: Pinned font subsetter
+        run: |
+          python3 -m venv /tmp/svginfo-fonts
+          /tmp/svginfo-fonts/bin/pip install --quiet 'fonttools==4.53.1' 'brotli==1.1.0'
+          /tmp/svginfo-fonts/bin/python -c "import fontTools, importlib.metadata as m; print('fonttools', fontTools.version, 'brotli', m.version('brotli'))"
+
+      - name: Package suite (svg-infographic, strict)
+        env:
+          SVGINFO_PYTHON: /tmp/svginfo-fonts/bin/python
+          SVGINFO_STRICT: "1"        # absence of the subsetter fails here; it never silently skips
+        run: bash skills/svg-infographic/scripts/run-tests.sh
+
       - name: Validator self-tests (fixtures)
         run: python3 -m unittest discover -s tests
 

--- a/skills/svg-infographic/scripts/run-tests.sh
+++ b/skills/svg-infographic/scripts/run-tests.sh
@@ -29,6 +29,9 @@ mkdir -p "$log_dir"
 parallel_suites=(skin preflight check-svg check-layout route-orthogonal check-language)
 # These launch a headless browser — strictly one at a time.
 serial_suites=(font-probe render compose generate)
+# How much of a failing suite log to print. Enough for the assertion and its context; a whole
+# browser-measurement log is not a build artifact.
+dump_lines="${SVGINFO_DUMP_LINES:-400}"
 
 status=0
 declare -a failed=()
@@ -64,6 +67,18 @@ for s in "${serial_suites[@]}"; do run_suite "$s"; report "$s"; done
 if [ "$status" != "0" ]; then
   echo "FAILED: ${failed[*]}"
   echo "full output per suite: $log_dir/<suite>.log"
+  # A summary that names the suite but not the reason is not actionable anywhere the log_dir is
+  # thrown away with the machine — CI, most of all. Only the suites that failed are dumped, and
+  # the dump changes nothing about the exit code below.
+  for s in "${failed[@]}"; do
+    echo "----- $s.log (first ${dump_lines} lines) -----"
+    # Token-shaped values are redacted rather than trusted not to appear: a test that echoed its
+    # environment on failure would otherwise put them in a public build log.
+    sed -E 's/((TOKEN|SECRET|KEY|PASSWORD|PASSWD|CREDENTIAL)[A-Z_]*[=:] *)[^ ]+/\1<redacted>/Ig' \
+      "$log_dir/$s.log" | head -n "$dump_lines"
+    lines="$(wc -l <"$log_dir/$s.log" | tr -d ' ')"
+    [ "$lines" -gt "$dump_lines" ] && echo "----- truncated: $s.log has $lines lines -----"
+  done
 else
   echo "all suites green"
 fi


### PR DESCRIPTION
PR #66의 compose 7건 실패가 회귀인지 선재인지 판정하기 위한 **일회성 대조 PR**이다.

`main`에 다음 두 가지만 얹었다.
- `validate.yml`: pin된 subsetter 설치 + strict 패키지 스위트 실행
- `run-tests.sh`: 실패한 suite의 로그를 stdout으로 출력

compose fixture·`measure-text.mjs`·typography·skins·production 코드는 `main` 그대로다.

- CI가 **동일하게 compose 7건 실패**하면 → base 선재 실패. #66의 회귀 아님.
- CI가 **green**이면 → #66의 변경이 원인.

판정 후 이 PR은 merge하지 않고 닫는다.