### PR TITLE
fix(release): v0.1.1 tag target 복구 계약을 보강한다

### DIFF
--- a/.skillstead/initial-release-targets/street-portrait-artist-v0.1.1.json
+++ b/.skillstead/initial-release-targets/street-portrait-artist-v0.1.1.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "skill": "street-portrait-artist",
+  "version": "0.1.1",
+  "target_commit": "311fa92db43256fcbfff103fdabb43b2be1cd9a2",
+  "authorization_id": "owner-20260830-3f7a2c9d8e1b6045",
+  "approved_at": "2026-08-30",
+  "reason": "The reviewed patch release includes a release-gate correction after its version introduction commit."
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Repository-level changes since the last dated entry.
 
 ### Repository
 
+- **Explicit release target recovery.** Generalized the legacy-named target
+  record beyond initial `0.1.0` releases so an owner-authorized immutable
+  binding can recover a reviewed protected tag without moving or recreating it.
+
 - **Street Artist runtime support and visual correction.** Promoted ChatGPT and Codex to Supported after fresh
   published `0.1.0` package discovery, invocation, synthetic reference-image generation, fail-visible size fallback, and
   output delivery. The package now separates caricature construction from ink finish and reduces watercolor scenes to

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -151,15 +151,15 @@ absolute path, 저장소·외부 URL을 포함할 수 없습니다. Validator는
 검사합니다. 그 밖의 민감하거나 식별 가능한 내용은 owner가 정확한 record와 diff를 검토하는 것이
 최종 기준입니다.
 
-### Initial-release target record
+### 명시적 릴리스 target record (기존 경로 유지)
 
-경로: `.skillstead/initial-release-targets/<skill>-v0.1.0.json`
+경로: `.skillstead/initial-release-targets/<skill>-v<version>.json`
 
 ```json
 {
   "schema_version": 1,
   "skill": "<skill>",
-  "version": "0.1.0",
+  "version": "<경로에 결속된 SemVer>",
   "target_commit": "<40자 lowercase commit SHA 전체>",
   "authorization_id": "owner-YYYYMMDD-<16 lowercase hex>",
   "approved_at": "YYYY-MM-DD",
@@ -167,12 +167,14 @@ absolute path, 저장소·외부 URL을 포함할 수 없습니다. Validator는
 }
 ```
 
-새 skill의 검토된 `0.1.0` tag target이 package·catalog atomic introduction commit보다 뒤일 때만
-이 record가 필요합니다. 정확한 기존 target을 선택한 뒤, tag를 만들기 전에 record를 `main`에
-commit합니다. Target은 `main` 위에 있고 path-bound version을 선언해야 합니다. 유효한 record가 한 번
+디렉터리 이름은 호환성을 위해 initial-release 명칭을 유지하지만, 이 record는 검토된 릴리스 target이
+해당 버전을 처음 도입한 `main` first-parent commit보다 뒤인 경우 모든 버전에 사용할 수 있습니다.
+보통 정확한 기존 target을 선택한 뒤 tag를 만들기 전에 record를 `main`에 commit합니다. 이미 공개된
+보호 tag에는 owner가 승인한 예외적 복구 결속으로만 사용하며, tag 자체를 이동하거나 다시 만들지
+않습니다. Target은 `main` 위에 있고 path-bound version을 선언해야 합니다. 유효한 record가 한 번
 나타나면 path와 semantic value는 불변입니다. 수정·삭제·이름 변경, off-main target 또는 version
-불일치는 영구적인 M3 finding입니다. 기존 릴리스와 atomic introduction commit 자체에 tag를 만드는
-initial release는 기존 expected-target 파생 규칙을 그대로 사용합니다.
+불일치는 영구적인 M3 finding입니다. 버전 도입 commit 자체에 tag를 만드는 릴리스는 기존
+expected-target 파생 규칙을 그대로 사용합니다.
 
 ### Retirement record
 
