### PR TITLE
test(ci): non-SVG scope skip을 관측한다

### DIFF
--- a/skills/writing-quality-editor/README.md
+++ b/skills/writing-quality-editor/README.md
@@ -168,3 +168,5 @@ Install the complete `skills/writing-quality-editor/` folder. The skill is self-
 synthetic fixtures and the answer key live in [`examples/writing-quality-editor`](https://github.com/kyungseo/skillstead/tree/main/examples/writing-quality-editor).
 
 See the catalog-wide installation options in [`docs/INSTALL.md`](https://github.com/kyungseo/skillstead/blob/main/docs/INSTALL.md).
+
+<!-- CI scope probe: this non-SVG Skill change is intentionally not for merge. -->


### PR DESCRIPTION
## 목적

WQE-only 변경에서 공통 checks는 실행되고 `svg-infographic-suite`와 `validator-suite`는 scope 판정에 따라 skip되는지 관측하는 일회용 PR입니다.

## 처리

- merge하지 않습니다.
- hosted check 결과를 기록한 뒤 PR을 close하고 branch를 삭제합니다.
- 변경 내용은 CI 관측용 HTML comment뿐입니다.