### PR TITLE
fix: 최초 릴리스 target binding으로 M2·M3 계약 정렬

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -118,7 +118,16 @@ jobs:
       # workflow run without grace, so a genuinely deleted tag still fails
       # there immediately and a never-created tag hardens after the window.
       - name: Continuous tag checks (M3)
-        run: PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref origin/main --repo-root . --release-grace-minutes 1440
+        run: |
+          set -u
+          main_ref=origin/main
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            # The checked-out PR merge ref is the candidate post-merge state.
+            # Using origin/main here would make a validator repair PR prove
+            # only that the still-broken base is broken.
+            main_ref=HEAD
+          fi
+          PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref "$main_ref" --repo-root . --release-grace-minutes 1440
 
       - name: Cutover verdict (M4)
         env:

--- a/.skillstead/initial-release-targets/street-portrait-artist-v0.1.0.json
+++ b/.skillstead/initial-release-targets/street-portrait-artist-v0.1.0.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "skill": "street-portrait-artist",
+  "version": "0.1.0",
+  "target_commit": "b2cad05ec351820b7d173bf413f738210641aa1e",
+  "authorization_id": "owner-20260830-8d0c1f74a6b293e5",
+  "approved_at": "2026-08-30",
+  "reason": "The reviewed initial release includes continuous pre-tag amendments after its atomic introduction."
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Repository-level changes since the last dated entry.
 
 ### Repository
 
+- **Repairable PR tag validation.** Pull requests now run M3 against the checked-out merge candidate, while
+  `main` pushes, tag events and the periodic workflow continue to validate the actual `origin/main` state. A
+  validator repair can therefore prove its post-merge result without weakening continuous checks on published state.
 - **Durable first-release target binding.** When review amendments make a new skill's `0.1.0` tag target later
   than its atomic introduction commit, M2 and M3 now share one strict immutable target record. Tags without such
   a record keep their prior expected-target rule, while record mutation, deletion and tag repointing fail closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Repository-level changes since the last dated entry.
 
 ### Repository
 
