### PR TITLE
fix(validate): merge→tag window의 I-5 transient를 bounded grace로 분류한다

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,8 +51,14 @@ jobs:
       - name: Gallery model drift (CP3B)
         run: PYTHONPATH=tools python3 -m skillstead_validate gallery --repo-root .
 
+      # The release protocol creates the tag only after the version-bump
+      # commit has merged, so this push/PR run may observe the merge→tag
+      # window. The bounded grace turns exactly that window into a visible
+      # I-5-PENDING notice instead of a red run; tag events and the periodic
+      # workflow run without grace, so a genuinely deleted tag still fails
+      # there immediately and a never-created tag hardens after the window.
       - name: Continuous tag checks (M3)
-        run: PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref origin/main --repo-root .
+        run: PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref origin/main --repo-root . --release-grace-minutes 1440
 
       - name: Cutover verdict (M4)
         env:
@@ -64,10 +70,11 @@ jobs:
 
   # Tag creation or deletion re-runs the continuous tag checks immediately
   # (a deleted tag leaves no ref to check out, so main is checked out
-  # explicitly). Branch create/delete events also land here; the extra run
-  # is harmless.
+  # explicitly). Branch create/delete events say nothing about tag state, so
+  # they are filtered out here — before the filter every release left a red
+  # run from the branch auto-delete that fired inside the merge→tag window.
   tag-event:
-    if: github.event_name == 'create' || github.event_name == 'delete'
+    if: (github.event_name == 'create' || github.event_name == 'delete') && github.event.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -247,6 +247,15 @@ Bump-Adjustment: <기본 단계를 조정한 이유>
 * **I-5** — 관측된 릴리스 commit에서 버전이 바뀐 모든 skill의 tag가 존재한다(존재만 검사 —
   대상 정확성은 다음 검사의 몫). cutover record가 생긴 뒤에는 `main` first-parent 버전 변경에서
   기대 tag 집합을 독립적으로 파생하므로 릴리스의 tag를 *전부* 삭제해도 검출된다.
+* **release grace window (event run 한정)** — 릴리스 절차는 version-bump commit이 merge된 뒤에야
+  tag를 만들기 때문에, merge와 tag 생성 사이에 실행되는 push/PR run은 구조적으로 tag 부재를
+  관측합니다. 그 job만 `--release-grace-minutes 1440`을 전달합니다: version-change commit이
+  window보다 젊은 누락 tag는 red run 대신 가시적 `I-5-PENDING` 통지 + exit 0으로 분류됩니다.
+  그 외는 전부 fail-closed red를 유지합니다 — window보다 오래된 변경, 관측 불가 timestamp,
+  그리고 flag 없이 실행되는 모든 경로(release gate, cutover evaluator, tag 생성/삭제 event,
+  periodic schedule. branch 생성/삭제 event는 tag 상태와 무관하므로 이제 M3를 실행하지
+  않습니다). 따라서 실제로 삭제된 tag는 delete event에서 즉시 red가 되고, 끝내 생성되지 않은
+  tag는 window 경과 후 다음 periodic run에서 red로 굳습니다.
 * **expected target** — tag를 보지 않고 파생한다: 일반 tag는 `main` first-parent에서 해당
   skill의 선언 버전이 그 버전으로 바뀐 가장 오래된 commit, baseline tag 4개(record의 exact ref
   membership으로만 판정 — 버전 문자열 비교 아님)는 record가 도입된 commit. 다른 곳을 가리키는

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -285,6 +285,19 @@ For every `<name>/vX.Y.Z` tag, on every run:
   next check's job). After the cutover record exists, the expected tag set
   is also derived independently from `main` first-parent version changes, so
   deleting *all* tags of a release is still detected.