@@ -290,7 +292,7 @@ Bump-Adjustment: <기본 단계를 조정한 이유>
   candidate(`HEAD`)를 검사합니다. `main` push는 `origin/main`을 검사하고, tag event와 periodic
   workflow도 grace 없이 공개된 `origin/main` 상태를 계속 검사합니다. 이 분리로 repair PR은
   candidate 결과를 증명하되, merge 뒤에도 공개 상태가 red라면 그 사실을 숨기지 않습니다.
-* **expected target** — tag를 보지 않고 파생한다: strict target record가 있는 initial `0.1.0` tag는
+* **expected target** — tag를 보지 않고 파생한다: strict explicit target record가 있는 모든 tag는
   record의 exact commit, 해당 record가 없는 일반 tag는 `main` first-parent에서 skill의 선언 버전이
   그 버전으로 바뀐 가장 오래된 commit, baseline tag 4개(record의 exact ref
   membership으로만 판정 — 버전 문자열 비교 아님)는 record가 도입된 commit. 다른 곳을 가리키는

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -174,15 +174,15 @@ validator applies those bounded hygiene patterns; owner review of the exact
 record and diff remains authoritative for other sensitive or identifying
 content.
 
-### Initial-release target record
+### Explicit release target record (legacy path)
 
-Path: `.skillstead/initial-release-targets/<skill>-v0.1.0.json`
+Path: `.skillstead/initial-release-targets/<skill>-v<version>.json`
 
 ```json
 {
   "schema_version": 1,
   "skill": "<skill>",
-  "version": "0.1.0",
+  "version": "<path-bound SemVer>",
   "target_commit": "<full 40-character lowercase commit SHA>",
   "authorization_id": "owner-YYYYMMDD-<16 lowercase hex>",
   "approved_at": "YYYY-MM-DD",
@@ -190,14 +190,17 @@ Path: `.skillstead/initial-release-targets/<skill>-v0.1.0.json`
 }
 ```
 
-The record is required only when a new skill's reviewed `0.1.0` tag target is
-later than its atomic package-and-catalog introduction commit. Commit it to
-`main` after selecting the exact already-existing target and before creating
-the tag. The target must be on `main` and declare the path-bound version. Once
-a valid record appears, its path and semantic value are immutable; mutation,
-deletion, rename, an off-main target, or a mismatched version is a durable M3
-finding. Existing releases and initial releases tagged at their atomic
-introduction commit keep the legacy expected-target derivation unchanged.
+The directory retains its initial-release name for compatibility, but the
+record can bind any reviewed release target that is later than the oldest
+`main` first-parent commit introducing that version. Normally, commit the
+record to `main` after selecting the exact already-existing target and before
+creating the tag. For an already-published protected tag, a recovery record is
+an exceptional owner-authorized binding; do not move or recreate the tag. The
+target must be on `main` and declare the path-bound version. Once a valid
+record appears, its path and semantic value are immutable; mutation, deletion,
+rename, an off-main target, or a mismatched version is a durable M3 finding.
+Releases tagged at their version-introduction commit keep the default
+expected-target derivation unchanged.
 
 ### Retirement record
 
@@ -338,9 +341,9 @@ For every `<name>/vX.Y.Z` tag, on every run:
   keep checking the published `origin/main` state without grace. This split
   lets a repair PR prove its candidate result without hiding a red published
   state after merge.
-* **Expected target** — derived without looking at the tag: for an initial
-  `0.1.0` tag with a strict target record, the record's exact commit; for an
-  ordinary tag without such a record, the oldest `main` first-parent commit
+* **Expected target** — derived without looking at the tag: for any tag with a
+  strict explicit target record, the record's exact commit; for an ordinary
+  tag without such a record, the oldest `main` first-parent commit
   where the skill's declared version changed to the tag's version; for the
   four baseline tags (exact ref membership in the cutover record, never
   version-string matching), the commit that introduced the record. A tag

