### PR TITLE
ci: PR aggregate check를 고유하게 만든다

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,8 @@
 # Workflow/classifier changes run everything. The daily periodic workflow also
 # stays full, so it remains the eventless fallback for repository state that a
 # scoped event run cannot observe. The `validate` job aggregates the results
-# under the historical check name.
+# under an event-specific check name so skipped create/delete jobs cannot
+# satisfy the pull-request gate.
 name: validate
 
 on:
@@ -150,10 +151,12 @@ jobs:
       - name: Spec reference validator (pinned skills-ref)
         run: python3 tools/run_skills_ref.py
 
-  # Aggregate under the historical check name: green only when every job that
-  # was supposed to run succeeded, and a skipped heavy suite is acceptable
-  # only when `scope` explicitly ruled it out.
+  # Aggregate under an event-specific check name: green only when every job
+  # that was supposed to run succeeded, and a skipped heavy suite is acceptable
+  # only when `scope` explicitly ruled it out. `validate / pull_request` is the
+  # single required status check for main.
   validate:
+    name: validate / ${{ github.event_name }}
     needs: [scope, svg-infographic-suite, validator-suite, checks]
     if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'push') }}
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Repository-level changes since the last dated entry.
 - **Change-scoped event validation.** Pull requests and `main` pushes keep the fast repository-wide checks while
   running heavy suites only for their observed inputs. SVG package and example inputs run both the SVG and validator
   suites; workflow, classifier, unreadable and non-ancestor changes fail closed to both, and the daily run stays full.
+  Event-specific aggregate names isolate the required PR check from skipped create/delete jobs.
 - **Fork-safe Pages deployment.** Pushes publish Pages automatically only from `kyungseo/skillstead`. Fork owners may
   opt in with a manual dispatch after enabling Pages in their own repository.
 

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -85,7 +85,7 @@ release의 `published_at`이 null이거나 빈 문자열인 경우 포함), tran
 
 | 파일 | trigger | 목적 |
 | --- | --- | --- |
-| `validate.yml` | PR, `main` push, tag 생성/삭제 | event 기반 검증을 병렬 job으로 실행 — `svg-infographic` regression suite와 validator self-test suite가 경량 검사(M1+gallery+M3+M4+skills-ref) 옆에서 돌고, `validate` aggregate job이 기존 check 이름을 유지. PR은 `origin/<base>...HEAD`, `main` push는 관측된 `github.event.before...HEAD` 범위를 분류함. SVG suite는 `skills/svg-infographic/**`와 `examples/svg-infographic/**`가 바뀔 때 실행하며, 다른 독립 Skill과 문서 변경은 모든 Skill에 적용되는 경량 검사를 유지하되 무관한 heavy suite 비용은 내지 않음. Repository fixture가 SVG script를 직접 실행하므로 SVG input은 validator self-test도 실행함. `tools/**`·`tests/**`는 validator self-test를 실행함. `.github/**`, workflow/classifier 변경, 0 또는 비조상 push base, diff 판독 불가는 fail-closed로 양 heavy suite를 실행함. 알 수 없는 scope output은 skip으로 완화하지 않고 aggregate를 실패시킴. PR M3는 checkout된 merge candidate를, `main` push M3는 `origin/main`을 검사함. tag event는 명시적 `main` checkout으로 M3+M4 실행, branch 생성/삭제 event는 아무것도 실행하지 않음 |
+| `validate.yml` | PR, `main` push, tag 생성/삭제 | event 기반 검증을 병렬 job으로 실행 — `svg-infographic` regression suite와 validator self-test suite가 경량 검사(M1+gallery+M3+M4+skills-ref) 옆에서 돌고, event별 aggregate가 `validate / pull_request` 또는 `validate / push`를 보고함. PR은 `origin/<base>...HEAD`, `main` push는 관측된 `github.event.before...HEAD` 범위를 분류함. SVG suite는 `skills/svg-infographic/**`와 `examples/svg-infographic/**`가 바뀔 때 실행하며, 다른 독립 Skill과 문서 변경은 모든 Skill에 적용되는 경량 검사를 유지하되 무관한 heavy suite 비용은 내지 않음. Repository fixture가 SVG script를 직접 실행하므로 SVG input은 validator self-test도 실행함. `tools/**`·`tests/**`는 validator self-test를 실행함. `.github/**`, workflow/classifier 변경, 0 또는 비조상 push base, diff 판독 불가는 fail-closed로 양 heavy suite를 실행함. 알 수 없는 scope output은 skip으로 완화하지 않고 aggregate를 실패시킴. PR M3는 checkout된 merge candidate를, `main` push M3는 `origin/main`을 검사함. tag event는 명시적 `main` checkout으로 M3+M4 실행, branch 생성/삭제 event는 아무것도 실행하지 않음 |
 | `validate-periodic.yml` | 매일 schedule(`17 3 * * *` UTC), 수동 dispatch | event가 발생하지 않는 상태 변화(예: push 밖의 tag repoint)를 잡는 주기적 안전망 |
 | `release.yml` | 수동 dispatch 전용 | M5 wrapper 진입점. dry-run이 기본값이며 checkout이 `main`에 고정되어 있어 dispatch가 미검토 wrapper나 request를 write token으로 실행할 수 없음 |
 | `pages.yml` | `main` push, 수동 dispatch | 제한된 gallery/examples site를 게시함. 자동 배포는 `kyungseo/skillstead`에만 허용되어 fork push에서는 deploy job을 skip함. Fork owner는 수동 dispatch로 opt-in할 수 있지만, 해당 fork에서 GitHub Pages를 활성화하지 않았다면 Pages setup 단계에서 계속 실패함 |