+- **Durable first-release target binding.** When review amendments make a new skill's `0.1.0` tag target later
+  than its atomic introduction commit, M2 and M3 now share one strict immutable target record. Tags without such
+  a record keep their prior expected-target rule, while record mutation, deletion and tag repointing fail closed.
 - **Reviewable first-release window.** M2 still requires a new skill package and both catalog rows to be introduced
   atomically, while allowing continuous pre-tag review amendments before the first `0.1.0` tag target.
 - **Locale-matched catalog links.** Skill names in the Korean catalog now open each package's Korean README directly;

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -19,7 +19,7 @@
 | M1 | 저장소 검증 — package 구조, `metadata.version` ↔ 스킬별 CHANGELOG 일치와 루트 CHANGELOG의 현재 버전 수록 여부(I-1), 카탈로그 `Version` 열(I-7), package 완전성(I-9), 라이선스 사본 바이트 일치, active identity 예약어 | 모든 PR, `main` push, 매일 schedule | `PYTHONPATH=tools python3 -m skillstead_validate repo` |
 | M2 | 릴리스 preflight와 tag 생성 — 통상 payload diff gate와 exact-record baseline 분기, bump 단계 검사(I-6), inventory·retirement 보호(I-10), major transition 승인, 신규 skill 최초 릴리스, tag 고유성 | 릴리스 제안 시. dry-run 가능 | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` (`git push --atomic`으로 remote에 발행. push 실패 시 local ref rollback) |
 | M2-SVG | `svg-infographic` artifact release gate — exact canonical inventory, clean source identity, package pair 검증, 2× PNG 크기, staging→repository byte 동일성과 source/artifact commit 경계 | 해당 스킬의 M2 preflight 전. read-only | `… svg-release-artifacts --staging STAGING --source-commit SHA [--compare-repository] [--artifact-commit SHA]` |
-| M3 | tag·retirement history 지속 검사 — 모든 namespaced tag의 I-2·I-5·I-8, durable expected-target 관계, retirement record 지속성과 identity 재활성화를 매 실행 검사 | 모든 PR, push, tag 생성/삭제, 매일 schedule | `… tags --main-ref origin/main` |
+| M3 | tag·retirement history 지속 검사 — 모든 namespaced tag의 I-2·I-5·I-8, durable expected-target 관계, retirement record 지속성과 identity 재활성화를 매 실행 검사 | 모든 PR, push, tag 생성/삭제, 매일 schedule | PR merge candidate: `… tags --main-ref HEAD`; 공개 상태: `… tags --main-ref origin/main` |
 | M4 | cutover verdict — cutover record·INSTALL pin·baseline ref·GitHub Releases에 대한 ordered evaluator | CI 상시 + 모든 릴리스 작업 전후 | `… cutover --live --repo-slug OWNER/REPO` |
 | M5 | canonical release wrapper — **GitHub Release 작업의 유일한 지원 경로** | 수동 또는 `release` workflow | `… release --request REQUEST.json --repo-slug OWNER/REPO [--dry-run]` |
 
@@ -85,7 +85,7 @@ release의 `published_at`이 null이거나 빈 문자열인 경우 포함), tran
 
 | 파일 | trigger | 목적 |
 | --- | --- | --- |
-| `validate.yml` | PR, `main` push, tag 생성/삭제 | event 기반 검증을 병렬 job으로 실행 — `svg-infographic` regression suite와 validator self-test suite가 경량 검사(M1+gallery+M3+M4+skills-ref) 옆에서 돌고, `validate` aggregate job이 기존 check 이름을 유지. PR에서 SVG suite는 `skills/svg-infographic/**`와 `examples/svg-infographic/**`가 바뀔 때 실행하며, 다른 독립 Skill 변경은 모든 Skill에 적용되는 경량 검사를 유지하되 무관한 SVG suite 비용은 내지 않음. Repository fixture가 SVG script를 직접 실행하므로 SVG input은 validator self-test도 실행함. `tools/**`·`tests/**`는 validator self-test를 실행하고 `.github/**`·diff 판독 불가·모든 push는 양 heavy suite를 실행함. 알 수 없는 scope output은 skip으로 완화하지 않고 aggregate를 실패시킴. tag event는 명시적 `main` checkout으로 M3+M4 실행, branch 생성/삭제 event는 아무것도 실행하지 않음 |
+| `validate.yml` | PR, `main` push, tag 생성/삭제 | event 기반 검증을 병렬 job으로 실행 — `svg-infographic` regression suite와 validator self-test suite가 경량 검사(M1+gallery+M3+M4+skills-ref) 옆에서 돌고, `validate` aggregate job이 기존 check 이름을 유지. PR에서 SVG suite는 `skills/svg-infographic/**`와 `examples/svg-infographic/**`가 바뀔 때 실행하며, 다른 독립 Skill 변경은 모든 Skill에 적용되는 경량 검사를 유지하되 무관한 SVG suite 비용은 내지 않음. Repository fixture가 SVG script를 직접 실행하므로 SVG input은 validator self-test도 실행함. `tools/**`·`tests/**`는 validator self-test를 실행하고 `.github/**`·diff 판독 불가·모든 push는 양 heavy suite를 실행함. 알 수 없는 scope output은 skip으로 완화하지 않고 aggregate를 실패시킴. PR M3는 checkout된 merge candidate를, `main` push M3는 `origin/main`을 검사함. tag event는 명시적 `main` checkout으로 M3+M4 실행, branch 생성/삭제 event는 아무것도 실행하지 않음 |
 | `validate-periodic.yml` | 매일 schedule(`17 3 * * *` UTC), 수동 dispatch | event가 발생하지 않는 상태 변화(예: push 밖의 tag repoint)를 잡는 주기적 안전망 |
 | `release.yml` | 수동 dispatch 전용 | M5 wrapper 진입점. dry-run이 기본값이며 checkout이 `main`에 고정되어 있어 dispatch가 미검토 wrapper나 request를 write token으로 실행할 수 없음 |
 | `pages.yml` | `main` push, 수동 dispatch | 제한된 gallery/examples site를 게시함. 자동 배포는 `kyungseo/skillstead`에만 허용되어 fork push에서는 deploy job을 skip함. Fork owner는 수동 dispatch로 opt-in할 수 있지만, 해당 fork에서 GitHub Pages를 활성화하지 않았다면 Pages setup 단계에서 계속 실패함 |
@@ -286,6 +286,10 @@ Bump-Adjustment: <기본 단계를 조정한 이유>
   periodic schedule. branch 생성/삭제 event는 tag 상태와 무관하므로 이제 M3를 실행하지
   않습니다). 따라서 실제로 삭제된 tag는 delete event에서 즉시 red가 되고, 끝내 생성되지 않은
   tag는 window 경과 후 다음 periodic run에서 red로 굳습니다.
+* **reference selection** — PR은 제안된 validator와 record 상태가 포함된 checkout된 merge
+  candidate(`HEAD`)를 검사합니다. `main` push는 `origin/main`을 검사하고, tag event와 periodic
+  workflow도 grace 없이 공개된 `origin/main` 상태를 계속 검사합니다. 이 분리로 repair PR은
+  candidate 결과를 증명하되, merge 뒤에도 공개 상태가 red라면 그 사실을 숨기지 않습니다.
 * **expected target** — tag를 보지 않고 파생한다: strict target record가 있는 initial `0.1.0` tag는
   record의 exact commit, 해당 record가 없는 일반 tag는 `main` first-parent에서 skill의 선언 버전이
   그 버전으로 바뀐 가장 오래된 commit, baseline tag 4개(record의 exact ref

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -123,7 +123,10 @@ bump 단계는 major transition 분기가 적용되는 경우를 제외하면 �
 양쪽 카탈로그 행을 하나의 `main` first-parent commit에서 함께 도입해야 합니다. Review 보정을 첫
 릴리스 전에 반영할 수 있도록 이 도입 commit이 tag target보다 앞서는 것은 허용하지만, package와
 양쪽 행은 제안 버전으로 target까지 끊김 없이 유지되어야 하고 target은 여전히 전체 M1을 통과해야
-합니다. 분리 도입, 제거 후 재추가, 연속성을 읽을 수 없는 상태는 fail-closed입니다. 기존 tag와
+합니다. 분리 도입, 제거 후 재추가, 연속성을 읽을 수 없는 상태는 fail-closed입니다. `tag target`이
+atomic introduction commit보다 뒤라면 현재 `main` tree에 아래의 exact initial-release target
+record가 있어야 합니다. M2와 M3는 이 record를 함께 사용하며, 같은 버전을 선언한 모든 commit을
+서로 바꿔 쓸 수 있는 대상으로 취급하지 않습니다. 기존 tag와
 SemVer precedence가 같은 버전(`+build` alias 포함)은 만들 수 없습니다.
 
 일회성 baseline 분기는 target에 canonical prepared cutover record가 있을 때만 활성화됩니다. Plan은
@@ -137,7 +140,7 @@ commit이어야 합니다. T1과 T2도 유지되어 최초 attempt는 `1`, 이�
 
 ## 추적 transition 증거
 
-두 증거 유형은 모두 strict JSON object입니다. 알 수 없거나 중복된 key, 잘못된 type,
+모든 증거 유형은 strict JSON object입니다. 알 수 없거나 중복된 key, 잘못된 type,
 path/content identity 불일치, 잘못된 날짜와 관측 불가 상태는 fail-closed입니다.
 `authorization_id`는 `owner-YYYYMMDD-<16 lowercase hex>` 형식이어야 하고 그 날짜는
 `approved_at`과 같아야 합니다. 이 식별자는 저장소 안에서 사용하는 allowlist handle이지 승인자를
@@ -147,6 +150,29 @@ path/content identity 불일치, 잘못된 날짜와 관측 불가 상태는 fai
 absolute path, 저장소·외부 URL을 포함할 수 없습니다. Validator는 이 한정된 hygiene pattern을
 검사합니다. 그 밖의 민감하거나 식별 가능한 내용은 owner가 정확한 record와 diff를 검토하는 것이
 최종 기준입니다.
+
+### Initial-release target record
+
+경로: `.skillstead/initial-release-targets/<skill>-v0.1.0.json`
+
+```json
+{
+  "schema_version": 1,
+  "skill": "<skill>",
+  "version": "0.1.0",
+  "target_commit": "<40자 lowercase commit SHA 전체>",
+  "authorization_id": "owner-YYYYMMDD-<16 lowercase hex>",
+  "approved_at": "YYYY-MM-DD",
+  "reason": "<중립적인 공개 안전 설명>"
+}
+```
+
+새 skill의 검토된 `0.1.0` tag target이 package·catalog atomic introduction commit보다 뒤일 때만
+이 record가 필요합니다. 정확한 기존 target을 선택한 뒤, tag를 만들기 전에 record를 `main`에
+commit합니다. Target은 `main` 위에 있고 path-bound version을 선언해야 합니다. 유효한 record가 한 번
+나타나면 path와 semantic value는 불변입니다. 수정·삭제·이름 변경, off-main target 또는 version
+불일치는 영구적인 M3 finding입니다. 기존 릴리스와 atomic introduction commit 자체에 tag를 만드는
+initial release는 기존 expected-target 파생 규칙을 그대로 사용합니다.
 
 ### Retirement record
 
@@ -260,8 +286,9 @@ Bump-Adjustment: <기본 단계를 조정한 이유>
   periodic schedule. branch 생성/삭제 event는 tag 상태와 무관하므로 이제 M3를 실행하지
   않습니다). 따라서 실제로 삭제된 tag는 delete event에서 즉시 red가 되고, 끝내 생성되지 않은
   tag는 window 경과 후 다음 periodic run에서 red로 굳습니다.
-* **expected target** — tag를 보지 않고 파생한다: 일반 tag는 `main` first-parent에서 해당
-  skill의 선언 버전이 그 버전으로 바뀐 가장 오래된 commit, baseline tag 4개(record의 exact ref
+* **expected target** — tag를 보지 않고 파생한다: strict target record가 있는 initial `0.1.0` tag는
+  record의 exact commit, 해당 record가 없는 일반 tag는 `main` first-parent에서 skill의 선언 버전이
+  그 버전으로 바뀐 가장 오래된 commit, baseline tag 4개(record의 exact ref
   membership으로만 판정 — 버전 문자열 비교 아님)는 record가 도입된 commit. 다른 곳을 가리키는
   tag는 repoint finding이다.
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -141,7 +141,10 @@ commit may precede the tag target so review fixes can land before the first
 release, but the package and both rows must remain continuously present at
 the proposed version through the target, which must still pass full M1. Any
 split introduction, removal/re-addition gap, or unreadable continuity state
-fails closed. No existing tag may share the proposed version's SemVer
+fails closed. When the tag target is later than the atomic introduction, the
+current `main` tree must carry the exact initial-release target record below;
+M2 and M3 both use that record instead of treating every same-version commit
+as interchangeable. No existing tag may share the proposed version's SemVer
 precedence (including `+build` aliases).
 
 The one-time baseline branch activates only when the target carries the
@@ -157,7 +160,7 @@ inventory with `baseline_finalization_sha:skills`; any decrease is a finding.
 
 ## Tracked transition evidence
 
-Both evidence types are strict JSON objects. Unknown or duplicate keys, wrong
+All evidence types are strict JSON objects. Unknown or duplicate keys, wrong
 types, path/content identity mismatches, malformed dates, and unobservable
 state fail closed. `authorization_id` must match
 `owner-YYYYMMDD-<16 lowercase hex>` and its date must equal `approved_at`.
@@ -170,6 +173,31 @@ tracker identifiers, local absolute paths, or repository/external URLs. The
 validator applies those bounded hygiene patterns; owner review of the exact
 record and diff remains authoritative for other sensitive or identifying
 content.
+
+### Initial-release target record
+
+Path: `.skillstead/initial-release-targets/<skill>-v0.1.0.json`
+
+```json
+{
+  "schema_version": 1,
+  "skill": "<skill>",
+  "version": "0.1.0",
+  "target_commit": "<full 40-character lowercase commit SHA>",
+  "authorization_id": "owner-YYYYMMDD-<16 lowercase hex>",
+  "approved_at": "YYYY-MM-DD",
+  "reason": "<neutral public-safe explanation>"
+}
+```
+
+The record is required only when a new skill's reviewed `0.1.0` tag target is
+later than its atomic package-and-catalog introduction commit. Commit it to
+`main` after selecting the exact already-existing target and before creating
+the tag. The target must be on `main` and declare the path-bound version. Once
+a valid record appears, its path and semantic value are immutable; mutation,
+deletion, rename, an off-main target, or a mismatched version is a durable M3
+finding. Existing releases and initial releases tagged at their atomic
+introduction commit keep the legacy expected-target derivation unchanged.
 
 ### Retirement record
 
@@ -304,12 +332,13 @@ For every `<name>/vX.Y.Z` tag, on every run:
   A genuinely deleted tag therefore still turns red at its delete event
   immediately, and a tag that is never created hardens to red at the next
   periodic run after the window expires.
-* **Expected target** — derived without looking at the tag: for an ordinary
-  tag, the oldest `main` first-parent commit where the skill's declared
-  version changed to the tag's version; for the four baseline tags (exact
-  ref membership in the cutover record, never version-string matching), the
-  commit that introduced the record. A tag pointing anywhere else is a
-  repoint finding.
+* **Expected target** — derived without looking at the tag: for an initial
+  `0.1.0` tag with a strict target record, the record's exact commit; for an
+  ordinary tag without such a record, the oldest `main` first-parent commit
+  where the skill's declared version changed to the tag's version; for the
+  four baseline tags (exact ref membership in the cutover record, never
+  version-string matching), the commit that introduced the record. A tag
+  pointing anywhere else is a repoint finding.
 
 Comparisons use peeled commit SHAs — annotated and lightweight tags mix in
 this repository's history and tag-object SHAs would split them.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -21,7 +21,7 @@ verdict, never a silent pass.
 | M1 | Repository validation — package structure, `metadata.version` ↔ per-skill CHANGELOG and root CHANGELOG current-version coverage (I-1), catalog `Version` columns (I-7), package completeness (I-9), licence copy byte-equality, and reserved active identities | every PR, push to `main`, daily schedule | `PYTHONPATH=tools python3 -m skillstead_validate repo` |
 | M2 | Release preflight and tag creation — ordinary payload-diff gate plus the exact-record baseline branch, bump-step check (I-6), inventory/retirement guard (I-10), major-transition approval, new-skill initial release, tag uniqueness | invoked for a proposed release; dry-runnable | `… preflight --plan PLAN.json` / `… apply-tags --plan PLAN.json` (publishes to the remote with `git push --atomic`; a push failure rolls local refs back) |
 | M2-SVG | `svg-infographic` artifact release gate — exact canonical inventory, clean source identity, package pair verification, 2× PNG dimensions, staging-to-repository byte identity and source/artifact commit boundary | before its M2 preflight; read-only | `… svg-release-artifacts --staging STAGING --source-commit SHA [--compare-repository] [--artifact-commit SHA]` |
-| M3 | Continuous tag and retirement-history checks — I-2, I-5, I-8, the durable expected-target relation for every namespaced tag, and retirement-record persistence/reactivation on every run | every PR, push, tag create/delete, daily schedule | `… tags --main-ref origin/main` |
+| M3 | Continuous tag and retirement-history checks — I-2, I-5, I-8, the durable expected-target relation for every namespaced tag, and retirement-record persistence/reactivation on every run | every PR, push, tag create/delete, daily schedule | PR merge candidate: `… tags --main-ref HEAD`; published state: `… tags --main-ref origin/main` |
 | M4 | Cutover verdict — the ordered evaluator over the cutover record, INSTALL pins, baseline refs, and GitHub Releases | CI runs + before/after every release operation | `… cutover --live --repo-slug OWNER/REPO` |
 | M5 | Canonical release wrapper — **the only supported path for GitHub Release operations** | manual, or the `release` workflow | `… release --request REQUEST.json --repo-slug OWNER/REPO [--dry-run]` |
 
@@ -96,7 +96,7 @@ would state something the run did not observe.
 
 | File | Triggers | Purpose |
 | --- | --- | --- |
-| `validate.yml` | PR, push to `main`, tag create/delete | event-driven validation as parallel jobs — the `svg-infographic` regression suite and validator self-test suite run beside the fast checks (M1+gallery+M3+M4+skills-ref), and a `validate` aggregate job carries the historical check name. On PRs the SVG suite runs for `skills/svg-infographic/**` and `examples/svg-infographic/**`, while other independent skill changes retain the fast all-skill checks without paying for that unrelated suite. SVG inputs also run validator self-tests because repository fixtures invoke the SVG scripts. `tools/**` and `tests/**` run validator self-tests; `.github/**`, an unreadable diff and every push run both heavy suites. Unknown scope output fails the aggregate rather than becoming a skip. Tag events run M3+M4 against an explicit `main` checkout; branch create/delete events run nothing |
+| `validate.yml` | PR, push to `main`, tag create/delete | event-driven validation as parallel jobs — the `svg-infographic` regression suite and validator self-test suite run beside the fast checks (M1+gallery+M3+M4+skills-ref), and a `validate` aggregate job carries the historical check name. On PRs the SVG suite runs for `skills/svg-infographic/**` and `examples/svg-infographic/**`, while other independent skill changes retain the fast all-skill checks without paying for that unrelated suite. SVG inputs also run validator self-tests because repository fixtures invoke the SVG scripts. `tools/**` and `tests/**` run validator self-tests; `.github/**`, an unreadable diff and every push run both heavy suites. Unknown scope output fails the aggregate rather than becoming a skip. PR M3 evaluates the checked-out merge candidate; `main` push M3 evaluates `origin/main`. Tag events run M3+M4 against an explicit `main` checkout; branch create/delete events run nothing |
 | `validate-periodic.yml` | daily schedule (`17 3 * * *` UTC), manual dispatch | periodic fallback for state changes that fire no event (e.g. a tag repointed outside a push) |
 | `release.yml` | manual dispatch only | M5 wrapper entry; dry-run by default; checkout pinned to `main` so a dispatch can never run an unreviewed wrapper or request under the write token |
 | `pages.yml` | push to `main`, manual dispatch | publishes the bounded gallery/examples site. Automatic deployment is limited to `kyungseo/skillstead`; a fork push skips the deploy job. A fork owner may opt in with a manual dispatch, but that run still fails at Pages setup when GitHub Pages has not been enabled in the fork |
@@ -332,6 +332,12 @@ For every `<name>/vX.Y.Z` tag, on every run:
   A genuinely deleted tag therefore still turns red at its delete event
   immediately, and a tag that is never created hardens to red at the next
   periodic run after the window expires.
+* **Reference selection** — a pull request checks the checked-out merge
+  candidate (`HEAD`), which includes the proposed validator and record state.
+  A `main` push checks `origin/main`; tag events and the periodic workflow also
+  keep checking the published `origin/main` state without grace. This split
+  lets a repair PR prove its candidate result without hiding a red published
+  state after merge.
 * **Expected target** — derived without looking at the tag: for an initial
   `0.1.0` tag with a strict target record, the record's exact commit; for an
   ordinary tag without such a record, the oldest `main` first-parent commit

--- a/playbooks/skill-development/skill-development-procedure.ko.md
+++ b/playbooks/skill-development/skill-development-procedure.ko.md
@@ -94,7 +94,10 @@ Merge-to-tag 구간의 임시 red를 숨기지 않습니다. 실제 merge target
 
 신규 skill은 package와 양쪽 catalog row를 하나의 `main` first-parent commit에서 함께 도입합니다.
 첫 tag 전 review 보정 commit은 허용하지만, 세 release surface가 `0.1.0`으로 끊김 없이 유지되고 최종
-tag target이 M1을 통과해야 합니다. 분리 도입이나 제거 후 재추가는 지원되는 우회 경로가 아닙니다.
+tag target이 M1을 통과해야 합니다. 검토된 target이 atomic introduction보다 뒤라면 exact SHA를 선택하고
+strict `.skillstead/initial-release-targets/<skill>-v0.1.0.json` binding을 `main`에 commit한 뒤 tag 생성 전에
+M2를 다시 실행합니다. Binding commit 자체는 tag target이 아닙니다. 분리 도입, 제거 후 재추가, mutable
+record 또는 binding 없는 후속 target은 지원되는 우회 경로가 아닙니다.
 
 Publish 단계 자체에는 그런 판단이 필요하지 않습니다. Release wrapper는 발행 직후의 관측이 스스로
 모순될 때에 **한해서만** 정해진 예산 안에서 재관측하고 그 결과를 보고합니다. 따라서 wrapper가 돌려준

--- a/playbooks/skill-development/skill-development-procedure.md
+++ b/playbooks/skill-development/skill-development-procedure.md
@@ -93,7 +93,10 @@ decision.
 
 For a new skill, introduce the package and both catalog rows together in one `main` first-parent commit. Review
 fixes may follow before the first tag, provided all three release surfaces remain continuously present at `0.1.0`
-and the final tag target passes M1. A split introduction or remove-and-re-add sequence is not a supported shortcut.
+and the final tag target passes M1. If the reviewed target is later than that atomic introduction, select its exact
+SHA, commit the strict `.skillstead/initial-release-targets/<skill>-v0.1.0.json` binding to `main`, and re-run M2
+before creating the tag. The binding commit is not the tag target. A split introduction, remove-and-re-add sequence,
+mutable record, or unbound later target is not a supported shortcut.
 
 The publish step itself needs no such judgement. The release wrapper already retries its own post-publish read
 when — and only when — that observation contradicts itself, within a bounded budget it reports. A red the

--- a/tests/test_ci_scope.py
+++ b/tests/test_ci_scope.py
@@ -92,6 +92,14 @@ class WorkflowContract(unittest.TestCase):
         self.assertIn('*) fail "$name has unknown scope decision', text)
         self.assertIn("git -c core.quotePath=off diff --name-only --no-renames", text)
 
+    def test_pull_request_m3_checks_candidate_while_push_checks_main(self):
+        text = (REPO / ".github/workflows/validate.yml").read_text(encoding="utf-8")
+        self.assertIn("main_ref=origin/main", text)
+        self.assertIn(
+            'if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then', text)
+        self.assertIn("main_ref=HEAD", text)
+        self.assertEqual(text.count('--main-ref "$main_ref"'), 1)
+
     def test_pages_automatic_deploy_is_canonical_only_and_manual_is_explicit(self):
         text = (REPO / ".github/workflows/pages.yml").read_text(encoding="utf-8")
         self.assertIn(

--- a/tests/test_evidence_records.py
+++ b/tests/test_evidence_records.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
 
 from skillstead_validate.evidence_records import (  # noqa: E402
     RecordError,
+    parse_initial_release_target_record,
     parse_major_approval_record,
     parse_retirement_record,
 )
@@ -39,6 +40,20 @@ def major(**overrides) -> str:
         "authorization_id": "owner-20260729-fedcba9876543210",
         "approved_at": "2026-07-29",
         "reason": "The version transition intentionally communicates a breaking change.",
+    }
+    record.update(overrides)
+    return json.dumps(record)
+
+
+def initial_target(**overrides) -> str:
+    record = {
+        "schema_version": 1,
+        "skill": "alpha-skill",
+        "version": "0.1.0",
+        "target_commit": "a" * 40,
+        "authorization_id": "owner-20260830-0123456789abcdef",
+        "approved_at": "2026-08-30",
+        "reason": "The reviewed amendments are bound to this initial release target.",
     }
     record.update(overrides)
     return json.dumps(record)
@@ -116,6 +131,24 @@ class MajorApprovalRecordParsing(unittest.TestCase):
                 major(
                     authorization_id="owner-20260729-FEDCBA9876543210"),
                 "alpha-skill", "2.0.0")
+
+
+class InitialReleaseTargetRecordParsing(unittest.TestCase):
+    def test_valid_record(self) -> None:
+        record = parse_initial_release_target_record(
+            initial_target(), "alpha-skill", "0.1.0")
+        self.assertEqual(record.target_commit, "a" * 40)
+
+    def test_wrong_version_target_and_private_reason_rejected(self) -> None:
+        for value in (
+                initial_target(version="0.2.0"),
+                initial_target(target_commit="A" * 40),
+                initial_target(target_commit="abc"),
+                initial_target(reason="See /Users/example/private-note.")):
+            with self.subTest(value=value):
+                with self.assertRaises(RecordError):
+                    parse_initial_release_target_record(
+                        value, "alpha-skill", "0.1.0")
 
 
 if __name__ == "__main__":

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -58,6 +58,23 @@ def _write_major_record(
     }), encoding="utf-8")
 
 
+def _write_initial_target_record(
+        repo: Path, target: str, *, skill: str = "gamma-skill",
+        version: str = "0.1.0") -> None:
+    path = repo / ".skillstead/initial-release-targets" / (
+        f"{skill}-v{version}.json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "schema_version": 1,
+        "skill": skill,
+        "version": version,
+        "target_commit": target,
+        "authorization_id": "owner-20260830-0123456789abcdef",
+        "approved_at": "2026-08-30",
+        "reason": "The reviewed amendments are bound to this initial release target.",
+    }), encoding="utf-8")
+
+
 def _retire_beta(
         repo: Path, *, last_release_ref: str | None = "beta-skill/v0.4.0",
         include_record: bool = True) -> None:
@@ -358,7 +375,7 @@ class ReleaseGateFixtures(unittest.TestCase):
         commit_all(self.repo, "add gamma without catalog rows")
         self.assertIn("I-7", self._preflight([entry("gamma-skill", None, "0.1.0")]))
 
-    def test_new_skill_allows_continuous_pre_tag_amendments(self) -> None:
+    def test_new_skill_amendment_target_requires_exact_binding(self) -> None:
         _add_unreleased_gamma(self.repo)
         skill_md = self.repo / "skills/gamma-skill/SKILL.md"
         skill_md.write_text(
@@ -372,9 +389,33 @@ class ReleaseGateFixtures(unittest.TestCase):
                     "| [`gamma-skill`](./skills/gamma-skill) | Fixture |",
                     "| [`gamma-skill`](./skills/gamma-skill) | Reviewed fixture |"),
                 encoding="utf-8")
-        commit_all(self.repo, "amend unreleased gamma package and catalogs")
+        target = commit_all(
+            self.repo, "amend unreleased gamma package and catalogs")
+        plan = parse_plan(plan_json(
+            target, [entry("gamma-skill", None, "0.1.0")]))
+        self.assertIn(
+            "INITIAL-RELEASE-TARGET",
+            {finding.check for finding in preflight(self.repo, plan)})
+
+        _write_initial_target_record(self.repo, target)
+        commit_all(self.repo, "bind reviewed initial release target")
         self.assertEqual(
-            self._preflight([entry("gamma-skill", None, "0.1.0")]), set())
+            preflight(self.repo, plan), [])
+
+    def test_new_skill_target_binding_rejects_different_target(self) -> None:
+        _add_unreleased_gamma(self.repo)
+        skill_md = self.repo / "skills/gamma-skill/SKILL.md"
+        skill_md.write_text(
+            skill_md.read_text(encoding="utf-8") + "\nReviewed amendment.\n",
+            encoding="utf-8")
+        target = commit_all(self.repo, "amend unreleased gamma")
+        _write_initial_target_record(self.repo, "a" * 40)
+        commit_all(self.repo, "bind wrong initial target")
+        plan = parse_plan(plan_json(
+            target, [entry("gamma-skill", None, "0.1.0")]))
+        self.assertIn(
+            "INITIAL-RELEASE-TARGET",
+            {finding.check for finding in preflight(self.repo, plan)})
 
     def test_new_skill_rejects_package_gap_before_first_tag(self) -> None:
         import shutil

--- a/tests/test_tag_check.py
+++ b/tests/test_tag_check.py
@@ -56,6 +56,44 @@ def _release_alpha(repo: Path, version: str, prev: str) -> str:
     return sha
 
 
+def _initial_gamma_with_amendment(repo: Path) -> tuple[str, str]:
+    pkg = repo / "skills/gamma-skill"
+    pkg.mkdir(parents=True)
+    (pkg / "SKILL.md").write_text(
+        "---\nname: gamma-skill\nlicense: LICENSE.txt\nmetadata:\n"
+        "  version: 0.1.0\n---\n\nInitial body.\n",
+        encoding="utf-8")
+    (pkg / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [0.1.0] — 2026-08-30\n\nInitial.\n",
+        encoding="utf-8")
+    (pkg / "LICENSE.txt").write_text(
+        (repo / "LICENSE").read_text(encoding="utf-8"),
+        encoding="utf-8")
+    introduction = commit_all(repo, "introduce gamma 0.1.0")
+    (pkg / "SKILL.md").write_text(
+        (pkg / "SKILL.md").read_text(encoding="utf-8")
+        + "\nReviewed amendment.\n", encoding="utf-8")
+    target = commit_all(repo, "amend gamma before first tag")
+    _git(repo, "tag", "gamma-skill/v0.1.0", target)
+    return introduction, target
+
+
+def _write_initial_target_record(repo: Path, target: str) -> Path:
+    path = (repo / ".skillstead/initial-release-targets/"
+            "gamma-skill-v0.1.0.json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "schema_version": 1,
+        "skill": "gamma-skill",
+        "version": "0.1.0",
+        "target_commit": target,
+        "authorization_id": "owner-20260830-0123456789abcdef",
+        "approved_at": "2026-08-30",
+        "reason": "The reviewed amendments are bound to this initial release target.",
+    }), encoding="utf-8")
+    return path
+
+
 def _retire_beta(repo: Path) -> str:
     import shutil
     shutil.rmtree(repo / "skills/beta-skill")
@@ -105,6 +143,35 @@ class TagCheckFixtures(unittest.TestCase):
         self.assertNotIn("I-2", checks)
         self.assertNotIn("I-8", checks)
         self.assertNotIn("I-5", checks)
+
+    def test_initial_amendment_tag_requires_binding(self) -> None:
+        _initial_gamma_with_amendment(self.repo)
+        self.assertIn("I-3-c", self.checks())
+
+    def test_initial_amendment_binding_is_green_and_repoint_safe(self) -> None:
+        introduction, target = _initial_gamma_with_amendment(self.repo)
+        _write_initial_target_record(self.repo, target)
+        commit_all(self.repo, "bind reviewed gamma target")
+        self.assertEqual(run_tag_checks(self.repo), [])
+
+        _git(self.repo, "tag", "-f", "gamma-skill/v0.1.0", introduction)
+        self.assertIn("I-3-c", self.checks())
+
+    def test_initial_target_record_mutation_and_deletion_are_durable_red(self) -> None:
+        _, target = _initial_gamma_with_amendment(self.repo)
+        path = _write_initial_target_record(self.repo, target)
+        commit_all(self.repo, "bind reviewed gamma target")
+        original = path.read_text(encoding="utf-8")
+
+        path.write_text(
+            original.replace("reviewed amendments", "different amendments"),
+            encoding="utf-8")
+        commit_all(self.repo, "mutate gamma target record")
+        self.assertIn("INITIAL-RELEASE-TARGET-HISTORY", self.checks())
+
+        path.unlink()
+        commit_all(self.repo, "delete gamma target record")
+        self.assertIn("INITIAL-RELEASE-TARGET-HISTORY", self.checks())
 
     # E7-ⓕ: multi-skill release tag의 부분 삭제 → I-5
     def test_e7f_partial_deletion_of_multi_skill_release(self) -> None:

--- a/tools/skillstead_validate/evidence_records.py
+++ b/tools/skillstead_validate/evidence_records.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 RETIREMENT_DIR = ".skillstead/retirements"
 MAJOR_APPROVAL_DIR = ".skillstead/major-approvals"
+INITIAL_RELEASE_TARGET_DIR = ".skillstead/initial-release-targets"
 RESERVED_SKILL_NAMES = frozenset({"sample-skill"})
 
 _NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
@@ -46,6 +47,16 @@ class MajorApprovalRecord:
     skill: str
     previous_ref: str
     proposed_version: str
+    authorization_id: str
+    approved_at: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class InitialReleaseTargetRecord:
+    skill: str
+    version: str
+    target_commit: str
     authorization_id: str
     approved_at: str
     reason: str
@@ -190,9 +201,44 @@ def parse_major_approval_record(
     )
 
 
+def parse_initial_release_target_record(
+        text: str, expected_skill: str,
+        expected_version: str) -> InitialReleaseTargetRecord:
+    raw = _load_object(text)
+    _require_exact_keys(raw, {
+        "schema_version", "skill", "version", "target_commit",
+        "authorization_id", "approved_at", "reason",
+    })
+    _require_schema_and_identity(raw, expected_skill)
+    authorization_id, approved_at = _require_authorization(raw)
+
+    version = raw["version"]
+    if version != "0.1.0" or version != expected_version:
+        raise RecordError(
+            "version must be the path-bound initial release 0.1.0")
+    target_commit = raw["target_commit"]
+    if not isinstance(target_commit, str) \
+            or not re.fullmatch(r"[0-9a-f]{40}", target_commit):
+        raise RecordError(
+            "target_commit must be a full 40-character lowercase commit SHA")
+
+    return InitialReleaseTargetRecord(
+        skill=expected_skill,
+        version=version,
+        target_commit=target_commit,
+        authorization_id=authorization_id,
+        approved_at=approved_at,
+        reason=raw["reason"].strip(),
+    )
+
+
 def retirement_path(skill: str) -> str:
     return f"{RETIREMENT_DIR}/{skill}.json"
 
 
 def major_approval_path(skill: str, version: str) -> str:
     return f"{MAJOR_APPROVAL_DIR}/{skill}-v{version}.json"
+
+
+def initial_release_target_path(skill: str, version: str) -> str:
+    return f"{INITIAL_RELEASE_TARGET_DIR}/{skill}-v{version}.json"

--- a/tools/skillstead_validate/release_gate.py
+++ b/tools/skillstead_validate/release_gate.py
@@ -17,7 +17,9 @@ from .changelog import ChangelogError, topmost_released_version
 from .catalog import EN_HEADER, KO_HEADER, CatalogError, catalog_versions
 from .evidence_records import (
     RecordError,
+    initial_release_target_path,
     major_approval_path,
+    parse_initial_release_target_record,
     parse_major_approval_record,
     parse_retirement_record,
     retirement_path,
@@ -206,6 +208,54 @@ def _initial_release_history_findings(
                 f"version {proposed_version} through pre-tag amendment "
                 f"commit {commit[:12]}"))
     return findings
+
+
+def _initial_release_target_findings(
+        repo: Path, main_tip: str, target: str, skill: str,
+        proposed_version: str) -> list[Finding]:
+    """Bind a reviewed amendment target independently of the future tag.
+
+    The atomic introduction remains the default expected target. A later
+    continuous pre-tag amendment is valid only when current ``main`` carries
+    a strict owner-authorized record naming the exact earlier commit. This
+    lets M2 and M3 derive the same target without trusting the tag itself.
+    """
+    path = initial_release_target_path(skill, proposed_version)
+    text = file_at(repo, main_tip, path)
+    try:
+        history = git(
+            repo, "log", "--first-parent", "--reverse", "--format=%H",
+            target, "--", f"skills/{skill}").split()
+    except GitError as error:
+        return [Finding(
+            "GIT", skill,
+            f"initial-release target history unobservable (fail-closed): {error}")]
+    if not history:
+        return [Finding(
+            "D3-3", skill,
+            "initial-release target cannot be derived (fail-closed)")]
+    introduction = history[0]
+
+    if text is None:
+        if target == introduction:
+            return []
+        return [Finding(
+            "INITIAL-RELEASE-TARGET", path,
+            f"reviewed target {target[:12]} follows introduction "
+            f"{introduction[:12]} but has no exact target record")]
+    try:
+        record = parse_initial_release_target_record(
+            text, skill, proposed_version)
+    except RecordError as error:
+        return [Finding(
+            "INITIAL-RELEASE-TARGET", path,
+            f"record rejected (fail-closed): {error}")]
+    if record.target_commit != target:
+        return [Finding(
+            "INITIAL-RELEASE-TARGET", path,
+            f"record target {record.target_commit[:12]} != proposed target "
+            f"{target[:12]}")]
+    return []
 
 
 def _retired_row(skill: str, last_release_ref: str | None) -> str:
@@ -437,6 +487,7 @@ def preflight(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[Fin
     if target not in positions:
         return [Finding("I-8", plan.target_commit, f"target {target[:12]} is not on {main_ref} first-parent history")]
     ordered = sorted(positions, key=positions.__getitem__)
+    main_tip = ordered[0]
     idx = positions[target]
     target_parent = ordered[idx + 1] if idx + 1 < len(ordered) else None
 
@@ -587,6 +638,8 @@ def preflight(repo: Path, plan: ReleasePlan, main_ref: str = "main") -> list[Fin
                         f"{e.proposed_version} at the tag target"))
             findings.extend(_initial_release_history_findings(
                 repo, target, e.skill, e.proposed_version, positions))
+            findings.extend(_initial_release_target_findings(
+                repo, main_tip, target, e.skill, e.proposed_version))
 
     # I-10: inventory reduction requires a target-bound retirement record and
     # the complete target-tree removal predicate.

--- a/tools/skillstead_validate/tag_check.py
+++ b/tools/skillstead_validate/tag_check.py
@@ -6,7 +6,8 @@ creation-time checks guarantee nothing durable. Checks:
 * I-2  — the peeled target declares exactly the tag's version.
 * I-8  — the peeled target is a commit on ``main``.
 * I-3-ⓒ — durable relation: the expected target is derived *without looking
-  at the tag*. General tags: the oldest ``main`` first-parent commit where the
+  at the tag*. A recorded initial release uses its exact immutable target;
+  other general tags use the oldest ``main`` first-parent commit where the
   skill's declared version changed to the tag's version. Baseline tags (exact
   ref membership in the cutover record's ``baseline_tags``): the first-parent
   commit where the record with the current ``attempt`` was introduced.
@@ -38,9 +39,12 @@ from pathlib import Path
 
 from . import record_schema
 from .evidence_records import (
+    INITIAL_RELEASE_TARGET_DIR,
     RETIREMENT_DIR,
+    InitialReleaseTargetRecord,
     RecordError,
     RetirementRecord,
+    parse_initial_release_target_record,
     parse_retirement_record,
 )
 from .findings import Finding
@@ -58,6 +62,8 @@ from .gitio import (
 RECORD_PATH = record_schema.RECORD_PATH
 _TAG_RE = re.compile(r"^([a-z0-9][a-z0-9-]*)/v(\d+\.\d+\.\d+)$")
 _TAG_SHAPE = re.compile(r"^[^/]+/v")
+_INITIAL_TARGET_FILE = re.compile(
+    r"^([a-z0-9][a-z0-9-]*)-v(\d+\.\d+\.\d+)\.json$")
 
 
 class _RecordError(ValueError):
@@ -238,6 +244,105 @@ def _retirement_history_findings(
     return findings
 
 
+def _initial_release_target_history(
+        repo: Path, history: _History
+) -> tuple[dict[tuple[str, str], InitialReleaseTargetRecord], list[Finding]]:
+    """Read immutable initial-target bindings from first-parent history.
+
+    A current-tree-only lookup would let a record be deleted and the tag be
+    repointed to the legacy introduction commit. Once a valid binding appears,
+    its path and semantic value therefore remain durable.
+    """
+    findings: list[Finding] = []
+    known: dict[tuple[str, str], InitialReleaseTargetRecord] = {}
+    reported: set[tuple[str, str, str]] = set()
+    commit_set = set(history.commits)
+
+    def report(kind: str, key: tuple[str, str], commit: str,
+               detail: str) -> None:
+        identity = (kind, *key)
+        if identity not in reported:
+            reported.add(identity)
+            findings.append(Finding(
+                "INITIAL-RELEASE-TARGET-HISTORY", "/".join(key),
+                f"{detail} at {commit[:12]} (fail-closed)"))
+
+    try:
+        changed_commits = git(
+            repo, "log", "--first-parent", "--reverse", "--format=%H",
+            history.commits[0], "--", INITIAL_RELEASE_TARGET_DIR).split()
+    except GitError as error:
+        findings.append(Finding(
+            "GIT", INITIAL_RELEASE_TARGET_DIR,
+            f"initial-target history unobservable (fail-closed): {error}"))
+        return known, findings
+
+    for commit in changed_commits:  # oldest change -> newest change
+        try:
+            paths = files_at(repo, commit, INITIAL_RELEASE_TARGET_DIR)
+        except GitError as error:
+            findings.append(Finding(
+                "GIT", INITIAL_RELEASE_TARGET_DIR,
+                f"initial-target history unobservable at {commit[:12]} "
+                f"(fail-closed): {error}"))
+            return known, findings
+
+        current: dict[tuple[str, str], InitialReleaseTargetRecord] = {}
+        prefix = INITIAL_RELEASE_TARGET_DIR + "/"
+        for path in sorted(paths):
+            leaf = path.removeprefix(prefix)
+            match = _INITIAL_TARGET_FILE.fullmatch(leaf)
+            if "/" in leaf or match is None:
+                findings.append(Finding(
+                    "INITIAL-RELEASE-TARGET-HISTORY", path,
+                    f"unexpected initial-target record path at "
+                    f"{commit[:12]} (fail-closed)"))
+                continue
+            skill, version = match.groups()
+            text = file_at(repo, commit, path)
+            if text is None:
+                findings.append(Finding(
+                    "INITIAL-RELEASE-TARGET-HISTORY", path,
+                    f"record content unobservable at {commit[:12]} "
+                    "(fail-closed)"))
+                continue
+            try:
+                record = parse_initial_release_target_record(
+                    text, skill, version)
+            except RecordError as error:
+                findings.append(Finding(
+                    "INITIAL-RELEASE-TARGET-HISTORY", path,
+                    f"record rejected at {commit[:12]} "
+                    f"(fail-closed): {error}"))
+                continue
+            key = (skill, version)
+            current[key] = record
+            if record.target_commit not in commit_set:
+                report(
+                    "off-main", key, commit,
+                    f"record target {record.target_commit[:12]} is not on main")
+            elif history.version_at(
+                    record.target_commit, skill) != version:
+                report(
+                    "wrong-version", key, commit,
+                    "record target does not declare the path-bound version")
+
+        for key, original in known.items():
+            observed = current.get(key)
+            if observed is None:
+                report(
+                    "missing", key, commit,
+                    "initial-target record disappeared or moved")
+            elif observed != original:
+                report(
+                    "mutated", key, commit,
+                    "initial-target record semantic value changed")
+        for key, record in current.items():
+            known.setdefault(key, record)
+
+    return known, findings
+
+
 def run_tag_checks(
     repo: Path,
     main_ref: str = "main",
@@ -253,6 +358,9 @@ def run_tag_checks(
         return [Finding("GIT", main_ref, f"main history unobservable (fail-closed): {e}")]
 
     findings.extend(_retirement_history_findings(repo, history))
+    initial_targets, initial_target_findings = \
+        _initial_release_target_history(repo, history)
+    findings.extend(initial_target_findings)
 
     record: dict | None = None
     try:
@@ -312,11 +420,16 @@ def run_tag_checks(
             if record_intro is not None and target != record_intro:
                 findings.append(Finding("I-3-c", name, f"baseline tag target {target[:12]} != record introduction commit {record_intro[:12]}"))
         else:
-            expected = history.oldest_version_change(skill, version) if on_main else None
+            binding = initial_targets.get((skill, version))
+            expected = (
+                binding.target_commit if binding is not None
+                else history.oldest_version_change(skill, version)
+            ) if on_main else None
             if expected is None:
                 findings.append(Finding("I-3-c", name, f"no main first-parent commit introduces version {version} for {skill} (fail-closed)"))
             elif target != expected:
-                findings.append(Finding("I-3-c", name, f"target {target[:12]} != expected {expected[:12]} (repoint suspected)"))
+                source = "initial-release target record" if binding else "version introduction"
+                findings.append(Finding("I-3-c", name, f"target {target[:12]} != expected {expected[:12]} from {source} (repoint suspected)"))
 
     # I-5: existence only — target correctness is I-3-ⓒ's job, and merging
     # the two would leak the baseline exception into I-5 (the contract requires


### PR DESCRIPTION
## 요약

- 신규 Skill의 첫 `0.1.0` tag target이 atomic introduction commit보다 뒤일 때만 exact target record를 요구합니다.
- M2와 M3가 같은 immutable binding을 읽도록 정렬합니다.
- Record가 없는 기존 tag와 atomic introduction 자체를 가리키는 첫 tag는 기존 expected-target 규칙을 유지합니다.
- PR의 M3는 checkout된 merge candidate(`HEAD`)를, `main` push·tag·periodic 검사는 공개 상태인 `origin/main`을 검사합니다.

## 배경

첫 릴리스 전 연속 보정 commit을 허용하도록 M2를 변경했지만, M3는 여전히 version이 처음 등장한 commit만 expected target으로 계산했습니다. 그 결과 승인된 `street-portrait-artist/v0.1.0` tag가 정확한 merge target을 가리키는데도 M3가 repoint로 판정했습니다.

또한 PR workflow가 `origin/main`만 검사하면 validator를 고치는 PR도 아직 고쳐지지 않은 base만 검증하게 됩니다. PR에서는 제안된 validator와 record가 포함된 merge candidate를 검사하고, merge 뒤에는 공개된 `origin/main`을 다시 검사하도록 reference 경계를 분리했습니다.

공개 tag는 `b2cad05ec351820b7d173bf413f738210641aa1e`에서 이동·삭제하지 않습니다. GitHub Release도 아직 발행하지 않았습니다.

## 변경

- `.skillstead/initial-release-targets/<skill>-v0.1.0.json` strict schema를 추가했습니다.
- M2는 tag target이 atomic introduction보다 뒤라면 current `main`의 exact binding을 요구합니다.
- M3는 binding이 있으면 그 SHA를 독립 expected target으로 사용하고, 없으면 기존 version-introduction 파생을 유지합니다.
- 유효한 record가 나타난 뒤 수정·삭제·이름 변경되거나 off-main/wrong-version target을 가리키면 지속 검사에서 fail-closed합니다.
- PR M3는 `HEAD`, `main` push·tag·periodic M3는 `origin/main`을 검사하도록 workflow contract test를 추가했습니다.
- 영문·한국어 validation 문서, Skill 개발 절차와 `[Unreleased]` changelog를 같은 계약으로 갱신했습니다.

## 검증

- 전체 repository test: `293/293` 통과
- 최종 history-scan 조정 후 영향 M3 suite: `28/28` 통과
- `PYTHONPATH=tools python3 -m skillstead_validate repo`: `0 finding(s)`
- `PYTHONPATH=tools python3 -m skillstead_validate tags --main-ref HEAD`: `0 finding(s)`
- `git diff --check`: 통과
- 영향받은 한국어 문서를 GFM-compatible parser로 렌더해 code span/fence 밖 literal `**`가 없음을 확인
- Hosted CI run `33290797274`: `checks`, `scope`, `svg-infographic-suite`, `validator-suite`, 최종 `validate` 모두 통과

## 릴리스 경계

이 PR은 기존 tag를 변경하거나 GitHub Release를 발행하지 않습니다. Merge 뒤 실제 `main`의 push CI와 M3가 green임을 확인한 후에만 후속 Release gate를 진행합니다.