--- a/tests/test_evidence_records.py
+++ b/tests/test_evidence_records.py
@@ -139,6 +139,11 @@ class InitialReleaseTargetRecordParsing(unittest.TestCase):
             initial_target(), "alpha-skill", "0.1.0")
         self.assertEqual(record.target_commit, "a" * 40)
 
+    def test_valid_later_release_record(self) -> None:
+        record = parse_initial_release_target_record(
+            initial_target(version="0.1.1"), "alpha-skill", "0.1.1")
+        self.assertEqual(record.version, "0.1.1")
+
     def test_wrong_version_target_and_private_reason_rejected(self) -> None:
         for value in (
                 initial_target(version="0.2.0"),

--- a/tests/test_tag_check.py
+++ b/tests/test_tag_check.py
@@ -78,20 +78,26 @@ def _initial_gamma_with_amendment(repo: Path) -> tuple[str, str]:
     return introduction, target
 
 
-def _write_initial_target_record(repo: Path, target: str) -> Path:
+def _write_release_target_record(
+        repo: Path, skill: str, version: str, target: str) -> Path:
     path = (repo / ".skillstead/initial-release-targets/"
-            "gamma-skill-v0.1.0.json")
+            f"{skill}-v{version}.json")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps({
         "schema_version": 1,
-        "skill": "gamma-skill",
-        "version": "0.1.0",
+        "skill": skill,
+        "version": version,
         "target_commit": target,
         "authorization_id": "owner-20260830-0123456789abcdef",
         "approved_at": "2026-08-30",
-        "reason": "The reviewed amendments are bound to this initial release target.",
+        "reason": "The reviewed amendments are bound to this release target.",
     }), encoding="utf-8")
     return path
+
+
+def _write_initial_target_record(repo: Path, target: str) -> Path:
+    return _write_release_target_record(
+        repo, "gamma-skill", "0.1.0", target)
 
 
 def _retire_beta(repo: Path) -> str:
@@ -172,6 +178,22 @@ class TagCheckFixtures(unittest.TestCase):
         path.unlink()
         commit_all(self.repo, "delete gamma target record")
         self.assertIn("INITIAL-RELEASE-TARGET-HISTORY", self.checks())
+
+    def test_later_release_binding_is_green_and_repoint_safe(self) -> None:
+        introduction = _release_alpha(self.repo, "1.3.0", "1.2.3")
+        skill_md = self.repo / "skills/alpha-skill/SKILL.md"
+        skill_md.write_text(
+            skill_md.read_text(encoding="utf-8")
+            + "\nReviewed release amendment.\n", encoding="utf-8")
+        target = commit_all(self.repo, "amend alpha before tag finalization")
+        _git(self.repo, "tag", "-f", "alpha-skill/v1.3.0", target)
+        _write_release_target_record(
+            self.repo, "alpha-skill", "1.3.0", target)
+        commit_all(self.repo, "bind reviewed alpha target")
+        self.assertEqual(run_tag_checks(self.repo), [])
+
+        _git(self.repo, "tag", "-f", "alpha-skill/v1.3.0", introduction)
+        self.assertIn("I-3-c", self.checks())
 
     # E7-ⓕ: multi-skill release tag의 부분 삭제 → I-5
     def test_e7f_partial_deletion_of_multi_skill_release(self) -> None:

