### PR TITLE
chore(ci): validate를 병렬 job으로 나누고 PR에서 path-scoping한다

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,14 @@
 # GitHub's automatic 60-day-inactivity disable of scheduled workflows — never
 # silences the other. Continuous tag checks (M3) and the cutover evaluator
 # (M4) are added by later stages of the validator work.
+#
+# The two heavy suites run as parallel jobs, and on pull_request events they
+# run only when the change set touches their inputs (the `scope` job derives
+# that from the diff, fail-closed to "run everything" when it cannot tell).
+# Push and dispatch runs always run everything, and the daily periodic
+# workflow stays full, so a scoping mistake on a PR is caught at the merge
+# push at the latest. The `validate` job aggregates the results under the
+# historical check name.
 name: validate
 
 on:
@@ -16,15 +24,57 @@ permissions:
   contents: read
 
 jobs:
-  validate:
+  # PR-only diff classification; push runs get "run everything" without a
+  # checkout. A failed diff also means "run everything" — never skip on an
+  # unobserved change set.
+  scope:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
+    outputs:
+      package: ${{ steps.diff.outputs.package }}
+      validator: ${{ steps.diff.outputs.validator }}
     steps:
-      # Full hydration is contractual: first-parent history, all tags, and
-      # origin/main must be observable for the tag and cutover checks.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        if: github.event_name == 'pull_request'
         with:
           fetch-depth: 0