@@ -93,6 +93,12 @@ release의 `published_at`이 null이거나 빈 문자열인 경우 포함), tran
 매일 실행되는 periodic workflow는 scope를 적용하지 않는 전체 검증으로 남아, event 기반 scope가
 관측하지 못한 상태 변경이나 분류 실수를 탐지합니다. 두 검증 workflow는 별도 파일입니다 — 어느 한쪽의 비활성화(저장소 60일 미활동 시 GitHub의
 schedule workflow 자동 비활성화 포함)가 다른 쪽을 침묵시키지 않도록 하기 위해서입니다.
+Canonical `protect-main` ruleset은 GitHub Actions의 `validate / pull_request`를 loose policy로
+요구합니다. 관측된 PR aggregate는 반드시 통과해야 하지만, `main`이 앞서갔다는 이유만으로 branch를
+다시 build하지는 않습니다. 개별 heavy suite는 직접 required로 두지 않고 scope가 선택한 suite를
+aggregate가 검증합니다. Event별 이름은 skip된 create/delete job이 PR requirement를 만족시키는 것을
+막습니다.
+
 event 없는 변경의 명목상 최대 탐지 지연은 schedule 주기 1회(~24시간) + 스케줄러 지연입니다.
 schedule workflow가 자동 비활성화되면 다음 활동 후 Actions 탭에서 재활성화하거나 수동
 dispatch로 1회 실행하십시오.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -96,13 +96,20 @@ would state something the run did not observe.
 
 | File | Triggers | Purpose |
 | --- | --- | --- |
