### PR TITLE
docs: 설치 가이드를 스킬별 빠른 경로로 개편한다

### DIFF
--- a/docs/INSTALL.ko.md
+++ b/docs/INSTALL.ko.md
@@ -1,15 +1,34 @@
+<a id="top"></a>
+
 # Skillstead 스킬 설치하기
 
 *[English (canonical)](./INSTALL.md) · 한국어*
 
-Skillstead의 각 스킬은 폴더 하나로 설치할 수 있는 독립 패키지입니다. 검토된 Git 참조를 복제한 뒤
-스킬 폴더 전체를 복사하며, 원격 설치 스크립트는 실행하지 않습니다.
+Skillstead의 각 스킬은 폴더 하나로 설치하는 독립 패키지입니다. 가장 빠른 방법은 원하는 스킬 섹션으로
+이동해 현재 고정 버전의 설치 요청을 지원 실행 환경에 붙여 넣는 것입니다. 직접 복사해야 할 때를 위한
+파일 시스템 명령도 문서 뒤쪽에 유지합니다.
 
-## 스킬과 버전 선택하기
+## 스킬 바로가기
 
-스킬마다 릴리스 태그가 다릅니다. 같은 표의 태그와 폴더를 한 쌍으로 사용하세요.
+- [`svg-infographic`](#svg-infographic) — 편집 가능한 기술 SVG와 검증된 PNG
+- [`docs-claim-check`](#docs-claim-check) — 근거 범위가 분명한 공개 주장 검토
+- [`github-release-guide`](#github-release-guide) — 승인 단계를 지키는 GitHub 릴리스 안내
+- [`writing-quality-editor`](#writing-quality-editor) — 의미를 보존하는 자연스러운 사용자 문서
+- [`street-portrait-artist`](#street-portrait-artist) — Street Caricature와 Romance Watercolor 초상화
 
-| 스킬 폴더 | 현재 고정 태그 | 지원 실행 환경 |
+참고 섹션:
+
+- [파일 시스템에서 직접 설치하기](#파일-시스템에서-직접-설치하기)
+- [실행 환경 지원과 기록된 근거](#실행-환경-지원과-기록된-근거)
+- [최신 개발 상태 평가하기](#최신-개발-상태-평가하기)
+- [업데이트·제거·패키지 무결성](#업데이트제거패키지-무결성)
+
+## 현재 릴리스
+
+스킬마다 릴리스 태그가 다릅니다. 아래 복사·붙여넣기 요청은 릴리스 태그와 전체 스킬 폴더를 하나의
+고정 GitHub 경로로 묶어, 서로 다른 버전이 섞이지 않게 합니다.
+
+| 스킬 | 현재 고정 태그 | 지원 실행 환경 |
 | --- | --- | --- |
 | `svg-infographic` | `svg-infographic/v0.11.0` | Claude Code와 Codex |
 | `docs-claim-check` | `docs-claim-check/v0.9.1` | Claude Code |
@@ -17,90 +36,148 @@ Skillstead의 각 스킬은 폴더 하나로 설치할 수 있는 독립 패키�
 | `writing-quality-editor` | `writing-quality-editor/v0.13.0` | Claude Code와 Codex |
 | `street-portrait-artist` | `street-portrait-artist/v0.1.1` | ChatGPT와 Codex |
 
-아래 명령은 `github-release-guide`를 설치하는 예시입니다. 다른 스킬을 설치하려면
-`github-release-guide/v0.9.0`과 `github-release-guide`를 같은 행에 있는 값으로 함께 바꾸세요.
-폴더 이름만 바꾸면 의도한 릴리스 시점과 다른 패키지를 설치할 수 있습니다.
+기본 요청은 개인 전역 범위에 설치합니다. 파일 시스템에 설치하는 스킬을 현재 저장소 안에서만 쓰려면
+`전역으로`를 `현재 프로젝트에`로 바꾸세요. ChatGPT는 제품 안에서 스킬을 관리하므로 이 문서의 파일
+시스템 설치 범위를 사용하지 않습니다.
 
-## AI에게 맡기기
+---
 
-어떤 명령과 폴더를 골라야 할지 막막하다면, 아래 요청의 빈칸을 바꿔 Claude Code나 Codex에 붙여
-넣으세요.
+<a id="svg-infographic"></a>
+
+## `svg-infographic`
+
+- 현재 릴리스: `svg-infographic/v0.11.0`
+- 지원 실행 환경: Claude Code와 Codex
+- 패키지 안내: [`skills/svg-infographic/README.ko.md`](../skills/svg-infographic/README.ko.md)
+
+Claude Code나 Codex에 다음 한 줄을 붙여 넣으세요.
 
 ```text
-Skillstead의 <스킬>을 <Claude Code 또는 Codex>용으로 <프로젝트 또는 전역> 범위에 설치해 줘.
-docs/INSTALL.ko.md에서 해당 스킬의 현재 고정 태그를 확인하고 스킬 폴더 전체를 복사해 줘.
-원격 설치 스크립트는 실행하지 마. 시스템 변경, 파괴적 정리 또는 인증 정보 작업이 필요하면
-정확한 작업을 먼저 보여 주고 내 승인을 받아 줘.
+다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/svg-infographic/v0.11.0/skills/svg-infographic
 ```
 
-에이전트는 아래에 안내된 고정 버전과 전체 폴더 복사 방식을 따르고, 변경 전에 승인을 받습니다. 이
-요청은 저장소나 시스템 변경을 미리 승인하지 않으며, Skillstead를 원격 설치 프로그램으로 바꾸지도
-않습니다.
+`svg-infographic`을 복사하거나 실행 환경이 발견하는 데는 Node.js가 필요하지 않습니다. Node.js 18 이상은
+자동 원본 검사와 패키지에 포함된 렌더링 절차에만 필요합니다. Node.js를 사용할 수 없으면 문서화된 수동
+원본 검사와 Node 없이 실행하는 Chromium 시각 검토 경로를 유지합니다.
 
-## 전체 예시: macOS/Linux에서 Claude Code 프로젝트에 설치
+[스킬 목록으로 돌아가기](#스킬-바로가기)
 
-아래 예시는 `github-release-guide`를 설치합니다. 대상 저장소의 최상위 디렉터리에서 실행하세요.
+---
 
-```bash
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
-mkdir -p .claude/skills
-cp -R /tmp/skillstead/skills/github-release-guide .claude/skills/
+<a id="docs-claim-check"></a>
+
+## `docs-claim-check`
+
+- 현재 릴리스: `docs-claim-check/v0.9.1`
+- 지원 실행 환경: Claude Code
+- 패키지 안내: [`skills/docs-claim-check/README.ko.md`](../skills/docs-claim-check/README.ko.md)
+
+Claude Code에 다음 한 줄을 붙여 넣으세요.
+
+```text
+다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/docs-claim-check/v0.9.1/skills/docs-claim-check
 ```
 
-다른 스킬을 설치하려면 [스킬과 버전 선택하기](#스킬과-버전-선택하기)에 있는 태그와 폴더를 한 쌍으로
-바꾸세요. 아래에서 실행 환경·설치 범위·운영체제별 명령을 확인할 수 있습니다.
+이 스킬은 아직 Codex 지원을 표시하지 않습니다. 다른 실행 환경에 평가용으로 설치하더라도 그것만으로
+공개 지원 근거가 되지는 않습니다.
 
-파일을 직접 내려받아 설치하는 방식은 아직 지원하지 않습니다. 스킬별 zip 파일을 제공하지 않기
-때문입니다. 현재 릴리스 검사는 zip 파일이 해당 스킬과 태그에 맞는지, checksum이 일치하는지 확인하지
-못하므로, 지금은 검증된 태그를 지정해 `git clone`하는 방법으로 설치해 주세요.
+[스킬 목록으로 돌아가기](#스킬-바로가기)
 
-## 실행 환경 지원과 기록된 근거
+---
 
-실행 환경 지원은 스킬별로 검증합니다.
+<a id="github-release-guide"></a>
 
-| 스킬 | Claude Code | Codex | 참고 |
-| --- | --- | --- | --- |
-| `svg-infographic` | Supported | Supported | 고정된 fresh-context 요구 사항을 Claude Code와 macOS Codex CLI에서 통과했고, Windows 11 ARM64 VM에서 시작한 새 Codex App 작업도 통과했습니다. 모든 Windows 장치와 파일 시스템을 지원한다는 의미는 아니며 Linux 렌더링은 아직 검증하지 않았습니다 |
-| `docs-claim-check` | Supported | Not yet claimed | Claude Code Fable과 Sonnet에서 동작 검증 자료를 통과했습니다 |
-| `github-release-guide` | Supported | Supported | 보호 설정 검증 자료를 포함한 핵심 행동 일치 검증, 일회용 first-public과 Guided tag-ruleset 실제 E2E, 고정 `v0.5.0`/`v0.6.0` 프로젝트 설치·발견, 릴리스 주장 검토를 통과했습니다 |
-| `writing-quality-editor` | Supported | Supported | 4개 mode, 21개 시나리오의 실행 환경 간 동작 검증, 저장소 문서 적용, 고정 `v0.7.0` 프로젝트 설치, 패키지 일치, 발견과 최종 주장 검토를 통과했습니다 |
-| `street-portrait-artist` | Not applicable | Supported | Codex에서 공개된 `0.1.0` package를 새로 설치한 뒤 discovery·invocation·합성 reference-image 생성·fail-visible size fallback·output delivery를 확인했습니다. ChatGPT 지원은 아래에서 별도로 설명합니다 |
+## `github-release-guide`
 
-`street-portrait-artist`는 같은 근거 축에서 ChatGPT도 Supported입니다. ChatGPT의 skill interface는 제품에서 관리하므로
-이 문서의 filesystem 설치 경로 표에는 별도 runtime 열로 넣지 않았습니다. 두 제품에서 관찰한 이미지는 모두
-`1122 x 1402 px`였으며, exact `1080 x 1350 px` export를 사용할 수 없다는 사실을 숨기지 않고 실제 치수와 함께
-알렸습니다.
+- 현재 릴리스: `github-release-guide/v0.9.0`
+- 지원 실행 환경: Claude Code와 Codex
+- 패키지 안내: [`skills/github-release-guide/README.ko.md`](../skills/github-release-guide/README.ko.md)
 
-위 근거는 각 지원 표시를 확정할 때 기록한 검사 내용을 설명합니다. 과거 근거에 적힌 시나리오 수는
-현재 검증 자료의 개수와 다를 수 있습니다. 일반적인 용도에서는 사용하는 실행 환경 열이
-`Supported`인 스킬만 복사하세요. 해당 열이 `Not yet claimed`이면 격리된 테스트 저장소에 평가용으로만
-복사할 수 있으며, 이것만으로 공개 지원 표시가 성립하지 않습니다.
+Claude Code나 Codex에 다음 한 줄을 붙여 넣으세요.
 
-## 스킬별 요구 사항
+```text
+다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/github-release-guide/v0.9.0/skills/github-release-guide
+```
 
-### `svg-infographic`
+설치는 재사용 가능한 안내만 추가합니다. 저장소 공개 전환, tag, GitHub Release, 설정 변경, 파괴적 정리,
+인증 정보 작업을 승인하지 않습니다.
 
-`svg-infographic`을 복사하거나 실행 환경이 스킬을 발견하는 데는 Node.js가 필요하지 않습니다.
-Node.js 18 이상은 자동 원본 검사와 패키지에 포함된 렌더링 절차에만 필요합니다. Node.js가 없으면
-스킬은 감지한 패키지 관리자로 설치하기 전에 사용자에게 확인합니다. 사용자가 거부해도 수동 원본 검사와
-Node 없이 실행하는 Chromium PNG 시각 검토 경로는 사용할 수 있으며, 자동 검사만 사용할 수 없습니다.
+[스킬 목록으로 돌아가기](#스킬-바로가기)
 
-## 실행 환경별 설치 경로
+---
 
-| 실행 환경 | 전역 | 프로젝트 |
+<a id="writing-quality-editor"></a>
+
+## `writing-quality-editor`
+
+- 현재 릴리스: `writing-quality-editor/v0.13.0`
+- 지원 실행 환경: Claude Code와 Codex
+- 패키지 안내: [`skills/writing-quality-editor/README.ko.md`](../skills/writing-quality-editor/README.ko.md)
+
+Claude Code나 Codex에 다음 한 줄을 붙여 넣으세요.
+
+```text
+다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/writing-quality-editor/v0.13.0/skills/writing-quality-editor
+```
+
+패키지에는 영문·한글 작성과 검토에 필요한 참고 문서가 함께 들어 있습니다. `SKILL.md`만 따로 복사하지
+말고 폴더 전체를 설치하세요.
+
+[스킬 목록으로 돌아가기](#스킬-바로가기)
+
+---
+
+<a id="street-portrait-artist"></a>
+
+## `street-portrait-artist`
+
+- 현재 릴리스: `street-portrait-artist/v0.1.1`
+- 지원 실행 환경: ChatGPT와 Codex
+- 패키지 안내: [`skills/street-portrait-artist/README.ko.md`](../skills/street-portrait-artist/README.ko.md)
+
+ChatGPT에 다음 한 줄을 붙여 넣으세요.
+
+```text
+다음 고정 GitHub 폴더의 street-portrait-artist 스킬을 설치해 줘: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.1/skills/street-portrait-artist
+```
+
+Codex에 다음 한 줄을 붙여 넣으세요.
+
+```text
+다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.1/skills/street-portrait-artist
+```
+
+ChatGPT가 설치 확인을 요청할 수 있습니다. 현재 대화에서 이전에 캐시한 버전이 계속 발견되면 설치 후
+새 대화를 시작하세요. ChatGPT의 사용 가능 여부와 workspace 권한은 제품에서 관리합니다.
+
+[스킬 목록으로 돌아가기](#스킬-바로가기)
+
+---
+
+## 파일 시스템에서 직접 설치하기
+
+직접 명령을 실행하고 싶거나 agent가 복사를 완료할 수 없을 때 사용하는 참고 절차입니다. 정확한 검토
+태그를 복제한 뒤 스킬 폴더 전체를 복사하며, 원격 설치 스크립트는 실행하지 않습니다.
+
+### 실행 환경별 경로
+
+| 실행 환경 | 개인 전역 경로 | 프로젝트 경로 |
 | --- | --- | --- |
 | Claude Code | `~/.claude/skills/<name>/` | `<repo>/.claude/skills/<name>/` |
-| Codex | `~/.agents/skills/<name>/` | `<repo>/.agents/skills/<name>/` |
+| Codex | `~/.codex/skills/<name>/` | `<repo>/.agents/skills/<name>/` |
 
-Windows에서 `~`는 `%USERPROFILE%`을 뜻합니다. 새로 복사한 스킬이 발견되지 않으면 실행 환경을
-재시작하세요.
+Windows에서 `~`는 `%USERPROFILE%`을 뜻합니다. 새로 복사한 스킬이 발견되지 않으면 새 세션을 시작하세요.
 
-아래 명령도 `github-release-guide`를 사용합니다. 다른 지원 스킬을 설치하려면 릴리스 태그와 폴더를
-함께 바꾸세요.
+기본 설치 경로는 각 스킬 섹션의 복사·붙여넣기 요청입니다. 정확한 shell 명령이 필요하면 아래의
+`github-release-guide` 예시를 펼치세요. 실행 환경과 범위에 맞는 예시 하나만 깨끗한 임시 경로에서
+실행하세요. 다른 스킬은 위에 표시된 태그와 폴더를 한 쌍으로 바꿉니다.
 
-## 전역 설치
+<details>
+<summary>macOS/Linux와 Windows 명령 모두 보기</summary>
 
-### Claude Code — macOS/Linux
+### 개인 전역 설치
+
+#### Claude Code — macOS/Linux
 
 ```bash
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
@@ -108,15 +185,15 @@ mkdir -p ~/.claude/skills
 cp -R /tmp/skillstead/skills/github-release-guide ~/.claude/skills/
 ```
 
-### Codex — macOS/Linux
+#### Codex — macOS/Linux
 
 ```bash
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
-mkdir -p ~/.agents/skills
-cp -R /tmp/skillstead/skills/github-release-guide ~/.agents/skills/
+mkdir -p ~/.codex/skills
+cp -R /tmp/skillstead/skills/github-release-guide ~/.codex/skills/
 ```
 
-### Claude Code — Windows PowerShell
+#### Claude Code — Windows PowerShell
 
 ```powershell
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
@@ -124,20 +201,19 @@ New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$env:USERPROFILE\.claude\skills\"
 ```
 
-### Codex — Windows PowerShell
+#### Codex — Windows PowerShell
 
 ```powershell
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
-New-Item -ItemType Directory -Force "$env:USERPROFILE\.agents\skills" | Out-Null
-Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$env:USERPROFILE\.agents\skills\"
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\skills" | Out-Null
+Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$env:USERPROFILE\.codex\skills\"
 ```
 
-## 프로젝트 설치
+### 프로젝트 설치
 
-대상 저장소의 최상위 디렉터리에서 실행하세요. 팀원이 저장소를 복제할 때도 이 폴더를 받아야 한다면
-복사한 폴더를 커밋하세요.
+대상 저장소의 최상위 디렉터리에서 실행하세요.
 
-### Claude Code — macOS/Linux
+#### Claude Code — macOS/Linux
 
 ```bash
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
@@ -145,7 +221,7 @@ mkdir -p .claude/skills
 cp -R /tmp/skillstead/skills/github-release-guide .claude/skills/
 ```
 
-### Codex — macOS/Linux
+#### Codex — macOS/Linux
 
 ```bash
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
@@ -153,9 +229,15 @@ mkdir -p .agents/skills
 cp -R /tmp/skillstead/skills/github-release-guide .agents/skills/
 ```
 
-### Windows PowerShell
+#### Claude Code — Windows PowerShell
 
-Claude Code는 `.claude\skills`, Codex는 `.agents\skills`를 사용합니다.
+```powershell
+git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
+New-Item -ItemType Directory -Force ".claude\skills" | Out-Null
+Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" ".claude\skills\"
+```
+
+#### Codex — Windows PowerShell
 
 ```powershell
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
@@ -163,73 +245,75 @@ New-Item -ItemType Directory -Force ".agents\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" ".agents\skills\"
 ```
 
-## 평가용으로 최신 개발 상태 사용하기
+</details>
 
-현재 기본 브랜치를 복사하려면 `--branch github-release-guide/v0.9.0`을 빼세요. 평가할 때는 유용하지만
-팀에서 재현할 수 있는 설치 방식은 아닙니다. 팀 설치와 릴리스 근거에는 고정 태그를 권장합니다.
+현재 스킬별 zip 파일은 게시하거나 checksum으로 검증하지 않습니다. 고정 tag를 지정한 clone이 재현 가능한
+직접 설치 경로입니다.
 
-## 패키지 전체 유지하기
+[맨 위로](#top)
 
-폴더 전체를 그대로 유지하세요.
+## 실행 환경 지원과 기록된 근거
 
-```text
-github-release-guide/
-├── CHANGELOG.md
-├── LICENSE.txt
-├── README.md
-├── README.ko.md
-├── SKILL.md
-├── agents/
-│   └── openai.yaml
-└── references/
-    ├── assessment.md
-    ├── first-public.md
-    └── version-release.md
-```
+실행 환경 지원은 스킬별로 검증합니다.
 
-설치된 영문·한국어 README는 작업 흐름을 사용자 관점에서 설명합니다. 저장소에만 있는 검증 자료와
-다이어그램은 Skillstead 저장소의 `examples/github-release-guide/`에 남으며 스킬과 함께 복사되지
-않습니다.
+| 스킬 | Claude Code | Codex | 기타 | 근거 범위 |
+| --- | --- | --- | --- | --- |
+| `svg-infographic` | Supported | Supported | — | 고정 fresh-context 요구 사항을 Claude Code와 macOS Codex CLI에서 통과했고 Windows 11 ARM64 VM의 새 Codex App 작업도 통과했습니다. Linux 렌더링과 모든 Windows 장치·파일 시스템을 지원한다는 의미는 아닙니다 |
+| `docs-claim-check` | Supported | Not yet claimed | — | Claude Code Fable과 Sonnet에서 동작 검증 자료를 통과했습니다 |
+| `github-release-guide` | Supported | Supported | — | 핵심 행동 일치, 일회용 first-public과 Guided tag-ruleset 실제 E2E, 고정 설치·발견, 릴리스 주장 검토를 통과했습니다 |
+| `writing-quality-editor` | Supported | Supported | — | 4개 mode의 실행 환경 간 동작, 저장소 문서 적용, 고정 설치, 패키지 일치, 발견과 주장 종결을 확인했습니다 |
+| `street-portrait-artist` | Not applicable | Supported | ChatGPT: Supported | 공개된 `0.1.0` package의 새 설치·발견·호출·합성 reference-image 생성·fail-visible 크기 fallback·결과 전달로 실행 환경 지원을 확인했으며, 현재 설치 릴리스는 `0.1.1`입니다 |
 
-`writing-quality-editor`에도 같은 전체 폴더 규칙이 적용됩니다. 패키지에는 `CHANGELOG.md`,
-`LICENSE.txt`, `SKILL.md`, 영문·한국어 README, `agents/openai.yaml`, 참고 파일 3개가 들어 있습니다.
-저장소 전용 검증 자료는 `examples/writing-quality-editor/`에 남습니다.
+이전 릴리스에서 기록한 근거가 제한된 실행 능력을 뒷받침할 수 있지만, 해당 릴리스가 현재 설치 대상이라는
+뜻은 아닙니다. 일반적인 용도에서는 사용하는 실행 환경이 `Supported`인 스킬을 선택하세요. `Not yet
+claimed`는 평가용이라는 뜻이며 공개 지원 표시는 아닙니다.
 
-`street-portrait-artist`에도 같은 전체 폴더 규칙이 적용됩니다. 패키지에는 `CHANGELOG.md`, `LICENSE.txt`,
-`SKILL.md`, 영문·한국어 README, `agents/openai.yaml`, 참고 파일 4개가 들어 있습니다. 합성 gallery와 저장소
-전용 behavior fixture는 `examples/street-portrait-artist/`에 남습니다.
+`street-portrait-artist`는 ChatGPT의 제품 관리형 스킬 interface를 사용하므로 위 파일 시스템 경로에 포함하지
+않습니다. ChatGPT와 Codex에서 관찰한 결과는 `1122 x 1402 px`였고 exact `1080 x 1350 px` export를 사용할
+수 없다는 사실을 숨기지 않고 보고했습니다. 이 근거는 실행 환경 지원과 정직한 fallback을 보여 주지만,
+결정론적 얼굴 유사성이나 폭넓은 시각 품질 성숙도를 보장하지 않습니다.
 
-## 삭제된 파일을 남기지 않고 업데이트하기
+[맨 위로](#top)
 
-`cp -R`을 사용하면 원본에서 삭제된 파일이 설치 위치에는 남을 수 있습니다. 빠진 파일 없이 정확히
-업데이트하려면
-다음 순서로 진행하세요.
+## 최신 개발 상태 평가하기
 
-1. 원하는 태그를 새 임시 디렉터리에 복제합니다.
-2. 설치된 대상 스킬 폴더만 삭제합니다.
+평가할 때만 고정 tag 대신 기본 branch를 사용할 수 있습니다. 이 방식은 팀이 재현할 수 있는 설치가 아니며
+위의 현재 릴리스 링크를 대체하지 않습니다. 일반 사용, 팀 설치, 릴리스 근거에는 고정 tag를 권장합니다.
+
+[맨 위로](#top)
+
+## 업데이트·제거·패키지 무결성
+
+### 패키지 전체 유지하기
+
+`skills/<name>/` 폴더 전체를 복사하세요. 패키지에는 `SKILL.md`, 영문·한글 README, changelog, license,
+실행 환경 metadata, script, 필수 참고 문서가 들어갈 수 있습니다. `examples/` 아래의 저장소 전용 fixture와
+gallery asset은 해당 스킬 안내에서 별도로 명시하지 않는 한 설치 패키지에 포함되지 않습니다.
+
+### 오래된 파일을 남기지 않고 업데이트하기
+
+`cp -R`은 원본에서 삭제된 파일을 설치 위치에 남길 수 있습니다. 정확히 업데이트하려면 다음 순서를 따르세요.
+
+1. 원하는 tag를 새 임시 디렉터리에 복제합니다.
+2. 설치된 대상 스킬 폴더만 제거합니다.
 3. 새 스킬 폴더 전체를 복사합니다.
-4. 필요하면 실행 환경을 재시작하고 스킬이 발견되는지 확인합니다.
+4. 새 실행 환경 세션을 시작하고 발견된 버전을 확인합니다.
 5. 프로젝트 설치라면 변경 내용을 검토하고 커밋합니다.
 
-관련 없는 스킬이 들어 있을 수 있는 상위 `skills` 디렉터리는 삭제하지 마세요.
+관련 없는 스킬이 들어 있을 수 있는 상위 skills 디렉터리는 제거하지 마세요.
 
-## 제거
+### 제거
 
-설치된 스킬 폴더만 삭제하세요.
+설치된 대상 폴더만 제거하세요.
 
-```bash
-rm -rf ~/.claude/skills/github-release-guide
-rm -rf ~/.agents/skills/github-release-guide
-rm -rf .claude/skills/github-release-guide
-rm -rf .agents/skills/github-release-guide
+```text
+Claude Code 개인: ~/.claude/skills/<name>
+Claude Code 프로젝트: <repo>/.claude/skills/<name>
+Codex 개인: ~/.codex/skills/<name>
+Codex 프로젝트: <repo>/.agents/skills/<name>
 ```
 
-```powershell
-Remove-Item -Recurse -Force "$env:USERPROFILE\.claude\skills\github-release-guide"
-Remove-Item -Recurse -Force "$env:USERPROFILE\.agents\skills\github-release-guide"
-Remove-Item -Recurse -Force ".claude\skills\github-release-guide"
-Remove-Item -Recurse -Force ".agents\skills\github-release-guide"
-```
+제거하면 로컬 실행 환경의 발견 상태만 바뀝니다. 이전에 승인하고 수행한 저장소나 GitHub 변경은 되돌리지
+않습니다.
 
-제거하면 로컬 실행 환경에서 해당 스킬을 더 이상 발견하지 못합니다. 이전에 승인하고 수행한 GitHub
-릴리스나 저장소 변경은 되돌리지 않습니다.
+[맨 위로](#top)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,15 +1,34 @@
+<a id="top"></a>
+
 # Install a Skillstead skill
 
 *English (canonical) · [한국어](./INSTALL.ko.md)*
 
-Skillstead packages each skill as a portable folder. Installation means cloning a reviewed ref and copying one
-complete folder; no remote install script is executed.
+Skillstead packages each skill as one portable folder. The quickest path is to open the section for the skill you
+want and paste its pinned install request into a supported runtime. Manual filesystem commands remain available
+later in this guide.
 
-## Choose a skill and version
+## Jump to a skill
 
-Each skill has its own release tag. Choose the matching tag and folder as a pair:
+- [`svg-infographic`](#svg-infographic) — editable technical SVG and verified PNG
+- [`docs-claim-check`](#docs-claim-check) — evidence-bounded public claim review
+- [`github-release-guide`](#github-release-guide) — approval-gated GitHub release guidance
+- [`writing-quality-editor`](#writing-quality-editor) — natural, meaning-preserving user-facing writing
+- [`street-portrait-artist`](#street-portrait-artist) — Street Caricature and Romance Watercolor portraits
 
-| Skill folder | Current pinned tag | Runtime support |
+Reference sections:
+
+- [Manual filesystem installation](#manual-filesystem-installation)
+- [Runtime support and recorded evidence](#runtime-support-and-recorded-evidence)
+- [Evaluate the latest development state](#evaluate-the-latest-development-state)
+- [Update, uninstall, and package integrity](#update-uninstall-and-package-integrity)
+
+## Current releases
+
+Each skill has its own release tag. The copy-ready requests below pin both the release tag and the complete skill
+folder so they cannot drift apart.
+
+| Skill | Current pinned tag | Supported runtime |
 | --- | --- | --- |
 | `svg-infographic` | `svg-infographic/v0.11.0` | Claude Code and Codex |
 | `docs-claim-check` | `docs-claim-check/v0.9.1` | Claude Code |
@@ -17,88 +36,149 @@ Each skill has its own release tag. Choose the matching tag and folder as a pair
 | `writing-quality-editor` | `writing-quality-editor/v0.13.0` | Claude Code and Codex |
 | `street-portrait-artist` | `street-portrait-artist/v0.1.1` | ChatGPT and Codex |
 
-The commands below use `github-release-guide` as a worked example. To install another skill, replace both
-`github-release-guide/v0.9.0` and `github-release-guide` with the matching values from the same row. Replacing
-only the folder can install a package from the wrong release point.
+The default request installs a personal/global skill. To keep a filesystem-installed skill inside the current
+repository, replace `globally` with `in the current project`. ChatGPT manages its skill library in the product and
+does not use the filesystem scopes in this guide.
 
-## Ask Your AI
+---
 
-Not sure which commands or folders you need? Replace the placeholders and paste this prompt into Claude Code or
-Codex:
+<a id="svg-infographic"></a>
+
+## `svg-infographic`
+
+- Current release: `svg-infographic/v0.11.0`
+- Supported runtime: Claude Code and Codex
+- Package guide: [`skills/svg-infographic/README.md`](../skills/svg-infographic/README.md)
+
+Paste this into Claude Code or Codex:
 
 ```text
-Install <skill> from Skillstead for <Claude Code or Codex> at <project or global> scope. Use the matching
-current pinned tag in docs/INSTALL.md, copy the complete skill folder, and do not run a remote install script.
-Before any system change, destructive cleanup, or credential action, show the exact action and ask for my
-approval.
+Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/svg-infographic/v0.11.0/skills/svg-infographic
 ```
 
-The agent follows the same pinned version, complete-folder copy, and approval boundaries shown below. This prompt
-does not approve repository or system changes, and it does not turn Skillstead into a remote installer.
+Copying or discovering `svg-infographic` does not require Node.js. Node.js 18+ is needed only for its automated
+source lint and bundled render workflow. If Node.js is unavailable, the skill preserves its documented manual
+source-check and Node-free Chromium visual-QA fallback.
 
-## Worked example: Claude Code project install on macOS/Linux
+[Back to the skill list](#jump-to-a-skill)
 
-This example installs `github-release-guide`. Run it from the target repository root:
+---
 
-```bash
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
-mkdir -p .claude/skills
-cp -R /tmp/skillstead/skills/github-release-guide .claude/skills/
+<a id="docs-claim-check"></a>
+
+## `docs-claim-check`
+
+- Current release: `docs-claim-check/v0.9.1`
+- Supported runtime: Claude Code
+- Package guide: [`skills/docs-claim-check/README.md`](../skills/docs-claim-check/README.md)
+
+Paste this into Claude Code:
+
+```text
+Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/docs-claim-check/v0.9.1/skills/docs-claim-check
 ```
 
-To install a different skill, use the tag-and-folder pair in
-[Choose a skill and version](#choose-a-skill-and-version). The complete runtime, scope, and operating-system
-matrix follows.
+Codex runtime support is not yet claimed for this skill. Installing it experimentally in another runtime does not
+establish a public support claim.
 
-Prefer a download instead of git? Per-skill zip files are not available yet. The release checks do not currently
-verify a zip file's identity and checksum, so the pinned-tag clone above is still the reliable way to install.
+[Back to the skill list](#jump-to-a-skill)
 
-## Runtime support and recorded evidence
+---
 
-Runtime support is verified per skill:
+<a id="github-release-guide"></a>
 
-| Skill | Claude Code | Codex | Notes |
-| --- | --- | --- | --- |
-| `svg-infographic` | Supported | Supported | Frozen fresh-context briefs passed on Claude Code and macOS Codex CLI; a fresh Codex App task also passed in a Windows 11 ARM64 VM. This is not a claim for every Windows machine/filesystem; Linux rendering remains unverified |
-| `docs-claim-check` | Supported | Not yet claimed | Behavioral fixtures passed with Claude Code Fable and Sonnet |
-| `github-release-guide` | Supported | Supported | Clean material parity (incl. protection fixtures), disposable first-public and Guided tag-ruleset live E2E, pinned `v0.5.0`/`v0.6.0` project installation/discovery, and release claim audits passed |
-| `writing-quality-editor` | Supported | Supported | Four-mode, 21-scenario cross-runtime behavior, repository dogfood, and pinned `v0.7.0` project installation, package-equality, discovery, and final claim closeout passed |
-| `street-portrait-artist` | Not applicable | Supported | Fresh published `0.1.0` package installation, discovery, invocation, synthetic reference-image generation, fail-visible size fallback, and output delivery passed in Codex; ChatGPT support is recorded separately below |
+## `github-release-guide`
 
-`street-portrait-artist` is also Supported in ChatGPT within the same evidence axes. ChatGPT is not listed as a general
-installation-path column because its skill interface is product-managed rather than one of the filesystem paths in
-this guide. In both products the observed image was `1122 x 1402 px`; exact `1080 x 1350 px` export was unavailable and
-the limitation was reported rather than hidden.
+- Current release: `github-release-guide/v0.9.0`
+- Supported runtime: Claude Code and Codex
+- Package guide: [`skills/github-release-guide/README.md`](../skills/github-release-guide/README.md)
 
-The evidence notes above describe the checks recorded when each support label was established. Scenario counts
-in historical evidence can differ from the current fixture inventory. For normal use, copy a skill only when its
-column for your runtime says `Supported`. If that column says `Not yet claimed`, copy the skill only into an
-isolated test repository for evaluation; this does not establish a public support claim.
+Paste this into Claude Code or Codex:
 
-## Skill-specific requirements
+```text
+Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/github-release-guide/v0.9.0/skills/github-release-guide
+```
 
-### `svg-infographic`
+Installation adds the reusable guidance only. It does not approve a repository visibility change, tag, GitHub
+Release, settings change, destructive cleanup, or credential action.
 
-Copying or discovering `svg-infographic` does not install or require Node.js. Node.js 18+ is needed only for its
-automated source-lint and bundled render workflow. If it is missing, the skill asks before using the detected
-package manager to install it. If the user declines, the skill preserves its earlier manual source-check and
-Node-free Chromium PNG/visual-QA path; only the automated lint is unavailable.
+[Back to the skill list](#jump-to-a-skill)
 
-## Runtime paths
+---
 
-| Runtime | Global | Project |
+<a id="writing-quality-editor"></a>
+
+## `writing-quality-editor`
+
+- Current release: `writing-quality-editor/v0.13.0`
+- Supported runtime: Claude Code and Codex
+- Package guide: [`skills/writing-quality-editor/README.md`](../skills/writing-quality-editor/README.md)
+
+Paste this into Claude Code or Codex:
+
+```text
+Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/writing-quality-editor/v0.13.0/skills/writing-quality-editor
+```
+
+The package includes the complete English/Korean authoring and review references. Install the whole folder rather
+than copying only `SKILL.md`.
+
+[Back to the skill list](#jump-to-a-skill)
+
+---
+
+<a id="street-portrait-artist"></a>
+
+## `street-portrait-artist`
+
+- Current release: `street-portrait-artist/v0.1.1`
+- Supported runtime: ChatGPT and Codex
+- Package guide: [`skills/street-portrait-artist/README.md`](../skills/street-portrait-artist/README.md)
+
+Paste this into ChatGPT:
+
+```text
+Install the street-portrait-artist skill from this pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.1/skills/street-portrait-artist
+```
+
+Paste this into Codex:
+
+```text
+Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.1/skills/street-portrait-artist
+```
+
+ChatGPT may ask you to confirm the installation. If the current conversation still discovers an older cached
+version, start a new conversation after installation. ChatGPT availability and workspace permissions are managed
+by the product.
+
+[Back to the skill list](#jump-to-a-skill)
+
+---
+
+## Manual filesystem installation
+
+Use this section when you prefer direct commands or when an agent cannot complete the copy itself. Installation
+means cloning the exact reviewed tag and copying the complete skill folder. No remote install script is executed.
+
+### Runtime paths
+
+| Runtime | Personal/global path | Project path |
 | --- | --- | --- |
 | Claude Code | `~/.claude/skills/<name>/` | `<repo>/.claude/skills/<name>/` |
-| Codex | `~/.agents/skills/<name>/` | `<repo>/.agents/skills/<name>/` |
+| Codex | `~/.codex/skills/<name>/` | `<repo>/.agents/skills/<name>/` |
 
-On Windows, `~` means `%USERPROFILE%`. Restart the runtime if a newly copied skill is not discovered.
+On Windows, `~` means `%USERPROFILE%`. If the runtime does not discover a newly copied skill, start a new session.
 
-The commands below continue to use the `github-release-guide` example. When choosing another supported skill,
-replace the release tag and folder together.
+The primary path is the copy-ready request in each skill section. If you need exact shell commands, expand the
+worked `github-release-guide` examples below. Run only the example matching your runtime and scope, from a clean
+temporary path. For another skill, replace the tag and folder together with the pair shown above.
 
-## Global install
+<details>
+<summary>Show exact macOS/Linux and Windows commands</summary>
 
-### Claude Code — macOS/Linux
+### Personal/global install
+
+#### Claude Code — macOS/Linux
 
 ```bash
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
@@ -106,15 +186,15 @@ mkdir -p ~/.claude/skills
 cp -R /tmp/skillstead/skills/github-release-guide ~/.claude/skills/
 ```
 
-### Codex — macOS/Linux
+#### Codex — macOS/Linux
 
 ```bash
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
-mkdir -p ~/.agents/skills
-cp -R /tmp/skillstead/skills/github-release-guide ~/.agents/skills/
+mkdir -p ~/.codex/skills
+cp -R /tmp/skillstead/skills/github-release-guide ~/.codex/skills/
 ```
 
-### Claude Code — Windows PowerShell
+#### Claude Code — Windows PowerShell
 
 ```powershell
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
@@ -122,19 +202,19 @@ New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$env:USERPROFILE\.claude\skills\"
 ```
 
-### Codex — Windows PowerShell
+#### Codex — Windows PowerShell
 
 ```powershell
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
-New-Item -ItemType Directory -Force "$env:USERPROFILE\.agents\skills" | Out-Null
-Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$env:USERPROFILE\.agents\skills\"
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\skills" | Out-Null
+Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$env:USERPROFILE\.codex\skills\"
 ```
 
-## Project install
+### Project install
 
-Run from the target repository root. Commit the copied folder if the team should receive it on clone.
+Run these commands from the target repository root.
 
-### Claude Code — macOS/Linux
+#### Claude Code — macOS/Linux
 
 ```bash
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
@@ -142,7 +222,7 @@ mkdir -p .claude/skills
 cp -R /tmp/skillstead/skills/github-release-guide .claude/skills/
 ```
 
-### Codex — macOS/Linux
+#### Codex — macOS/Linux
 
 ```bash
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
@@ -150,9 +230,15 @@ mkdir -p .agents/skills
 cp -R /tmp/skillstead/skills/github-release-guide .agents/skills/
 ```
 
-### Windows PowerShell
+#### Claude Code — Windows PowerShell
 
-Use `.claude\skills` for Claude Code or `.agents\skills` for Codex:
+```powershell
+git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
+New-Item -ItemType Directory -Force ".claude\skills" | Out-Null
+Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" ".claude\skills\"
+```
+
+#### Codex — Windows PowerShell
 
 ```powershell
 git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
@@ -160,71 +246,75 @@ New-Item -ItemType Directory -Force ".agents\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" ".agents\skills\"
 ```
 
-## Use the latest development state for evaluation
+</details>
 
-Omit `--branch github-release-guide/v0.9.0` to copy the current default branch. This is useful for evaluation, not reproducible
-team installation. Pinned tags are recommended for teams and release evidence.
+Per-skill zip files are not currently published or checksum-verified. The pinned-tag clone remains the reproducible
+manual installation path.
 
-## Keep the complete package
+[Back to top](#top)
 
-Keep the whole folder intact:
+## Runtime support and recorded evidence
 
-```text
-github-release-guide/
-├── CHANGELOG.md
-├── LICENSE.txt
-├── README.md
-├── README.ko.md
-├── SKILL.md
-├── agents/
-│   └── openai.yaml
-└── references/
-    ├── assessment.md
-    ├── first-public.md
-    └── version-release.md
-```
+Runtime support is verified per skill:
 
-The installed README pair explains the workflow in user-facing language. Repository-only fixtures and
-diagrams remain at `examples/github-release-guide/` in the Skillstead repository and are not copied with the
-skill.
+| Skill | Claude Code | Codex | Other | Evidence boundary |
+| --- | --- | --- | --- | --- |
+| `svg-infographic` | Supported | Supported | — | Frozen fresh-context briefs passed on Claude Code and macOS Codex CLI; a fresh Codex App task also passed in a Windows 11 ARM64 VM. Linux rendering and every Windows machine/filesystem are not claimed |
+| `docs-claim-check` | Supported | Not yet claimed | — | Behavioral fixtures passed with Claude Code Fable and Sonnet |
+| `github-release-guide` | Supported | Supported | — | Material parity, disposable first-public and Guided tag-ruleset E2E, pinned installation/discovery, and release claim audits passed |
+| `writing-quality-editor` | Supported | Supported | — | Four-mode cross-runtime behavior, repository dogfood, pinned installation, package equality, discovery, and claim closeout passed |
+| `street-portrait-artist` | Not applicable | Supported | ChatGPT: Supported | Fresh published `0.1.0` package installation, discovery, invocation, synthetic reference-image generation, fail-visible size fallback, and output delivery established runtime support; `0.1.1` is the current install release |
 
-`writing-quality-editor` follows the same complete-folder rule. Its package contains `CHANGELOG.md`,
-`LICENSE.txt`, `SKILL.md`, English/Korean READMEs, `agents/openai.yaml`, and three reference files; its
-repository-only fixtures remain under `examples/writing-quality-editor/`.
+Evidence recorded for an earlier release can establish a bounded runtime capability without making that older
+release the current install target. For normal use, choose only a runtime marked `Supported`. `Not yet claimed`
+means evaluation only; it is not a public support claim.
 
-`street-portrait-artist` also follows the complete-folder rule. Its package contains `CHANGELOG.md`, `LICENSE.txt`,
-`SKILL.md`, English/Korean READMEs, `agents/openai.yaml`, and four reference files. Its synthetic gallery and
-repository-only behavior fixtures remain under `examples/street-portrait-artist/`.
+For `street-portrait-artist`, ChatGPT uses a product-managed skill interface rather than the filesystem paths
+above. The observed ChatGPT and Codex runtime images were `1122 x 1402 px`; exact `1080 x 1350 px` export was
+unavailable and reported rather than hidden. This evidence establishes runtime support and honest fallback, not
+deterministic likeness or broad visual-quality maturity.
 
-## Update without leaving removed files behind
+[Back to top](#top)
 
-`cp -R` can leave files that were removed upstream. For a guaranteed clean update:
+## Evaluate the latest development state
+
+For evaluation only, replace the pinned tag with the default branch. This is not a reproducible team installation
+and does not replace the current-release links above. Pinned tags remain the recommended path for normal use,
+teams, and release evidence.
+
+[Back to top](#top)
+
+## Update, uninstall, and package integrity
+
+### Keep the complete package
+
+Copy the entire `skills/<name>/` folder. A package can include `SKILL.md`, bilingual READMEs, a changelog, license,
+runtime metadata, scripts, and required references. Repository-only fixtures and gallery assets under `examples/`
+are not part of the installed package unless a skill guide explicitly says otherwise.
+
+### Update without stale files
+
+`cp -R` can leave files that were removed upstream. For a clean update:
 
 1. Clone the desired tag into a fresh temporary directory.
-2. Delete only the target installed skill folder.
+2. Remove only the installed folder for the target skill.
 3. Copy the complete replacement folder.
-4. Restart the runtime if needed and verify discovery.
+4. Start a new runtime session and verify the discovered version.
 5. For a project install, review and commit the replacement.
 
-Do not delete a parent skills directory that may contain unrelated skills.
+Do not remove a parent skills directory that may contain unrelated skills.
 
-## Uninstall
+### Uninstall
 
-Delete only the installed skill folder:
+Delete only the installed target folder:
 
-```bash
-rm -rf ~/.claude/skills/github-release-guide
-rm -rf ~/.agents/skills/github-release-guide
-rm -rf .claude/skills/github-release-guide
-rm -rf .agents/skills/github-release-guide
+```text
+Claude Code personal: ~/.claude/skills/<name>
+Claude Code project:  <repo>/.claude/skills/<name>
+Codex personal:       ~/.codex/skills/<name>
+Codex project:        <repo>/.agents/skills/<name>
 ```
 
-```powershell
-Remove-Item -Recurse -Force "$env:USERPROFILE\.claude\skills\github-release-guide"
-Remove-Item -Recurse -Force "$env:USERPROFILE\.agents\skills\github-release-guide"
-Remove-Item -Recurse -Force ".claude\skills\github-release-guide"
-Remove-Item -Recurse -Force ".agents\skills\github-release-guide"
-```
+Uninstall changes only local discovery. It does not undo a previously approved repository or GitHub mutation.
 
-Uninstall changes only local discovery. It does not undo a GitHub release or any repository mutation that
-was previously approved and performed.
+[Back to top](#top)


### PR DESCRIPTION
## 요약

- 문서 상단에 스킬별 바로가기를 추가했습니다.
- 각 스킬 섹션에 현재 고정 버전의 복사·붙여넣기 설치 요청을 제공합니다.
- 직접 설치 명령과 지원 근거는 뒤쪽 참고 섹션으로 재배치했습니다.
- Codex 개인 설치 경로를 현재 경로인 `~/.codex/skills`로 바로잡았습니다.
- 영문 canonical 문서와 한국어 문서를 같은 구조로 맞췄습니다.

## 검증

- `python3 -m unittest discover -s tests` — 296 tests passed
- `PYTHONPATH=tools python3 -m skillstead_validate repo` — 0 findings
- `git diff --check`
- 다섯 개 고정 GitHub 폴더 URL — HTTP 200
- GitHub GFM API로 한국어 문서 렌더링 확인