+
+      - id: diff
+        run: |
+          set -u
+          run_all() {
+            echo "package=true" >> "$GITHUB_OUTPUT"
+            echo "validator=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            run_all
+          fi
+          changed="$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")" || run_all
+          package=false
+          validator=false
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            case "$f" in
+              skills/*|.github/workflows/*) package=true ;;
+            esac
+            case "$f" in
+              tools/*|tests/*|.github/workflows/*) validator=true ;;
+            esac
+          done <<EOF
+          $changed
+          EOF
+          echo "package=$package" >> "$GITHUB_OUTPUT"
+          echo "validator=$validator" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+
+  package-suite:
+    needs: scope
+    if: needs.scope.outputs.package == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # The package's own suite subsets fonts, and its subsetter-dependent fixtures used to skip
       # themselves silently when the toolchain was absent — which is what CI looked like, so those
@@ -42,8 +92,25 @@ jobs:
           SVGINFO_STRICT: "1"        # absence of the subsetter fails here; it never silently skips
         run: bash skills/svg-infographic/scripts/run-tests.sh
 
+  validator-suite:
+    needs: scope
+    if: needs.scope.outputs.validator == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
       - name: Validator self-tests (fixtures)
         run: python3 -m unittest discover -s tests
+
+  # Full hydration is contractual: first-parent history, all tags, and
+  # origin/main must be observable for the tag and cutover checks.
+  checks:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
 
       - name: Repo validation (M1)
         run: PYTHONPATH=tools python3 -m skillstead_validate repo --repo-root .
@@ -67,6 +134,35 @@ jobs:
 
       - name: Spec reference validator (pinned skills-ref)
         run: python3 tools/run_skills_ref.py
+
+  # Aggregate under the historical check name: green only when every job that
+  # was supposed to run succeeded, and a skipped heavy suite is acceptable
+  # only when `scope` explicitly ruled it out.
+  validate:
+    needs: [scope, package-suite, validator-suite, checks]
+    if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'push') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate results
+        run: |
+          set -u
+          fail() { echo "$1" >&2; exit 1; }
+          [ "${{ needs.scope.result }}" = "success" ] || fail "scope job did not succeed"
+          [ "${{ needs.checks.result }}" = "success" ] || fail "checks job did not succeed"
+          suite_ok() {
+            result="$1"; wanted="$2"; name="$3"
+            if [ "$wanted" = "true" ]; then
+              [ "$result" = "success" ] || fail "$name was required but did not succeed"
+            else
+              case "$result" in
+                success|skipped) : ;;
+                *) fail "$name failed" ;;
+              esac
+            fi
+          }
+          suite_ok "${{ needs.package-suite.result }}" "${{ needs.scope.outputs.package }}" "package-suite"
+          suite_ok "${{ needs.validator-suite.result }}" "${{ needs.scope.outputs.validator }}" "validator-suite"
+          echo "all required jobs green"
 
   # Tag creation or deletion re-runs the continuous tag checks immediately
   # (a deleted tag leaves no ref to check out, so main is checked out

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -85,7 +85,7 @@ release의 `published_at`이 null이거나 빈 문자열인 경우 포함), tran
 
 | 파일 | trigger | 목적 |
 | --- | --- | --- |
-| `validate.yml` | PR, `main` push, tag 생성/삭제 | event 기반 M1+M3+M4 (tag event는 명시적 `main` checkout으로 M3+M4 실행) |
+| `validate.yml` | PR, `main` push, tag 생성/삭제 | event 기반 검증을 병렬 job으로 실행 — package suite와 validator self-test suite가 경량 검사(M1+gallery+M3+M4+skills-ref) 옆에서 돌고, `validate` aggregate job이 기존 check 이름을 유지. PR에서는 diff가 해당 suite의 입력을 건드릴 때만 무거운 두 suite를 실행(`skills/**` / `tools/**`+`tests/**`; workflow 변경은 둘 다 실행, diff 판독 불가 시 전체 실행). push는 항상 전체 실행. tag event는 명시적 `main` checkout으로 M3+M4 실행, branch 생성/삭제 event는 아무것도 실행하지 않음 |
 | `validate-periodic.yml` | 매일 schedule(`17 3 * * *` UTC), 수동 dispatch | event가 발생하지 않는 상태 변화(예: push 밖의 tag repoint)를 잡는 주기적 안전망 |
 | `release.yml` | 수동 dispatch 전용 | M5 wrapper 진입점. dry-run이 기본값이며 checkout이 `main`에 고정되어 있어 dispatch가 미검토 wrapper나 request를 write token으로 실행할 수 없음 |
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -96,7 +96,7 @@ would state something the run did not observe.
 
 | File | Triggers | Purpose |
 | --- | --- | --- |
-| `validate.yml` | PR, push to `main`, tag create/delete | event-driven M1+M3+M4 (tag events run M3+M4 against an explicit `main` checkout) |
+| `validate.yml` | PR, push to `main`, tag create/delete | event-driven validation as parallel jobs — the package suite and the validator self-test suite run beside the fast checks (M1+gallery+M3+M4+skills-ref), and a `validate` aggregate job carries the historical check name. On PRs the two heavy suites run only when the diff touches their inputs (`skills/**` / `tools/**`+`tests/**`; workflow changes run both, an unreadable diff runs everything). Pushes always run everything. Tag events run M3+M4 against an explicit `main` checkout; branch create/delete events run nothing |
 | `validate-periodic.yml` | daily schedule (`17 3 * * *` UTC), manual dispatch | periodic fallback for state changes that fire no event (e.g. a tag repointed outside a push) |
 | `release.yml` | manual dispatch only | M5 wrapper entry; dry-run by default; checkout pinned to `main` so a dispatch can never run an unreviewed wrapper or request under the write token |
 


### PR DESCRIPTION
## 배경

validate run 전체 ~14분의 실측 분포(run 32432981187): validator self-tests **589s(70%)** + package suite **218s(26%)** + 나머지 전부 ~30s. 무거운 건 검사(M1·M3·M4)가 아니라 테스트 2개 스텝이다.

## 변경

- 직렬 1-job → 병렬 5-job: `scope`(PR diff 분류) → `package-suite` ∥ `validator-suite` ∥ `checks`(M1·gallery·M3 grace·M4·skills-ref) → `validate`(aggregate, 기존 check 이름 유지)
- **PR에서만** path-scoping: `skills/**` 미변경 → package-suite skip, `tools/**`·`tests/**` 미변경 → validator-suite skip. workflow 변경은 둘 다 실행, diff 판독 실패는 전체 실행(fail-closed)
- **push(main)·dispatch는 항상 전체 실행**, periodic 일일 full 무변경 — scoping 실수는 늦어도 merge push에서 잡힌다
- aggregate는 scope가 명시적으로 배제한 skip만 pass로 인정
- docs/VALIDATION EN/KO workflow 표 갱신

기대 효과: docs/릴리스 bookkeeping PR **14분 → 1~2분**, 코드 PR도 관련 suite만 실행. 이 PR 자체는 workflow 변경이라 전체 실행 경로로 검증된다. merge 후 docs-only 시험 PR로 skip 경로를 실측한다(시험 PR은 merge 없이 close).

구조적 후속(digest-bound evidence inheritance)은 backlog가 별도 소유한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)