-| `validate.yml` | PR, push to `main`, tag create/delete | event-driven validation as parallel jobs — the `svg-infographic` regression suite and validator self-test suite run beside the fast checks (M1+gallery+M3+M4+skills-ref), and a `validate` aggregate job carries the historical check name. PRs classify `origin/<base>...HEAD`; `main` pushes classify the observed `github.event.before...HEAD` range. The SVG suite runs for `skills/svg-infographic/**` and `examples/svg-infographic/**`, while other independent skill and documentation changes retain the fast all-skill checks without paying for unrelated heavy suites. SVG inputs also run validator self-tests because repository fixtures invoke the SVG scripts. `tools/**` and `tests/**` run validator self-tests. `.github/**`, workflow/classifier changes, a zero or non-ancestor push base, and an unreadable diff fail closed to both heavy suites. Unknown scope output fails the aggregate rather than becoming a skip. PR M3 evaluates the checked-out merge candidate; `main` push M3 evaluates `origin/main`. Tag events run M3+M4 against an explicit `main` checkout; branch create/delete events run nothing |
+| `validate.yml` | PR, push to `main`, tag create/delete | event-driven validation as parallel jobs — the `svg-infographic` regression suite and validator self-test suite run beside the fast checks (M1+gallery+M3+M4+skills-ref), and an event-specific aggregate reports `validate / pull_request` or `validate / push`. PRs classify `origin/<base>...HEAD`; `main` pushes classify the observed `github.event.before...HEAD` range. The SVG suite runs for `skills/svg-infographic/**` and `examples/svg-infographic/**`, while other independent skill and documentation changes retain the fast all-skill checks without paying for unrelated heavy suites. SVG inputs also run validator self-tests because repository fixtures invoke the SVG scripts. `tools/**` and `tests/**` run validator self-tests. `.github/**`, workflow/classifier changes, a zero or non-ancestor push base, and an unreadable diff fail closed to both heavy suites. Unknown scope output fails the aggregate rather than becoming a skip. PR M3 evaluates the checked-out merge candidate; `main` push M3 evaluates `origin/main`. Tag events run M3+M4 against an explicit `main` checkout; branch create/delete events run nothing |
 | `validate-periodic.yml` | daily schedule (`17 3 * * *` UTC), manual dispatch | periodic fallback for state changes that fire no event (e.g. a tag repointed outside a push) |
 | `release.yml` | manual dispatch only | M5 wrapper entry; dry-run by default; checkout pinned to `main` so a dispatch can never run an unreviewed wrapper or request under the write token |
 | `pages.yml` | push to `main`, manual dispatch | publishes the bounded gallery/examples site. Automatic deployment is limited to `kyungseo/skillstead`; a fork push skips the deploy job. A fork owner may opt in with a manual dispatch, but that run still fails at Pages setup when GitHub Pages has not been enabled in the fork |
 
 The daily periodic workflow remains a full, unscoped run and catches state
 changes or classification mistakes that an event-scoped run did not observe.
+The canonical `protect-main` ruleset requires the GitHub Actions check
+`validate / pull_request` under a loose policy: every observed PR aggregate
+must pass, but the branch need not be rebuilt solely because `main` advanced.
+Individual heavy suites are not required directly; the aggregate verifies each
+suite that scope selected. Event-specific naming prevents a skipped
+create/delete job from satisfying the PR requirement.
+
 The two validation workflows are separate files so that disabling either —
 including GitHub's automatic disable of scheduled workflows after 60 days of
 repository inactivity — never silences the other. Nominal maximum detection

--- a/tests/test_ci_scope.py
+++ b/tests/test_ci_scope.py
@@ -85,6 +85,8 @@ class CiScopeClassifier(unittest.TestCase):
 class WorkflowContract(unittest.TestCase):
     def test_validate_wires_the_exact_scope_output_and_rejects_unknown_values(self):
         text = (REPO / ".github/workflows/validate.yml").read_text(encoding="utf-8")
+        self.assertIn("name: validate / ${{ github.event_name }}", text)
+        self.assertIn("`validate / pull_request` is the", text)
         self.assertIn("svg_infographic: ${{ steps.diff.outputs.svg_infographic }}", text)
         self.assertIn("if: needs.scope.outputs.svg_infographic == 'true'", text)
         self.assertIn('"${{ needs.scope.outputs.svg_infographic }}"', text)


### PR DESCRIPTION
## 요약

- aggregate job 이름을 event별로 분리해 PR에서는 `validate / pull_request`를 생성합니다.
- create/delete event의 skipped job이 required PR check와 같은 이름을 갖지 않도록 합니다.
- 병합 후 `protect-main` ruleset에는 이 aggregate 하나만 loose required check로 등록할 예정입니다.

## 검증

- `python3 -m unittest -v tests.test_ci_scope` — 12 tests passed
- `PYTHONPATH=tools python3 -m skillstead_validate repo --repo-root .` — 0 findings
- `git diff --check`

workflow 변경이므로 fail-closed 정책에 따라 hosted CI heavy suite가 실행됩니다. 새 aggregate가 실제로 green인 것을 확인한 뒤 병합합니다.