--- a/tools/skillstead_validate/evidence_records.py
+++ b/tools/skillstead_validate/evidence_records.py
@@ -213,9 +213,10 @@ def parse_initial_release_target_record(
     authorization_id, approved_at = _require_authorization(raw)
 
     version = raw["version"]
-    if version != "0.1.0" or version != expected_version:
-        raise RecordError(
-            "version must be the path-bound initial release 0.1.0")
+    if not isinstance(version, str) \
+            or _VERSION_RE.fullmatch(version) is None \
+            or version != expected_version:
+        raise RecordError("version must be the path-bound semantic version")
     target_commit = raw["target_commit"]
     if not isinstance(target_commit, str) \
             or not re.fullmatch(r"[0-9a-f]{40}", target_commit):

--- a/tools/skillstead_validate/tag_check.py
+++ b/tools/skillstead_validate/tag_check.py
@@ -6,8 +6,8 @@ creation-time checks guarantee nothing durable. Checks:
 * I-2  — the peeled target declares exactly the tag's version.
 * I-8  — the peeled target is a commit on ``main``.
 * I-3-ⓒ — durable relation: the expected target is derived *without looking
-  at the tag*. A recorded initial release uses its exact immutable target;
-  other general tags use the oldest ``main`` first-parent commit where the
+  at the tag*. A recorded release uses its exact immutable target; other
+  general tags use the oldest ``main`` first-parent commit where the
   skill's declared version changed to the tag's version. Baseline tags (exact
   ref membership in the cutover record's ``baseline_tags``): the first-parent
   commit where the record with the current ``attempt`` was introduced.
@@ -247,11 +247,12 @@ def _retirement_history_findings(
 def _initial_release_target_history(
         repo: Path, history: _History
 ) -> tuple[dict[tuple[str, str], InitialReleaseTargetRecord], list[Finding]]:
-    """Read immutable initial-target bindings from first-parent history.
+    """Read immutable explicit target bindings from first-parent history.
 
     A current-tree-only lookup would let a record be deleted and the tag be
     repointed to the legacy introduction commit. Once a valid binding appears,
-    its path and semantic value therefore remain durable.
+    its path and semantic value therefore remain durable. The directory keeps
+    its historical initial-release name for repository compatibility.
     """
     findings: list[Finding] = []
     known: dict[tuple[str, str], InitialReleaseTargetRecord] = {}
@@ -428,7 +429,7 @@ def run_tag_checks(
             if expected is None:
                 findings.append(Finding("I-3-c", name, f"no main first-parent commit introduces version {version} for {skill} (fail-closed)"))
             elif target != expected:
-                source = "initial-release target record" if binding else "version introduction"
+                source = "explicit release target record" if binding else "version introduction"
                 findings.append(Finding("I-3-c", name, f"target {target[:12]} != expected {expected[:12]} from {source} (repoint suspected)"))
 
     # I-5: existence only — target correctness is I-3-ⓒ's job, and merging


### PR DESCRIPTION
## 요약

- 공개된 `street-portrait-artist/v0.1.1` tag를 이동하거나 다시 만들지 않고, 승인된 final release commit `311fa92`에 결속하는 exact target record를 추가합니다.
- legacy-named target record 계약을 path-bound SemVer 전체로 일반화해 후속 릴리스의 검토된 target도 fail-closed 방식으로 고정합니다.
- 영문·한글 검증 문서와 회귀 테스트, `[Unreleased]` 기록을 함께 갱신합니다.

## 원인과 복구 경계

M2는 release-gate 보정 뒤의 최종 patch target을 허용했지만 M3는 version introduction commit만 기대했습니다. 기존 record parser가 `0.1.0`만 허용해 두 단계의 target derivation이 불일치했습니다.

공개 tag는 보호 규칙 아래 그대로 유지합니다. 이 PR은 owner 승인 record를 통해 validator의 기대 target을 명시적으로 결속하며, record mutation·deletion·tag repoint는 계속 fail-closed로 차단합니다.

## 검증

- `skillstead_validate repo`: `0 finding(s)`
- 관련 회귀 테스트: `94 tests`, `OK`
- `skillstead_validate tags --main-ref HEAD`: `0 finding(s)`
- `git diff --check`: 통과
- 한글 검증 문서 GFM rendering: code 영역 밖 literal `**` 없음

## 릴리스 상태

GitHub Release는 아직 만들지 않았습니다. PR merge와 published `main` M3 확인 이후 별도 release 단계로 진행합니다.