### PR TITLE
fix: 첫 릴리스 전 보정 커밋을 허용한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Repository-level changes since the last dated entry.
 
 ### Repository
 
+- **Reviewable first-release window.** M2 still requires a new skill package and both catalog rows to be introduced
+  atomically, while allowing continuous pre-tag review amendments before the first `0.1.0` tag target.
 - **Locale-matched catalog links.** Skill names in the Korean catalog now open each package's Korean README directly;
   the catalog validator accepts folder links or explicit README links only when the target matches the catalog locale.
 - **Street Artist public package.** Added the self-contained `street-portrait-artist` package, bilingual guides,

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -120,8 +120,11 @@ I-4 finding입니다. payload는 정확히 두 개의 bookkeeping 산출물(`met
 bump 단계는 major transition 분기가 적용되는 경우를 제외하면 경로 기본값과 일치해야 합니다.
 한 단계 major transition에는 아래의 정확한 추적 승인 record가 필요하고, inventory 감소에는 아래의
 정확한 retirement record와 전체 제거 predicate가 필요합니다. 신규 skill의 최초 릴리스는 package와
-양쪽 카탈로그 행을 target commit에서 함께 도입해야 하고, 기존 tag와 SemVer precedence가 같은
-버전(`+build` alias 포함)은 만들 수 없습니다.
+양쪽 카탈로그 행을 하나의 `main` first-parent commit에서 함께 도입해야 합니다. Review 보정을 첫
+릴리스 전에 반영할 수 있도록 이 도입 commit이 tag target보다 앞서는 것은 허용하지만, package와
+양쪽 행은 제안 버전으로 target까지 끊김 없이 유지되어야 하고 target은 여전히 전체 M1을 통과해야
+합니다. 분리 도입, 제거 후 재추가, 연속성을 읽을 수 없는 상태는 fail-closed입니다. 기존 tag와
+SemVer precedence가 같은 버전(`+build` alias 포함)은 만들 수 없습니다.
 
 일회성 baseline 분기는 target에 canonical prepared cutover record가 있을 때만 활성화됩니다. Plan은
 record의 `baseline_tags` 네 항목과 순서까지 같아야 하고, 모든 항목은 `previous_ref: null`과 버전

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -136,8 +136,13 @@ step unless the major-transition branch applies; a single-step major
 transition requires the exact tracked approval record below; an inventory
 reduction requires the exact retirement record and full-removal predicate
 below; a new skill's initial release must introduce the package and both
-catalog rows in the target commit itself; no existing tag may share the
-proposed version's SemVer precedence (including `+build` aliases).
+catalog rows together in one `main` first-parent commit. That introduction
+commit may precede the tag target so review fixes can land before the first
+release, but the package and both rows must remain continuously present at
+the proposed version through the target, which must still pass full M1. Any
+split introduction, removal/re-addition gap, or unreadable continuity state
+fails closed. No existing tag may share the proposed version's SemVer
+precedence (including `+build` aliases).
 
 The one-time baseline branch activates only when the target carries the
 canonical prepared cutover record. The plan must equal the record's four

--- a/playbooks/skill-development/skill-development-procedure.ko.md
+++ b/playbooks/skill-development/skill-development-procedure.ko.md
@@ -92,6 +92,10 @@ GitHub source archive는 repository snapshot이며 standalone package artifact�
 Merge-to-tag 구간의 임시 red를 숨기지 않습니다. 실제 merge target과 remote ref를 관측한 뒤 문서에
 정한 bounded path만 다시 실행합니다. 예상하지 못한 code나 partial ref는 Owner가 결정합니다.
 
+신규 skill은 package와 양쪽 catalog row를 하나의 `main` first-parent commit에서 함께 도입합니다.
+첫 tag 전 review 보정 commit은 허용하지만, 세 release surface가 `0.1.0`으로 끊김 없이 유지되고 최종
+tag target이 M1을 통과해야 합니다. 분리 도입이나 제거 후 재추가는 지원되는 우회 경로가 아닙니다.
+
 Publish 단계 자체에는 그런 판단이 필요하지 않습니다. Release wrapper는 발행 직후의 관측이 스스로
 모순될 때에 **한해서만** 정해진 예산 안에서 재관측하고 그 결과를 보고합니다. 따라서 wrapper가 돌려준
 red는 이미 그 재시도를 견딘 결과이므로, 타이밍 문제가 아니라 실제 finding으로 읽고 red를 없애려고

--- a/playbooks/skill-development/skill-development-procedure.md
+++ b/playbooks/skill-development/skill-development-procedure.md
@@ -91,6 +91,10 @@ During the merge-to-tag window, do not suppress a temporary red result. Re-run o
 after the actual merge target and remote refs are observable. Unexpected codes or partial refs require an owner
 decision.
 
+For a new skill, introduce the package and both catalog rows together in one `main` first-parent commit. Review
+fixes may follow before the first tag, provided all three release surfaces remain continuously present at `0.1.0`
+and the final tag target passes M1. A split introduction or remove-and-re-add sequence is not a supported shortcut.
+
 The publish step itself needs no such judgement. The release wrapper already retries its own post-publish read
 when — and only when — that observation contradicts itself, within a bounded budget it reports. A red the
 wrapper returns has therefore already survived that retry, so read it as a real finding rather than a timing

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -107,6 +107,8 @@ def _add_unreleased_gamma(repo: Path) -> None:
     (pkg / "SKILL.md").write_text(
         "---\n"
         "name: gamma-skill\n"
+        "description: >\n"
+        "  Fixture skill package used by validator tests.\n"
         "license: LICENSE.txt\n"
         "metadata:\n"
         "  version: 0.1.0\n"
@@ -131,6 +133,7 @@ def _add_unreleased_gamma(repo: Path) -> None:
                 "Fixture | `0.1.0` | Claude Code | Beta |",
                 1),
             encoding="utf-8")
+    record_root_release(repo, "gamma-skill", "0.1.0")
     commit_all(repo, "add unreleased gamma-skill")
 
 
@@ -354,6 +357,62 @@ class ReleaseGateFixtures(unittest.TestCase):
             (self.repo / "LICENSE").read_text(encoding="utf-8"), encoding="utf-8")
         commit_all(self.repo, "add gamma without catalog rows")
         self.assertIn("I-7", self._preflight([entry("gamma-skill", None, "0.1.0")]))
+
+    def test_new_skill_allows_continuous_pre_tag_amendments(self) -> None:
+        _add_unreleased_gamma(self.repo)
+        skill_md = self.repo / "skills/gamma-skill/SKILL.md"
+        skill_md.write_text(
+            skill_md.read_text(encoding="utf-8")
+            + "\nReviewed wording amendment.\n",
+            encoding="utf-8")
+        for fname in ("README.md", "README.ko.md"):
+            readme = self.repo / fname
+            readme.write_text(
+                readme.read_text(encoding="utf-8").replace(
+                    "| [`gamma-skill`](./skills/gamma-skill) | Fixture |",
+                    "| [`gamma-skill`](./skills/gamma-skill) | Reviewed fixture |"),
+                encoding="utf-8")
+        commit_all(self.repo, "amend unreleased gamma package and catalogs")
+        self.assertEqual(
+            self._preflight([entry("gamma-skill", None, "0.1.0")]), set())
+
+    def test_new_skill_rejects_package_gap_before_first_tag(self) -> None:
+        import shutil
+
+        _add_unreleased_gamma(self.repo)
+        pkg = self.repo / "skills/gamma-skill"
+        saved = {
+            path.name: path.read_text(encoding="utf-8")
+            for path in pkg.iterdir()
+        }
+        shutil.rmtree(pkg)
+        commit_all(self.repo, "temporarily remove unreleased gamma package")
+        pkg.mkdir()
+        for name, content in saved.items():
+            (pkg / name).write_text(content, encoding="utf-8")
+        commit_all(self.repo, "restore unreleased gamma package")
+        self.assertIn(
+            "D3-3",
+            self._preflight([entry("gamma-skill", None, "0.1.0")]))
+
+    def test_new_skill_rejects_catalog_gap_before_first_tag(self) -> None:
+        _add_unreleased_gamma(self.repo)
+        originals = {}
+        for fname in ("README.md", "README.ko.md"):
+            readme = self.repo / fname
+            originals[fname] = readme.read_text(encoding="utf-8")
+            readme.write_text(
+                "\n".join(
+                    line for line in originals[fname].splitlines()
+                    if "gamma-skill" not in line) + "\n",
+                encoding="utf-8")
+        commit_all(self.repo, "temporarily remove unreleased gamma catalog rows")
+        for fname, content in originals.items():
+            (self.repo / fname).write_text(content, encoding="utf-8")
+        commit_all(self.repo, "restore unreleased gamma catalog rows")
+        self.assertIn(
+            "D3-3",
+            self._preflight([entry("gamma-skill", None, "0.1.0")]))
 
     # apply-tags: preflight 위반 시 거부, green이면 계획된 tag를 생성
     def test_apply_tags_refuses_on_findings(self) -> None:

--- a/tools/skillstead_validate/release_gate.py
+++ b/tools/skillstead_validate/release_gate.py
@@ -93,6 +93,121 @@ def _entry_section(changelog_text: str, version: str) -> str | None:
     return "\n".join(lines[start:end])
 
 
+def _initial_release_history_findings(
+        repo: Path, target: str, skill: str, proposed_version: str,
+        positions: dict[str, int]) -> list[Finding]:
+    """Prove atomic introduction while allowing continuous pre-tag amendments.
+
+    The package and both catalog rows must first appear together on main's
+    first-parent history. Later commits may amend the unreleased package, but
+    none of the three release surfaces may disappear or leave the proposed
+    version before the tag target.
+    """
+    findings: list[Finding] = []
+    package_path = f"skills/{skill}"
+    try:
+        package_history = git(
+            repo, "log", "--first-parent", "--reverse", "--format=%H",
+            target, "--", package_path).split()
+    except GitError as error:
+        return [Finding(
+            "GIT", skill,
+            f"initial-release package history unobservable (fail-closed): {error}")]
+    if not package_history:
+        return [Finding(
+            "D3-3", skill,
+            "package introduction commit is unobservable (fail-closed)")]
+
+    intro = package_history[0]
+    intro_idx = positions.get(intro)
+    target_idx = positions[target]
+    if intro_idx is None or intro_idx < target_idx:
+        return [Finding(
+            "D3-3", skill,
+            "package introduction is not on the target's main first-parent history")]
+
+    def state_at(commit: str) -> tuple[bool, dict[str, str | None]] | None:
+        try:
+            package_present = skill in dirs_at(repo, commit, "skills")
+        except GitError as error:
+            findings.append(Finding(
+                "GIT", skill,
+                f"initial-release inventory at {commit[:12]} unobservable "
+                f"(fail-closed): {error}"))
+            return None
+        versions: dict[str, str | None] = {}
+        for fname, header in (("README.md", EN_HEADER),
+                              ("README.ko.md", KO_HEADER)):
+            text = file_at(repo, commit, fname)
+            if text is None:
+                findings.append(Finding(
+                    "D3-3", skill,
+                    f"{fname} absent at {commit[:12]}; initial-release history "
+                    "is unprovable (fail-closed)"))
+                return None
+            try:
+                versions[fname] = catalog_versions(text, header).get(skill)
+            except CatalogError as error:
+                findings.append(Finding(
+                    "D3-3", skill,
+                    f"{fname} catalog at {commit[:12]} unreadable; "
+                    f"initial-release history unprovable (fail-closed): {error}"))
+                return None
+        return package_present, versions
+
+    intro_state = state_at(intro)
+    if intro_state is not None:
+        package_present, versions = intro_state
+        if (not package_present
+                or any(value != proposed_version for value in versions.values())):
+            findings.append(Finding(
+                "D3-3", skill,
+                "initial release must introduce the package and both catalog "
+                f"rows at version {proposed_version} in one commit"))
+
+    ordered = sorted(positions, key=positions.__getitem__)
+    intro_parent = ordered[intro_idx + 1] if intro_idx + 1 < len(ordered) else None
+    if intro_parent is not None:
+        parent_state = state_at(intro_parent)
+        if parent_state is not None:
+            package_present, versions = parent_state
+            if package_present or any(value is not None for value in versions.values()):
+                findings.append(Finding(
+                    "D3-3", skill,
+                    "package or catalog row existed before the atomic "
+                    "initial-release introduction commit"))
+
+    try:
+        changed_commits = git(
+            repo, "log", "--first-parent", "--format=%H", target, "--",
+            package_path, "README.md", "README.ko.md").split()
+    except GitError as error:
+        findings.append(Finding(
+            "GIT", skill,
+            f"pre-tag amendment history unobservable (fail-closed): {error}"))
+        return findings
+
+    checkpoints = {target, intro}
+    checkpoints.update(
+        commit for commit in changed_commits
+        if commit in positions and target_idx <= positions[commit] <= intro_idx)
+    for commit in sorted(checkpoints, key=positions.__getitem__, reverse=True):
+        if commit == intro:
+            continue
+        state = state_at(commit)
+        if state is None:
+            continue
+        package_present, versions = state
+        if (not package_present
+                or any(value != proposed_version for value in versions.values())):
+            findings.append(Finding(
+                "D3-3", skill,
+                "initial-release surfaces were not continuously present at "
+                f"version {proposed_version} through pre-tag amendment "
+                f"commit {commit[:12]}"))
+    return findings
+
+
 def _retired_row(skill: str, last_release_ref: str | None) -> str:
     release = last_release_ref or "unreleased"
     path = retirement_path(skill)
@@ -440,7 +555,9 @@ def preflight(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[Fin
                 if not _ADJUSTMENT_LINE.search(section):
                     findings.append(Finding("I-6", e.skill, f"step {step} != path default {default} and CHANGELOG entry has no standalone non-empty '{ADJUSTMENT_MARKER}' reason line"))
         else:
-            # New-skill initial release (all artifacts land in one commit).
+            # New-skill initial release. The release surfaces are introduced
+            # atomically, then may receive continuous amendments before the
+            # first tag is bound to the reviewed target.
             if e.proposed_version != "0.1.0":
                 findings.append(Finding("D3-3", e.skill, f"initial release must be 0.1.0, got {e.proposed_version}"))
             license_ok = False
@@ -464,30 +581,12 @@ def preflight(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[Fin
                     findings.append(Finding("I-7", e.skill, f"{fname}: {err}"))
                     continue
                 if table.get(e.skill) != e.proposed_version:
-                    findings.append(Finding("I-7", e.skill, f"{fname} catalog row missing or version != {e.proposed_version} (initial release must add it in the same commit)"))
-            # §D3-3 ⓒ~ⓔ land in ONE commit: neither the package nor a catalog
-            # row may predate the target commit (MR1-F3).
-            if target_parent is not None:
-                try:
-                    parent_dirs = dirs_at(repo, target_parent, "skills")
-                except GitError as err:
-                    findings.append(Finding("GIT", e.skill, f"parent inventory unobservable (fail-closed): {err}"))
-                    parent_dirs = set()
-                if e.skill in parent_dirs:
-                    findings.append(Finding("D3-3", e.skill, "package existed before the target commit — initial release must introduce ⓒ~ⓔ in one commit"))
-                for fname, header in (("README.md", EN_HEADER), ("README.ko.md", KO_HEADER)):
-                    parent_text = file_at(repo, target_parent, fname)
-                    if parent_text is None:
-                        continue
-                    try:
-                        parent_table = catalog_versions(parent_text, header)
-                    except CatalogError as err:
-                        # Unobservable parent state cannot prove the
-                        # same-commit condition (fail-closed — MR1R-F3).
-                        findings.append(Finding("D3-3", e.skill, f"parent {fname} catalog unreadable, same-commit introduction unprovable (fail-closed): {err}"))
-                        continue
-                    if e.skill in parent_table:
-                        findings.append(Finding("D3-3", e.skill, f"{fname} catalog row existed before the target commit"))
+                    findings.append(Finding(
+                        "I-7", e.skill,
+                        f"{fname} catalog row missing or version != "
+                        f"{e.proposed_version} at the tag target"))
+            findings.extend(_initial_release_history_findings(
+                repo, target, e.skill, e.proposed_version, positions))
 
     # I-10: inventory reduction requires a target-bound retirement record and
     # the complete target-tree removal predicate.


### PR DESCRIPTION
## 요약

- 신규 skill package와 양쪽 catalog row의 원자적 최초 도입 규칙을 유지합니다.
- 최초 tag 전에는 세 release surface가 끊김 없이 유지되는 범위에서 review 보정 commit을 허용합니다.
- 분리 도입, 제거 후 재추가, 읽을 수 없는 이력은 계속 fail-closed로 거부합니다.
- 영문·한글 validation 문서와 skill development playbook을 함께 갱신했습니다.

## 검증

- M2 release-gate 테스트: 54/54 통과
- 전체 회귀 테스트: 287/287 통과
- repository validator: 0 findings
- git diff check: 통과

## 릴리스 영향

이 PR은 tag나 GitHub Release를 만들지 않습니다. Merge 후 최신 main을 대상으로 M2 preflight를 별도 승인 절차로 다시 실행합니다.