### PR TITLE
ci: checkout action을 Node 24로 갱신한다

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       # branch, and an unpinned checkout would run a feature branch's
       # modified wrapper — and its request file — under the write token.
       # Both the wrapper and the request must come from the trusted ref.
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/validate-periodic.yml
+++ b/.github/workflows/validate-periodic.yml
@@ -17,7 +17,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,7 @@ jobs:
       svg_infographic: ${{ steps.diff.outputs.svg_infographic }}
       validator: ${{ steps.diff.outputs.validator }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -80,7 +80,7 @@ jobs:
     if: needs.scope.outputs.svg_infographic == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The package's own suite subsets fonts, and its subsetter-dependent fixtures used to skip
       # themselves silently when the toolchain was absent — which is what CI looked like, so those
@@ -103,7 +103,7 @@ jobs:
     if: needs.scope.outputs.validator == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validator self-tests (fixtures)
         run: python3 -m unittest discover -s tests
@@ -114,7 +114,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -192,7 +192,7 @@ jobs:
     if: (github.event_name == 'create' || github.event_name == 'delete') && github.event.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Repository-level changes since the last dated entry.
 
 ### Repository
 
+- **Node 24 workflow runtime.** Updated every remaining `actions/checkout` pin to the verified `v7.0.1` commit,
+  removing the deprecated Node.js 20 action runtime while preserving immutable action references.
+
 - **Explicit release target recovery.** Generalized the legacy-named target
   record beyond initial `0.1.0` releases so an owner-authorized immutable
   binding can recover a reviewed protected tag without moving or recreating it.


### PR DESCRIPTION
## 요약

- 남아 있던 `actions/checkout` v4 pin을 공식 최신 `v7.0.1`의 검증된 commit SHA로 통일합니다.
- Node.js 20 deprecation 경고를 제거하고 immutable action pin 정책은 유지합니다.
- 이미 v7.0.1이던 Pages workflow와 동일한 pin을 사용합니다.

## 검증

- `python3 -m unittest -v tests.test_ci_scope` — 12 tests passed
- `PYTHONPATH=tools python3 -m skillstead_validate repo --repo-root .` — 0 findings
- workflow 전체에서 checkout v4 pin 부재 확인
- `git diff --check`

workflow 변경이므로 fail-closed 정책에 따라 hosted CI heavy suite가 실행됩니다.