+* **Release grace window (event runs only)** — the release protocol creates
+  the tag only after the version-bump commit has merged, so the push/PR run
+  that fires between merge and tag creation observes a structurally missing
+  tag. That job alone passes `--release-grace-minutes 1440`: a missing tag
+  whose version-change commit is younger than the window is reported as a
+  visible `I-5-PENDING` notice with exit 0 instead of a red run. Everything
+  else stays fail-closed red — older changes, unobservable timestamps, and
+  every run without the flag (the release gate, the cutover evaluator, tag
+  create/delete events, the periodic schedule, and branch create/delete
+  events no longer run M3 at all since they say nothing about tag state).
+  A genuinely deleted tag therefore still turns red at its delete event
+  immediately, and a tag that is never created hardens to red at the next
+  periodic run after the window expires.
 * **Expected target** — derived without looking at the tag: for an ordinary
   tag, the oldest `main` first-parent commit where the skill's declared
   version changed to the tag's version; for the four baseline tags (exact

--- a/tests/test_tag_check.py
+++ b/tests/test_tag_check.py
@@ -322,5 +322,98 @@ class CanonicalConstantsGuard(unittest.TestCase):
         self.assertEqual(record_schema.PHASES, frozenset({"prepared", "aborted"}))
 
 
+class ReleaseGraceWindow(unittest.TestCase):
+    """Merge→tag window classification: pending is bounded and opt-in.
+
+    Only the event workflow's push/PR job passes ``release_grace_minutes``;
+    the default call (release gate, cutover, tag events, periodic) must keep
+    today's red on the same state.
+    """
+
+    GRACE = 1440
+
+    def setUp(self) -> None:
+        # BaselineRecordBranch와 같은 record 앵커 설정 — 실제 repo처럼
+        # record-anchored I-5 파생이 활성인 상태에서 window를 재현한다.
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = build_released_repo(Path(self._tmp.name) / "repo", {"alpha-skill": "1.2.3"})
+        _git(self.repo, "tag", "-d", "alpha-skill/v1.2.3")
+        record_dir = self.repo / ".skillstead"
+        record_dir.mkdir()
+        (record_dir / "cutover-record.json").write_text(
+            json.dumps(_fixture_record()), encoding="utf-8")
+        self.record_sha = commit_all(self.repo, "cutover commit with record")
+        _git(self.repo, "tag", "alpha-skill/v1.2.3", self.record_sha)
+        patcher = patch.object(record_schema, "BASELINE_TAGS", FIXTURE_BASELINE)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _bump_alpha_untagged(self, version: str, prev: str) -> str:
+        """Valid release commit for alpha-skill WITHOUT its tag (the
+        merge→tag window state)."""
+        skill_md = self.repo / "skills/alpha-skill/SKILL.md"
+        skill_md.write_text(
+            skill_md.read_text(encoding="utf-8").replace(
+                f"  version: {prev}", f"  version: {version}") + "\nBody change.\n",
+            encoding="utf-8")
+        changelog = self.repo / "skills/alpha-skill/CHANGELOG.md"
+        changelog.write_text(
+            changelog.read_text(encoding="utf-8").replace(
+                f"## [{prev}]", f"## [{version}] — 2026-07-28\n\nEntry.\n\n## [{prev}]", 1),
+            encoding="utf-8")
+        for fname in ("README.md", "README.ko.md"):
+            f = self.repo / fname
+            f.write_text(f.read_text(encoding="utf-8").replace(f"`{prev}`", f"`{version}`"),
+                         encoding="utf-8")
+        record_root_release(self.repo, "alpha-skill", version)
+        return commit_all(self.repo, f"release alpha {version} (tag pending)")
+
+    def _age_head(self, date: str) -> None:
+        """Rewrite HEAD's committer (and author) timestamp."""
+        import os
+        import subprocess
+        env = dict(os.environ, GIT_COMMITTER_DATE=date, GIT_AUTHOR_DATE=date)
+        subprocess.run(
+            ["git", "-C", str(self.repo), "commit", "-q", "--amend",
+             "--no-edit", "--date", date],
+            capture_output=True, text=True, check=True, env=env)
+
+    def _graced(self) -> tuple[list, list]:
+        pending: list = []
+        findings = run_tag_checks(
+            self.repo, release_grace_minutes=self.GRACE, pending=pending)
+        return findings, pending
+
+    def test_window_state_is_pending_with_grace_and_red_without(self) -> None:
+        self._bump_alpha_untagged("1.3.0", "1.2.3")
+        # Default call: today's fail-closed red is unchanged.
+        self.assertIn("I-5", {f.check for f in run_tag_checks(self.repo)})
+        # Opted-in event run: visible pending, zero red findings.
+        findings, pending = self._graced()
+        self.assertEqual(findings, [])
+        self.assertEqual([p.check for p in pending], ["I-5-PENDING"])
+        self.assertEqual(pending[0].subject, "alpha-skill/v1.3.0")
+
+    def test_grace_expiry_hardens_to_red(self) -> None:
+        self._bump_alpha_untagged("1.3.0", "1.2.3")
+        self._age_head("2026-01-01T00:00:00 +0000")
+        findings, pending = self._graced()
+        self.assertIn("I-5", {f.check for f in findings})
+        self.assertEqual(pending, [])
+
+    def test_recent_deletion_is_pending_only_for_opted_in_runs(self) -> None:
+        # A fresh tag deleted inside the window is indistinguishable from the
+        # normal merge→tag gap for a push run; the delete event and the
+        # periodic run call without grace and stay red immediately.
+        _release_alpha(self.repo, "1.3.0", "1.2.3")
+        self.assertEqual(run_tag_checks(self.repo), [])
+        _git(self.repo, "tag", "-d", "alpha-skill/v1.3.0")
+        self.assertIn("I-5", {f.check for f in run_tag_checks(self.repo)})
+        findings, pending = self._graced()
+        self.assertEqual(findings, [])
+        self.assertEqual([p.check for p in pending], ["I-5-PENDING"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/skillstead_validate/__main__.py
+++ b/tools/skillstead_validate/__main__.py
@@ -45,6 +45,11 @@ def main(argv: list[str] | None = None) -> int:
     tags = sub.add_parser("tags", help="continuous tag checks (M3)")
     tags.add_argument("--main-ref", default="main")
     tags.add_argument("--repo-root", type=Path, default=Path.cwd())
+    tags.add_argument(
+        "--release-grace-minutes", type=int, default=None,
+        help="event-workflow opt-in: report a missing tag whose version-change "
+             "commit is younger than this as I-5-PENDING (exit 0) instead of "
+             "red; tag events and the periodic run must not pass it")
     gal = sub.add_parser("gallery", help="gallery model join + drift check (CP3B)")
     gal.add_argument("--repo-root", type=Path, default=Path.cwd())
     gal.add_argument("--write", action="store_true", help="regenerate gallery/model.json")
@@ -124,10 +129,18 @@ def main(argv: list[str] | None = None) -> int:
         return 1 if verdict.verdict == "red" else 0
 
     if args.mode == "tags":
-        findings = run_tag_checks(args.repo_root.resolve(), args.main_ref)
+        pending: list = []
+        findings = run_tag_checks(
+            args.repo_root.resolve(), args.main_ref,
+            release_grace_minutes=args.release_grace_minutes, pending=pending)
         for f in findings:
             print(f, file=sys.stderr)
-        print(f"skillstead_validate tags: {len(findings)} finding(s)")
+        for p in pending:
+            print(p, file=sys.stderr)
+        if args.release_grace_minutes is None:
+            print(f"skillstead_validate tags: {len(findings)} finding(s)")
+        else:
+            print(f"skillstead_validate tags: {len(findings)} finding(s), {len(pending)} pending")
         return 1 if findings else 0
 
     if args.mode == "gallery":

--- a/tools/skillstead_validate/tag_check.py
+++ b/tools/skillstead_validate/tag_check.py
@@ -13,6 +13,17 @@ creation-time checks guarantee nothing durable. Checks:
 * I-5  — partial deletion of a multi-skill release: every skill whose version
   changed at an observed release commit must still have its tag there.
 
+The release protocol creates the tag only after the version-bump commit has
+merged and the post-merge gates have passed, so an event-driven run between
+merge and tag creation observes a structurally missing tag. Callers that know
+they run in that window (the event workflow's push/PR job) may opt in to a
+bounded grace: a missing tag whose version-change commit is younger than
+``release_grace_minutes`` is reported to ``pending`` as ``I-5-PENDING``
+instead of red. Everything else — older changes, unobservable timestamps,
+every non-opted-in caller (release gate, cutover, tag events, periodic) —
+keeps today's fail-closed red, so a genuinely deleted tag still turns red at
+the delete event and at the next periodic run.
+
 Comparisons use peeled commit SHAs (annotated and lightweight tags mix in
 this repository's history). Every unobservable input is a finding
 (fail-closed).
@@ -22,6 +33,7 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from pathlib import Path
 
 from . import record_schema
@@ -226,7 +238,13 @@ def _retirement_history_findings(
     return findings
 
 
-def run_tag_checks(repo: Path, main_ref: str = "main") -> list[Finding]:
+def run_tag_checks(
+    repo: Path,
+    main_ref: str = "main",
+    *,
+    release_grace_minutes: int | None = None,
+    pending: list[Finding] | None = None,
+) -> list[Finding]:
     findings: list[Finding] = []
     try:
         main_tip = peeled(repo, main_ref)
@@ -316,6 +334,18 @@ def run_tag_checks(repo: Path, main_ref: str = "main") -> list[Finding]:
     reported_i5: set[str] = set()
     position = {c: i for i, c in enumerate(history.commits)}
 
+    def _within_release_grace(commit: str) -> bool:
+        """Opted-in callers only: the version-change commit is young enough to
+        be the normal merge→tag window. An unobservable timestamp is never
+        grace (fail-closed)."""
+        if release_grace_minutes is None or pending is None:
+            return False
+        try:
+            committed = int(git(repo, "log", "-1", "--format=%ct", commit))
+        except (GitError, ValueError):
+            return False
+        return time.time() - committed <= release_grace_minutes * 60
+
     def _expect_changes_at(commit: str) -> None:
         idx = position[commit]
         parent = history.commits[idx + 1] if idx + 1 < len(history.commits) else None
@@ -335,7 +365,11 @@ def run_tag_checks(repo: Path, main_ref: str = "main") -> list[Finding]:
                 continue  # baseline existence is checked from the record list
             if tag not in targets and tag not in reported_i5:
                 reported_i5.add(tag)
-                findings.append(Finding("I-5", tag, f"version changed at {commit[:12]} but the tag does not exist (deletion suspected)"))
+                if _within_release_grace(commit):
+                    assert pending is not None  # guaranteed by _within_release_grace
+                    pending.append(Finding("I-5-PENDING", tag, f"version changed at {commit[:12]} but the tag does not exist yet (release grace window; hardens at tag events and the periodic run)"))
+                else:
+                    findings.append(Finding("I-5", tag, f"version changed at {commit[:12]} but the tag does not exist (deletion suspected)"))
 
     for commit in sorted(set(targets.values())):
         if commit in position:  # off-main targets already reported via I-8


### PR DESCRIPTION
## 문제

release마다 hosted validate가 정확히 2건의 red run을 남겼다 — version bump merge push run과 feature branch auto-delete run. 두 run 모두 merge와 atomic tag 생성 사이의 window에서 M3 `I-5: version changed but the tag does not exist`를 관측한 구조적 transient이며, 약 5분 뒤 tag create run이 green으로 해소되는 패턴이 반복됐다 (v0.11.0: run 32440558526·32440558615 → 32440607170, github-release-guide 0.9.0에서도 동일).

## 수정

red를 숨기지 않고 이벤트를 분류한다.

- **push/PR job만** `tags --release-grace-minutes 1440`을 opt-in: version-change commit이 window보다 젊은 누락 tag는 가시적 `I-5-PENDING` 통지 + exit 0.
- **strict red 유지**: tag delete event, periodic schedule, M5 release gate, cutover evaluator, window 경과, timestamp 관측 불가(fail-closed).
- **branch create/delete event**는 tag 상태와 무관하므로 tag-event job에서 `ref_type == 'tag'` 필터로 제외.

실제 삭제된 tag는 delete event에서 즉시 red, 끝내 생성되지 않은 tag는 window 경과 후 periodic에서 red로 굳는다.

## 검증

- validator self-test 전체: **Ran 272 tests — OK** (신규 `ReleaseGraceWindow` 3종 포함)
- 기존 I-5·repoint·record negative fixture 전수 red 유지
- 실제 repo에서 CLI 양쪽 모드 0 finding, non-grace 요약 형식 불변
- docs/VALIDATION EN/KO 이벤트 분류 문단 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)