### PR TITLE
fix(street-portrait-artist): patch bump 조정 사유를 기록한다

### DIFF
--- a/skills/street-portrait-artist/CHANGELOG.md
+++ b/skills/street-portrait-artist/CHANGELOG.md
@@ -14,8 +14,8 @@ Notable changes to the `street-portrait-artist` skill package.
   remains surface-dependent and likeness remains non-deterministic.
 - Kept maturity Experimental because the new visual refinements have bounded synthetic evidence rather than a broad
   cross-subject regression set.
-- Released this as a patch rather than a minor version because it corrects outputs that missed the existing 0.1.0
-  relational-caricature and simplified-watercolor contracts; it does not add a mode, input profile, or capability.
+Bump-Adjustment: This patch corrects outputs that missed the existing 0.1.0 relational-caricature and
+simplified-watercolor contracts; it adds no mode, input profile, or capability.
 
 ## [0.1.0] — 2026-08-29
 


### PR DESCRIPTION
## 요약

- M2 preflight가 `0.1.1` patch와 path-default minor의 차이를 설명하는 standalone `Bump-Adjustment:` marker 부재를 fail-closed로 발견했습니다.
- 기존 CHANGELOG의 patch 선택 사유를 validator가 요구하는 독립 marker 형식으로 정렬했습니다.
- package 동작, version, release note와 install surface는 변경하지 않습니다.

## 검증

- M1 repository validator: `0 finding(s)`
- local M2 preflight against commit `6183b7d`: `0 finding(s)`
- local GFM render: green
- `git diff --check`: green

## 경계

- 이 PR은 tag 또는 GitHub Release를 생성·발행하지 않습니다.
- merge 뒤 실제 `origin/main` commit을 대상으로 M2 preflight를 다시 실행합니다.