### PR TITLE
docs: 0.10.0 repository changelog entry를 확정한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Granular, per-change entries begin at the first public release. Earlier developm
 
 ## [Unreleased]
 
-Repository-level changes since the last dated entry. No version is assigned and no release is cut.
+Repository-level changes since the last dated entry.
+
+## 2026-08-16
 
 ### Gallery
 


### PR DESCRIPTION
## 변경

- root CHANGELOG의 현재 release 내용을 `2026-08-16` dated entry로 확정합니다.
- `[Unreleased]`는 이후 repository-level changes를 위한 빈 구간으로 유지합니다.

## 경계

- package payload, version, runtime digest, artifacts, tag와 GitHub Release는 변경하지 않습니다.
- 이미 공개된 `svg-infographic/v0.10.0` source archive는 그대로 유지됩니다.

## 검증

- `python3 -m unittest tests.test_package_check`: 19 tests OK
- `PYTHONPATH=tools python3 -m skillstead_validate repo`: 0 findings
- `git diff --check`: pass