### PR TITLE
chore: 다섯 스킬의 문서 패치 릴리스 준비

### DIFF
--- a/.skillstead/release-notes/docs-claim-check-v0.9.2.md
+++ b/.skillstead/release-notes/docs-claim-check-v0.9.2.md
@@ -1,0 +1,24 @@
+> **Latest** refers to the most recently published individual skill release, not a catalog version.
+
+## docs-claim-check 0.9.2
+
+Clarifies what the claim review returns and removes repeated explanations in the English and Korean guides.
+
+This is a documentation patch. Runtime instructions and Beta maturity are unchanged. Existing users can keep their installed version for the same behavior, or replace the complete skill folder to receive the updated guides.
+
+Validation covers repository and gallery consistency, package-content comparison, and the release gates. This patch does not add runtime support or change the existing operating limits.
+
+### 한국어
+
+주장 검토 결과로 무엇을 받는지 더 명확하게 설명하고 영어·한국어 안내의 반복을 줄였습니다.
+
+문서 패치이며 실행 지침과 Beta 성숙도는 그대로입니다. 같은 동작을 사용하는 데 업데이트가 필수는 아닙니다. 새 안내 문서를 받으려면 설치된 스킬 폴더 전체를 교체하면 됩니다.
+
+저장소·갤러리 정합성, 패키지 내용 비교, 릴리스 절차를 검사했습니다. 지원 실행 환경을 추가하거나 기존 동작상의 제한을 바꾸는 패치는 아닙니다.
+
+- [Package / 패키지](https://github.com/kyungseo/skillstead/tree/docs-claim-check/v0.9.2/skills/docs-claim-check)
+- [Changelog / 변경 기록](https://github.com/kyungseo/skillstead/blob/docs-claim-check/v0.9.2/skills/docs-claim-check/CHANGELOG.md)
+- [Changes / 변경 비교](https://github.com/kyungseo/skillstead/compare/docs-claim-check/v0.9.1...docs-claim-check/v0.9.2)
+
+The versioned unit is `skills/docs-claim-check/`. GitHub source archives contain the whole repository snapshot, not a standalone skill package.
+GitHub 소스 압축 파일에는 저장소 전체가 들어 있습니다. 설치 대상은 `skills/docs-claim-check/` 폴더입니다.

--- a/.skillstead/release-notes/github-release-guide-v0.9.1.md
+++ b/.skillstead/release-notes/github-release-guide-v0.9.1.md
@@ -1,0 +1,24 @@
+> **Latest** refers to the most recently published individual skill release, not a catalog version.
+
+## github-release-guide 0.9.1
+
+Clarifies the Korean explanations of execution approval, exposed-tag corrections, and release automation checks.
+
+This is a documentation patch. Runtime instructions and Stable maturity are unchanged. Existing users can keep their installed version for the same behavior, or replace the complete skill folder to receive the updated guides.
+
+Validation covers repository and gallery consistency, package-content comparison, and the release gates. This patch does not add runtime support or change the existing operating limits.
+
+### 한국어
+
+실행 승인, 이미 공개된 태그의 정정, 릴리스 자동화 점검을 한국어로 더 쉽게 설명했습니다.
+
+문서 패치이며 실행 지침과 Stable 성숙도는 그대로입니다. 같은 동작을 사용하는 데 업데이트가 필수는 아닙니다. 새 안내 문서를 받으려면 설치된 스킬 폴더 전체를 교체하면 됩니다.
+
+저장소·갤러리 정합성, 패키지 내용 비교, 릴리스 절차를 검사했습니다. 지원 실행 환경을 추가하거나 기존 동작상의 제한을 바꾸는 패치는 아닙니다.
+
+- [Package / 패키지](https://github.com/kyungseo/skillstead/tree/github-release-guide/v0.9.1/skills/github-release-guide)
+- [Changelog / 변경 기록](https://github.com/kyungseo/skillstead/blob/github-release-guide/v0.9.1/skills/github-release-guide/CHANGELOG.md)
+- [Changes / 변경 비교](https://github.com/kyungseo/skillstead/compare/github-release-guide/v0.9.0...github-release-guide/v0.9.1)
+
+The versioned unit is `skills/github-release-guide/`. GitHub source archives contain the whole repository snapshot, not a standalone skill package.
+GitHub 소스 압축 파일에는 저장소 전체가 들어 있습니다. 설치 대상은 `skills/github-release-guide/` 폴더입니다.

--- a/.skillstead/release-notes/street-portrait-artist-v0.1.2.md
+++ b/.skillstead/release-notes/street-portrait-artist-v0.1.2.md
@@ -1,0 +1,24 @@
+> **Latest** refers to the most recently published individual skill release, not a catalog version.
+
+## street-portrait-artist 0.1.2
+
+Explains photo roles, face shape, expression, and drawing choices in familiar terms across the English and Korean guides.
+
+This is a documentation patch. Runtime instructions and Experimental maturity are unchanged. Existing users can keep their installed version for the same behavior, or replace the complete skill folder to receive the updated guides.
+
+Validation covers repository and gallery consistency, package-content comparison, and the release gates. This patch does not add runtime support or change the existing operating limits.
+
+### 한국어
+
+사진별 용도와 얼굴형·표정·그림 표현 방식을 영어·한국어 안내에서 익숙한 말로 풀어 썼습니다.
+
+문서 패치이며 실행 지침과 Experimental 성숙도는 그대로입니다. 같은 동작을 사용하는 데 업데이트가 필수는 아닙니다. 새 안내 문서를 받으려면 설치된 스킬 폴더 전체를 교체하면 됩니다.
+
+저장소·갤러리 정합성, 패키지 내용 비교, 릴리스 절차를 검사했습니다. 지원 실행 환경을 추가하거나 기존 동작상의 제한을 바꾸는 패치는 아닙니다.
+
+- [Package / 패키지](https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.2/skills/street-portrait-artist)
+- [Changelog / 변경 기록](https://github.com/kyungseo/skillstead/blob/street-portrait-artist/v0.1.2/skills/street-portrait-artist/CHANGELOG.md)
+- [Changes / 변경 비교](https://github.com/kyungseo/skillstead/compare/street-portrait-artist/v0.1.1...street-portrait-artist/v0.1.2)
+
+The versioned unit is `skills/street-portrait-artist/`. GitHub source archives contain the whole repository snapshot, not a standalone skill package.
+GitHub 소스 압축 파일에는 저장소 전체가 들어 있습니다. 설치 대상은 `skills/street-portrait-artist/` 폴더입니다.

--- a/.skillstead/release-notes/svg-infographic-v0.11.1.md
+++ b/.skillstead/release-notes/svg-infographic-v0.11.1.md
@@ -1,0 +1,28 @@
+> **Latest** refers to the most recently published individual skill release, not a catalog version.
+
+## svg-infographic 0.11.1
+
+Clarifies the introductory guide and aligns the documented Codex personal installation path with the catalog installation guide.
+
+This is a documentation patch. Runtime instructions and Stable maturity are unchanged. Existing users can keep their installed version for the same behavior, or replace the complete skill folder to receive the updated guides.
+
+The 18 canonical SVG/PNG pairs and their generation records were regenerated and checked for this documentation release.
+
+Validation covers repository and gallery consistency, package-content comparison, and the release gates. This patch does not add runtime support or change the existing operating limits.
+
+### 한국어
+
+소개 문장을 명확하게 다듬고 Codex 개인 설치 경로를 저장소의 설치 안내와 맞췄습니다.
+
+문서 패치이며 실행 지침과 Stable 성숙도는 그대로입니다. 같은 동작을 사용하는 데 업데이트가 필수는 아닙니다. 새 안내 문서를 받으려면 설치된 스킬 폴더 전체를 교체하면 됩니다.
+
+이 문서 릴리스를 위해 기본 예제 18쌍의 SVG·PNG와 생성 기록을 다시 생성하고 검사했습니다.
+
+저장소·갤러리 정합성, 패키지 내용 비교, 릴리스 절차를 검사했습니다. 지원 실행 환경을 추가하거나 기존 동작상의 제한을 바꾸는 패치는 아닙니다.
+
+- [Package / 패키지](https://github.com/kyungseo/skillstead/tree/svg-infographic/v0.11.1/skills/svg-infographic)
+- [Changelog / 변경 기록](https://github.com/kyungseo/skillstead/blob/svg-infographic/v0.11.1/skills/svg-infographic/CHANGELOG.md)
+- [Changes / 변경 비교](https://github.com/kyungseo/skillstead/compare/svg-infographic/v0.11.0...svg-infographic/v0.11.1)
+
+The versioned unit is `skills/svg-infographic/`. GitHub source archives contain the whole repository snapshot, not a standalone skill package.
+GitHub 소스 압축 파일에는 저장소 전체가 들어 있습니다. 설치 대상은 `skills/svg-infographic/` 폴더입니다.

--- a/.skillstead/release-notes/writing-quality-editor-v0.14.1.md
+++ b/.skillstead/release-notes/writing-quality-editor-v0.14.1.md
@@ -1,0 +1,24 @@
+> **Latest** refers to the most recently published individual skill release, not a catalog version.
+
+## writing-quality-editor 0.14.1
+
+Clarifies when to use each writing mode and separates editing principles from measured results. The guides distinguish earlier runtime evidence from the newer Korean drafting path.
+
+This is a documentation patch. Runtime instructions and Beta maturity are unchanged. Existing users can keep their installed version for the same behavior, or replace the complete skill folder to receive the updated guides.
+
+Validation covers repository and gallery consistency, package-content comparison, and the release gates. The Korean new-draft path retains its previously recorded limitations; this patch adds no new behavior or discovery evidence.
+
+### 한국어
+
+작성 모드별 용도를 더 쉽게 찾도록 정리하고, 편집 원칙과 실제로 측정한 결과를 구분했습니다. 기존 실행 근거와 새 한국어 작성 경로의 검증 범위도 나누어 설명합니다.
+
+문서 패치이며 실행 지침과 Beta 성숙도는 그대로입니다. 같은 동작을 사용하는 데 업데이트가 필수는 아닙니다. 새 안내 문서를 받으려면 설치된 스킬 폴더 전체를 교체하면 됩니다.
+
+저장소·갤러리 정합성, 패키지 내용 비교, 릴리스 절차를 검사했습니다. 새 한국어 작성 경로의 기존 한계는 그대로이며, 이번 패치는 동작이나 자동 발견에 관한 새 검증 근거를 추가하지 않습니다.
+
+- [Package / 패키지](https://github.com/kyungseo/skillstead/tree/writing-quality-editor/v0.14.1/skills/writing-quality-editor)
+- [Changelog / 변경 기록](https://github.com/kyungseo/skillstead/blob/writing-quality-editor/v0.14.1/skills/writing-quality-editor/CHANGELOG.md)
+- [Changes / 변경 비교](https://github.com/kyungseo/skillstead/compare/writing-quality-editor/v0.14.0...writing-quality-editor/v0.14.1)
+
+The versioned unit is `skills/writing-quality-editor/`. GitHub source archives contain the whole repository snapshot, not a standalone skill package.
+GitHub 소스 압축 파일에는 저장소 전체가 들어 있습니다. 설치 대상은 `skills/writing-quality-editor/` 폴더입니다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,27 @@ Notable changes to this repository. Format based on [Keep a Changelog](https://k
 
 Granular, per-change entries begin at the first public release. Earlier development history is in the git log.
 
-## [Unreleased]
+## 2026-09-07
+
+### Validation
+
+- Read the SVG artifact surface revision from the current package preflight instead of a stale fixed value; mismatched revisions and unavailable identity still fail the release gate.
+
+### Skills
+
+- `docs-claim-check` `0.9.2` — documentation patch; clarifies what the claim review returns and removes repeated explanations in the English and Korean guides.
+- `github-release-guide` `0.9.1` — documentation patch; clarifies the Korean explanations of execution approval, exposed-tag corrections, and release automation checks.
+- `street-portrait-artist` `0.1.2` — documentation patch; explains photo roles, face shape, expression, and drawing choices in familiar terms across the English and Korean guides.
+- `svg-infographic` `0.11.1` — documentation patch; clarifies the introductory guide and aligns the documented Codex personal installation path with the catalog installation guide.
+- `writing-quality-editor` `0.14.1` — documentation patch; clarifies when to use each writing mode and separates editing principles from measured results. The guides distinguish earlier runtime evidence from the newer Korean drafting path.
 
 ### Documentation
 
 - Put the skill selection table before the catalog galleries and clarified the writing and portrait guides.
 - Reviewed English/Korean guides, corrected the missing portrait entry and inconsistent Codex installation path,
   and distinguished historical four-skill evidence from the current catalog and the newer Korean drafting path.
-- Recorded documentation changes in the five affected package changelogs. Package versions and published install
-  pins remain unchanged pending patch release preparation; runtime instructions and maturity labels are unchanged.
+- Published the five documentation patches with matching package versions and installation pins. Runtime instructions
+  and maturity labels are unchanged.
 
 ## 2026-09-06
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -25,11 +25,11 @@ GitHub 릴리스 준비, 자연스럽고 정확한 글쓰기, 인물 사진을 �
 
 | 스킬 | 이런 작업에 적합 | 버전 | 지원 실행 환경 | 성숙도 |
 | --- | --- | --- | --- | --- |
-| [`svg-infographic`](./skills/svg-infographic/README.ko.md) | 아키텍처 설명, 작업 흐름, 비교 자료를 수정 가능한 SVG와 검증된 2× PNG로 제작 | `0.11.0` | Supported: Claude Code + Codex | Stable |
-| [`docs-claim-check`](./skills/docs-claim-check/README.ko.md) | 공개 문서의 주장이 제공된 근거로 뒷받침되는지 확인 | `0.9.1` | Claude Code | Beta |
-| [`github-release-guide`](./skills/github-release-guide/README.ko.md) | 비공개 GitHub 저장소의 첫 공개 전환 또는 공개 후 매 버전 릴리스를 점검하고 단계별로 안내 | `0.9.0` | Supported: Claude Code + Codex | Stable |
-| [`writing-quality-editor`](./skills/writing-quality-editor/README.ko.md) | 사용자 문서를 처음부터 작성하거나 자연스럽게 다듬고, 사실·의도·목소리·운영 제약을 보존하면서 영어↔한국어 내용을 재구성 | `0.14.0` | Supported: Claude Code + Codex | Beta |
-| [`street-portrait-artist`](./skills/street-portrait-artist/README.ko.md) | 인물 사진의 얼굴형·표정을 살려 캐리커처 또는 펜·수채화 초상화 제작 | `0.1.1` | Supported: ChatGPT + Codex | Experimental |
+| [`svg-infographic`](./skills/svg-infographic/README.ko.md) | 아키텍처 설명, 작업 흐름, 비교 자료를 수정 가능한 SVG와 검증된 2× PNG로 제작 | `0.11.1` | Supported: Claude Code + Codex | Stable |
+| [`docs-claim-check`](./skills/docs-claim-check/README.ko.md) | 공개 문서의 주장이 제공된 근거로 뒷받침되는지 확인 | `0.9.2` | Claude Code | Beta |
+| [`github-release-guide`](./skills/github-release-guide/README.ko.md) | 비공개 GitHub 저장소의 첫 공개 전환 또는 공개 후 매 버전 릴리스를 점검하고 단계별로 안내 | `0.9.1` | Supported: Claude Code + Codex | Stable |
+| [`writing-quality-editor`](./skills/writing-quality-editor/README.ko.md) | 사용자 문서를 처음부터 작성하거나 자연스럽게 다듬고, 사실·의도·목소리·운영 제약을 보존하면서 영어↔한국어 내용을 재구성 | `0.14.1` | Supported: Claude Code + Codex | Beta |
+| [`street-portrait-artist`](./skills/street-portrait-artist/README.ko.md) | 인물 사진의 얼굴형·표정을 살려 캐리커처 또는 펜·수채화 초상화 제작 | `0.1.2` | Supported: ChatGPT + Codex | Experimental |
 
 각 스킬은 필요한 파일을 모두 갖춘 독립 패키지입니다. 전체 목록을 설치할 필요 없이, 사용할 스킬의
 폴더만 통째로 복사하면 됩니다. 개인용·프로젝트용 설치 경로, 고정 버전 설치, 깨끗한 업데이트 방법,

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ maintainer references.
 
 | Skill | Best for | Version | Runtime support | Maturity |
 | --- | --- | --- | --- | --- |
-| [`svg-infographic`](./skills/svg-infographic) | Turning architecture notes, process flows, comparisons, and technical concepts into editable SVG + verified 2× PNG | `0.11.0` | Supported: Claude Code + Codex | Stable |
-| [`docs-claim-check`](./skills/docs-claim-check) | Checking whether public documentation claims are supported by supplied evidence | `0.9.1` | Claude Code | Beta |
-| [`github-release-guide`](./skills/github-release-guide) | Guiding a private repository's first public transition and every later version release, with separate approval before each change | `0.9.0` | Supported: Claude Code + Codex | Stable |
-| [`writing-quality-editor`](./skills/writing-quality-editor) | Composing and revising user-facing text, plus natural English↔Korean adaptation, without inventing or changing facts, intent, voice, or operational constraints | `0.14.0` | Supported: Claude Code + Codex | Beta |
-| [`street-portrait-artist`](./skills/street-portrait-artist) | Creating a caricature or pen-and-watercolor portrait from the face shape and expression in supplied photos | `0.1.1` | Supported: ChatGPT + Codex | Experimental |
+| [`svg-infographic`](./skills/svg-infographic) | Turning architecture notes, process flows, comparisons, and technical concepts into editable SVG + verified 2× PNG | `0.11.1` | Supported: Claude Code + Codex | Stable |
+| [`docs-claim-check`](./skills/docs-claim-check) | Checking whether public documentation claims are supported by supplied evidence | `0.9.2` | Claude Code | Beta |
+| [`github-release-guide`](./skills/github-release-guide) | Guiding a private repository's first public transition and every later version release, with separate approval before each change | `0.9.1` | Supported: Claude Code + Codex | Stable |
+| [`writing-quality-editor`](./skills/writing-quality-editor) | Composing and revising user-facing text, plus natural English↔Korean adaptation, without inventing or changing facts, intent, voice, or operational constraints | `0.14.1` | Supported: Claude Code + Codex | Beta |
+| [`street-portrait-artist`](./skills/street-portrait-artist) | Creating a caricature or pen-and-watercolor portrait from the face shape and expression in supplied photos | `0.1.2` | Supported: ChatGPT + Codex | Experimental |
 
 Each skill is self-contained and can be installed independently. You do not need to install the entire
 catalog—copy only the complete folder for the skill you want to use. See

--- a/docs/INSTALL.ko.md
+++ b/docs/INSTALL.ko.md
@@ -30,11 +30,11 @@ Skillstead의 각 스킬은 폴더 하나로 설치하는 독립 패키지입니
 
 | 스킬 | 현재 고정 태그 | 지원 실행 환경 |
 | --- | --- | --- |
-| `svg-infographic` | `svg-infographic/v0.11.0` | Claude Code와 Codex |
-| `docs-claim-check` | `docs-claim-check/v0.9.1` | Claude Code |
-| `github-release-guide` | `github-release-guide/v0.9.0` | Claude Code와 Codex |
-| `writing-quality-editor` | `writing-quality-editor/v0.14.0` | Claude Code와 Codex |
-| `street-portrait-artist` | `street-portrait-artist/v0.1.1` | ChatGPT와 Codex |
+| `svg-infographic` | `svg-infographic/v0.11.1` | Claude Code와 Codex |
+| `docs-claim-check` | `docs-claim-check/v0.9.2` | Claude Code |
+| `github-release-guide` | `github-release-guide/v0.9.1` | Claude Code와 Codex |
+| `writing-quality-editor` | `writing-quality-editor/v0.14.1` | Claude Code와 Codex |
+| `street-portrait-artist` | `street-portrait-artist/v0.1.2` | ChatGPT와 Codex |
 
 기본 요청은 개인 전역 범위에 설치합니다. 파일 시스템에 설치하는 스킬을 현재 저장소 안에서만 쓰려면
 `전역으로`를 `현재 프로젝트에`로 바꾸세요. ChatGPT는 제품 안에서 스킬을 관리하므로 이 문서의 파일
@@ -46,14 +46,14 @@ Skillstead의 각 스킬은 폴더 하나로 설치하는 독립 패키지입니
 
 ## `svg-infographic`
 
-- 현재 릴리스: `svg-infographic/v0.11.0`
+- 현재 릴리스: `svg-infographic/v0.11.1`
 - 지원 실행 환경: Claude Code와 Codex
 - 패키지 안내: [`skills/svg-infographic/README.ko.md`](../skills/svg-infographic/README.ko.md)
 
 Claude Code나 Codex에 다음 한 줄을 붙여 넣으세요.
 
 ```text
-다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/svg-infographic/v0.11.0/skills/svg-infographic
+다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/svg-infographic/v0.11.1/skills/svg-infographic
 ```
 
 `svg-infographic`을 복사하거나 실행 환경이 발견하는 데는 Node.js가 필요하지 않습니다. Node.js 18 이상은
@@ -68,14 +68,14 @@ Claude Code나 Codex에 다음 한 줄을 붙여 넣으세요.
 
 ## `docs-claim-check`
 
-- 현재 릴리스: `docs-claim-check/v0.9.1`
+- 현재 릴리스: `docs-claim-check/v0.9.2`
 - 지원 실행 환경: Claude Code
 - 패키지 안내: [`skills/docs-claim-check/README.ko.md`](../skills/docs-claim-check/README.ko.md)
 
 Claude Code에 다음 한 줄을 붙여 넣으세요.
 
 ```text
-다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/docs-claim-check/v0.9.1/skills/docs-claim-check
+다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/docs-claim-check/v0.9.2/skills/docs-claim-check
 ```
 
 이 스킬은 아직 Codex 지원을 표시하지 않습니다. 다른 실행 환경에 평가용으로 설치하더라도 그것만으로
@@ -89,14 +89,14 @@ Claude Code에 다음 한 줄을 붙여 넣으세요.
 
 ## `github-release-guide`
 
-- 현재 릴리스: `github-release-guide/v0.9.0`
+- 현재 릴리스: `github-release-guide/v0.9.1`
 - 지원 실행 환경: Claude Code와 Codex
 - 패키지 안내: [`skills/github-release-guide/README.ko.md`](../skills/github-release-guide/README.ko.md)
 
 Claude Code나 Codex에 다음 한 줄을 붙여 넣으세요.
 
 ```text
-다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/github-release-guide/v0.9.0/skills/github-release-guide
+다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/github-release-guide/v0.9.1/skills/github-release-guide
 ```
 
 설치는 재사용 가능한 안내만 추가합니다. 저장소 공개 전환, tag, GitHub Release, 설정 변경, 파괴적 정리,
@@ -110,7 +110,7 @@ Claude Code나 Codex에 다음 한 줄을 붙여 넣으세요.
 
 ## `writing-quality-editor`
 
-- 현재 릴리스: `writing-quality-editor/v0.14.0`
+- 현재 릴리스: `writing-quality-editor/v0.14.1`
 - 새 한국어 Compose 경로: 로컬 패키지를 명시해 읽히는 방식으로 확인했으며, 이번 변경의 설치 후 자동 발견과 다른 runtime 동작은 미확인입니다.
 - 지원 실행 환경: Claude Code와 Codex
 - 패키지 안내: [`skills/writing-quality-editor/README.ko.md`](../skills/writing-quality-editor/README.ko.md)
@@ -118,7 +118,7 @@ Claude Code나 Codex에 다음 한 줄을 붙여 넣으세요.
 Claude Code나 Codex에 다음 한 줄을 붙여 넣으세요.
 
 ```text
-다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/writing-quality-editor/v0.14.0/skills/writing-quality-editor
+다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/writing-quality-editor/v0.14.1/skills/writing-quality-editor
 ```
 
 패키지에는 영문·한글 작성과 검토에 필요한 참고 문서가 함께 들어 있습니다. `SKILL.md`만 따로 복사하지
@@ -132,20 +132,20 @@ Claude Code나 Codex에 다음 한 줄을 붙여 넣으세요.
 
 ## `street-portrait-artist`
 
-- 현재 릴리스: `street-portrait-artist/v0.1.1`
+- 현재 릴리스: `street-portrait-artist/v0.1.2`
 - 지원 실행 환경: ChatGPT와 Codex
 - 패키지 안내: [`skills/street-portrait-artist/README.ko.md`](../skills/street-portrait-artist/README.ko.md)
 
 ChatGPT에 다음 한 줄을 붙여 넣으세요.
 
 ```text
-다음 고정 GitHub 폴더의 street-portrait-artist 스킬을 설치해 줘: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.1/skills/street-portrait-artist
+다음 고정 GitHub 폴더의 street-portrait-artist 스킬을 설치해 줘: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.2/skills/street-portrait-artist
 ```
 
 Codex에 다음 한 줄을 붙여 넣으세요.
 
 ```text
-다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.1/skills/street-portrait-artist
+다음 고정 GitHub 폴더의 Skillstead 스킬을 전역으로 설치해 줘: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.2/skills/street-portrait-artist
 ```
 
 ChatGPT가 설치 확인을 요청할 수 있습니다. 현재 대화에서 이전에 캐시한 버전이 계속 발견되면 설치 후
@@ -181,7 +181,7 @@ Windows에서 `~`는 `%USERPROFILE%`을 뜻합니다. 새로 복사한 스킬이
 #### Claude Code — macOS/Linux
 
 ```bash
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git /tmp/skillstead
 mkdir -p ~/.claude/skills
 cp -R /tmp/skillstead/skills/github-release-guide ~/.claude/skills/
 ```
@@ -189,7 +189,7 @@ cp -R /tmp/skillstead/skills/github-release-guide ~/.claude/skills/
 #### Codex — macOS/Linux
 
 ```bash
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git /tmp/skillstead
 mkdir -p ~/.codex/skills
 cp -R /tmp/skillstead/skills/github-release-guide ~/.codex/skills/
 ```
@@ -197,7 +197,7 @@ cp -R /tmp/skillstead/skills/github-release-guide ~/.codex/skills/
 #### Claude Code — Windows PowerShell
 
 ```powershell
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$env:USERPROFILE\.claude\skills\"
 ```
@@ -205,7 +205,7 @@ Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$e
 #### Codex — Windows PowerShell
 
 ```powershell
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$env:USERPROFILE\.codex\skills\"
 ```
@@ -217,7 +217,7 @@ Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$e
 #### Claude Code — macOS/Linux
 
 ```bash
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git /tmp/skillstead
 mkdir -p .claude/skills
 cp -R /tmp/skillstead/skills/github-release-guide .claude/skills/
 ```
@@ -225,7 +225,7 @@ cp -R /tmp/skillstead/skills/github-release-guide .claude/skills/
 #### Codex — macOS/Linux
 
 ```bash
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git /tmp/skillstead
 mkdir -p .agents/skills
 cp -R /tmp/skillstead/skills/github-release-guide .agents/skills/
 ```
@@ -233,7 +233,7 @@ cp -R /tmp/skillstead/skills/github-release-guide .agents/skills/
 #### Claude Code — Windows PowerShell
 
 ```powershell
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
 New-Item -ItemType Directory -Force ".claude\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" ".claude\skills\"
 ```
@@ -241,7 +241,7 @@ Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" ".c
 #### Codex — Windows PowerShell
 
 ```powershell
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
 New-Item -ItemType Directory -Force ".agents\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" ".agents\skills\"
 ```
@@ -263,7 +263,7 @@ Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" ".a
 | `docs-claim-check` | Supported | Not yet claimed | — | Claude Code Fable과 Sonnet에서 동작 검증 자료를 통과했습니다 |
 | `github-release-guide` | Supported | Supported | — | 핵심 행동 일치, 일회용 first-public과 Guided tag-ruleset 실제 E2E, 고정 설치·발견, 릴리스 주장 검토를 통과했습니다 |
 | `writing-quality-editor` | Supported | Supported | — | 4개 mode의 실행 환경 간 동작, 저장소 문서 적용, 고정 설치, 패키지 일치, 발견과 주장 종결을 확인했습니다 |
-| `street-portrait-artist` | Not applicable | Supported | ChatGPT: Supported | 공개된 `0.1.0` package의 새 설치·발견·호출·합성 reference-image 생성·fail-visible 크기 fallback·결과 전달로 실행 환경 지원을 확인했으며, 현재 설치 릴리스는 `0.1.1`입니다 |
+| `street-portrait-artist` | Not applicable | Supported | ChatGPT: Supported | 공개된 `0.1.0` package의 새 설치·발견·호출·합성 reference-image 생성·fail-visible 크기 fallback·결과 전달로 실행 환경 지원을 확인했으며, 현재 설치 릴리스는 `0.1.2`입니다 |
 
 이전 릴리스에서 기록한 근거가 제한된 실행 능력을 뒷받침할 수 있지만, 해당 릴리스가 현재 설치 대상이라는
 뜻은 아닙니다. 일반적인 용도에서는 사용하는 실행 환경이 `Supported`인 스킬을 선택하세요. `Not yet

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -30,11 +30,11 @@ folder so they cannot drift apart.
 
 | Skill | Current pinned tag | Supported runtime |
 | --- | --- | --- |
-| `svg-infographic` | `svg-infographic/v0.11.0` | Claude Code and Codex |
-| `docs-claim-check` | `docs-claim-check/v0.9.1` | Claude Code |
-| `github-release-guide` | `github-release-guide/v0.9.0` | Claude Code and Codex |
-| `writing-quality-editor` | `writing-quality-editor/v0.14.0` | Claude Code and Codex |
-| `street-portrait-artist` | `street-portrait-artist/v0.1.1` | ChatGPT and Codex |
+| `svg-infographic` | `svg-infographic/v0.11.1` | Claude Code and Codex |
+| `docs-claim-check` | `docs-claim-check/v0.9.2` | Claude Code |
+| `github-release-guide` | `github-release-guide/v0.9.1` | Claude Code and Codex |
+| `writing-quality-editor` | `writing-quality-editor/v0.14.1` | Claude Code and Codex |
+| `street-portrait-artist` | `street-portrait-artist/v0.1.2` | ChatGPT and Codex |
 
 The default request installs a personal/global skill. To keep a filesystem-installed skill inside the current
 repository, replace `globally` with `in the current project`. ChatGPT manages its skill library in the product and
@@ -46,14 +46,14 @@ does not use the filesystem scopes in this guide.
 
 ## `svg-infographic`
 
-- Current release: `svg-infographic/v0.11.0`
+- Current release: `svg-infographic/v0.11.1`
 - Supported runtime: Claude Code and Codex
 - Package guide: [`skills/svg-infographic/README.md`](../skills/svg-infographic/README.md)
 
 Paste this into Claude Code or Codex:
 
 ```text
-Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/svg-infographic/v0.11.0/skills/svg-infographic
+Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/svg-infographic/v0.11.1/skills/svg-infographic
 ```
 
 Copying or discovering `svg-infographic` does not require Node.js. Node.js 18+ is needed only for its automated
@@ -68,14 +68,14 @@ source-check and Node-free Chromium visual-QA fallback.
 
 ## `docs-claim-check`
 
-- Current release: `docs-claim-check/v0.9.1`
+- Current release: `docs-claim-check/v0.9.2`
 - Supported runtime: Claude Code
 - Package guide: [`skills/docs-claim-check/README.md`](../skills/docs-claim-check/README.md)
 
 Paste this into Claude Code:
 
 ```text
-Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/docs-claim-check/v0.9.1/skills/docs-claim-check
+Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/docs-claim-check/v0.9.2/skills/docs-claim-check
 ```
 
 Codex runtime support is not yet claimed for this skill. Installing it experimentally in another runtime does not
@@ -89,14 +89,14 @@ establish a public support claim.
 
 ## `github-release-guide`
 
-- Current release: `github-release-guide/v0.9.0`
+- Current release: `github-release-guide/v0.9.1`
 - Supported runtime: Claude Code and Codex
 - Package guide: [`skills/github-release-guide/README.md`](../skills/github-release-guide/README.md)
 
 Paste this into Claude Code or Codex:
 
 ```text
-Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/github-release-guide/v0.9.0/skills/github-release-guide
+Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/github-release-guide/v0.9.1/skills/github-release-guide
 ```
 
 Installation adds the reusable guidance only. It does not approve a repository visibility change, tag, GitHub
@@ -110,7 +110,7 @@ Release, settings change, destructive cleanup, or credential action.
 
 ## `writing-quality-editor`
 
-- Current release: `writing-quality-editor/v0.14.0`
+- Current release: `writing-quality-editor/v0.14.1`
 - New Korean Compose path: explicit local-package loading checked; automatic discovery after installation and other-runtime behavior remain unverified for this change.
 - Supported runtime: Claude Code and Codex
 - Package guide: [`skills/writing-quality-editor/README.md`](../skills/writing-quality-editor/README.md)
@@ -118,7 +118,7 @@ Release, settings change, destructive cleanup, or credential action.
 Paste this into Claude Code or Codex:
 
 ```text
-Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/writing-quality-editor/v0.14.0/skills/writing-quality-editor
+Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/writing-quality-editor/v0.14.1/skills/writing-quality-editor
 ```
 
 The package includes the complete English/Korean authoring and review references. Install the whole folder rather
@@ -132,20 +132,20 @@ than copying only `SKILL.md`.
 
 ## `street-portrait-artist`
 
-- Current release: `street-portrait-artist/v0.1.1`
+- Current release: `street-portrait-artist/v0.1.2`
 - Supported runtime: ChatGPT and Codex
 - Package guide: [`skills/street-portrait-artist/README.md`](../skills/street-portrait-artist/README.md)
 
 Paste this into ChatGPT:
 
 ```text
-Install the street-portrait-artist skill from this pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.1/skills/street-portrait-artist
+Install the street-portrait-artist skill from this pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.2/skills/street-portrait-artist
 ```
 
 Paste this into Codex:
 
 ```text
-Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.1/skills/street-portrait-artist
+Install this Skillstead skill globally from the pinned GitHub folder: https://github.com/kyungseo/skillstead/tree/street-portrait-artist/v0.1.2/skills/street-portrait-artist
 ```
 
 ChatGPT may ask you to confirm the installation. If the current conversation still discovers an older cached
@@ -182,7 +182,7 @@ temporary path. For another skill, replace the tag and folder together with the 
 #### Claude Code — macOS/Linux
 
 ```bash
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git /tmp/skillstead
 mkdir -p ~/.claude/skills
 cp -R /tmp/skillstead/skills/github-release-guide ~/.claude/skills/
 ```
@@ -190,7 +190,7 @@ cp -R /tmp/skillstead/skills/github-release-guide ~/.claude/skills/
 #### Codex — macOS/Linux
 
 ```bash
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git /tmp/skillstead
 mkdir -p ~/.codex/skills
 cp -R /tmp/skillstead/skills/github-release-guide ~/.codex/skills/
 ```
@@ -198,7 +198,7 @@ cp -R /tmp/skillstead/skills/github-release-guide ~/.codex/skills/
 #### Claude Code — Windows PowerShell
 
 ```powershell
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$env:USERPROFILE\.claude\skills\"
 ```
@@ -206,7 +206,7 @@ Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$e
 #### Codex — Windows PowerShell
 
 ```powershell
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
 New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" "$env:USERPROFILE\.codex\skills\"
 ```
@@ -218,7 +218,7 @@ Run these commands from the target repository root.
 #### Claude Code — macOS/Linux
 
 ```bash
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git /tmp/skillstead
 mkdir -p .claude/skills
 cp -R /tmp/skillstead/skills/github-release-guide .claude/skills/
 ```
@@ -226,7 +226,7 @@ cp -R /tmp/skillstead/skills/github-release-guide .claude/skills/
 #### Codex — macOS/Linux
 
 ```bash
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git /tmp/skillstead
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git /tmp/skillstead
 mkdir -p .agents/skills
 cp -R /tmp/skillstead/skills/github-release-guide .agents/skills/
 ```
@@ -234,7 +234,7 @@ cp -R /tmp/skillstead/skills/github-release-guide .agents/skills/
 #### Claude Code — Windows PowerShell
 
 ```powershell
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
 New-Item -ItemType Directory -Force ".claude\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" ".claude\skills\"
 ```
@@ -242,7 +242,7 @@ Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" ".c
 #### Codex — Windows PowerShell
 
 ```powershell
-git clone --depth 1 --branch github-release-guide/v0.9.0 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
+git clone --depth 1 --branch github-release-guide/v0.9.1 https://github.com/kyungseo/skillstead.git "$env:TEMP\skillstead"
 New-Item -ItemType Directory -Force ".agents\skills" | Out-Null
 Copy-Item -Recurse -Force "$env:TEMP\skillstead\skills\github-release-guide" ".agents\skills\"
 ```
@@ -264,7 +264,7 @@ Runtime support is verified per skill:
 | `docs-claim-check` | Supported | Not yet claimed | — | Behavioral fixtures passed with Claude Code Fable and Sonnet |
 | `github-release-guide` | Supported | Supported | — | Material parity, disposable first-public and Guided tag-ruleset E2E, pinned installation/discovery, and release claim audits passed |
 | `writing-quality-editor` | Supported | Supported | — | Four-mode cross-runtime behavior, repository dogfood, pinned installation, package equality, discovery, and claim closeout passed |
-| `street-portrait-artist` | Not applicable | Supported | ChatGPT: Supported | Fresh published `0.1.0` package installation, discovery, invocation, synthetic reference-image generation, fail-visible size fallback, and output delivery established runtime support; `0.1.1` is the current install release |
+| `street-portrait-artist` | Not applicable | Supported | ChatGPT: Supported | Fresh published `0.1.0` package installation, discovery, invocation, synthetic reference-image generation, fail-visible size fallback, and output delivery established runtime support; `0.1.2` is the current install release |
 
 Evidence recorded for an earlier release can establish a bounded runtime capability without making that older
 release the current install target. For normal use, choose only a runtime marked `Supported`. `Not yet claimed`

--- a/docs/VALIDATION.ko.md
+++ b/docs/VALIDATION.ko.md
@@ -41,7 +41,7 @@ admin bypass가 있으므로 이 경계는 hard guarantee가 아니라 disciplin
 
 `svg-infographic`은 M2 전에 clean source commit에서 만든 repository 밖 staging directory를 M2-SVG로
 검사합니다. canonical file은 정확히 54개(아홉 TypePack × 두 locale × SVG·receipt·PNG)여야 하며,
-receipt canonicalization v2, surface revision 17, 선택한 source commit, clean source flag, live runtime digest,
+receipt canonicalization v2, 현재 package의 surface revision, 선택한 source commit, clean source flag, live runtime digest,
 package verifier 통과와 SVG viewBox의 정확히 두 배인 PNG 크기를 요구합니다. `--compare-repository`는 복사한
 byte의 완전 일치를 추가로 검사합니다. artifact commit 뒤 `--artifact-commit`을 사용하면 source commit의
 descendant인지, canonical artifact delta가 source snapshot과 staging의 byte가 실제로 다른 파일과 정확히

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -46,7 +46,7 @@ admin bypasses, so this boundary is discipline, not a hard guarantee.
 
 For `svg-infographic`, M2-SVG runs first against an out-of-tree staging directory made from the clean source
 commit. It requires exactly 54 canonical files (nine TypePacks × two locales × SVG, receipt and PNG), receipt
-canonicalization v2, surface revision 17, the selected source commit, clean source flags, the live runtime digest,
+canonicalization v2, the current package surface revision, the selected source commit, clean source flags, the live runtime digest,
 package-verifier success and a PNG exactly twice the SVG viewBox. `--compare-repository` adds byte-for-byte copy
 verification. After the artifact commit, `--artifact-commit` requires a descendant whose canonical-artifact delta
 is exactly the files whose staged bytes differ from the source snapshot; only `gallery/model.json` and

--- a/examples/svg-infographic/typepacks/approval-gate/approval-gate.en.json
+++ b/examples/svg-infographic/typepacks/approval-gate/approval-gate.en.json
@@ -67,7 +67,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -194,14 +194,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.json
+++ b/examples/svg-infographic/typepacks/approval-gate/approval-gate.ko.json
@@ -67,7 +67,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -194,14 +194,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/before-after/before-after.en.json
+++ b/examples/svg-infographic/typepacks/before-after/before-after.en.json
@@ -65,7 +65,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -136,14 +136,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/before-after/before-after.ko.json
+++ b/examples/svg-infographic/typepacks/before-after/before-after.ko.json
@@ -65,7 +65,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -136,14 +136,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.json
+++ b/examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.en.json
@@ -67,7 +67,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -127,14 +127,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.json
+++ b/examples/svg-infographic/typepacks/cards-kpi-grid/cards-kpi-grid.ko.json
@@ -67,7 +67,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -127,14 +127,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.json
+++ b/examples/svg-infographic/typepacks/decision-matrix/decision-matrix.en.json
@@ -67,7 +67,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -198,14 +198,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.json
+++ b/examples/svg-infographic/typepacks/decision-matrix/decision-matrix.ko.json
@@ -67,7 +67,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -198,14 +198,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/layer-stack/layer-stack.en.json
+++ b/examples/svg-infographic/typepacks/layer-stack/layer-stack.en.json
@@ -75,7 +75,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -146,14 +146,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.json
+++ b/examples/svg-infographic/typepacks/layer-stack/layer-stack.ko.json
@@ -75,7 +75,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -146,14 +146,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/nested-scope/nested-scope.en.json
+++ b/examples/svg-infographic/typepacks/nested-scope/nested-scope.en.json
@@ -66,7 +66,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -137,14 +137,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.json
+++ b/examples/svg-infographic/typepacks/nested-scope/nested-scope.ko.json
@@ -66,7 +66,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -137,14 +137,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/process-flow/process-flow.en.json
+++ b/examples/svg-infographic/typepacks/process-flow/process-flow.en.json
@@ -67,7 +67,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -221,14 +221,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/process-flow/process-flow.ko.json
+++ b/examples/svg-infographic/typepacks/process-flow/process-flow.ko.json
@@ -67,7 +67,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -221,14 +221,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.json
+++ b/examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.en.json
@@ -67,7 +67,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -178,14 +178,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.json
+++ b/examples/svg-infographic/typepacks/roadmap-timeline/roadmap-timeline.ko.json
@@ -67,7 +67,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -178,14 +178,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/topology-component/topology-component.en.json
+++ b/examples/svg-infographic/typepacks/topology-component/topology-component.en.json
@@ -71,7 +71,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -285,14 +285,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/examples/svg-infographic/typepacks/topology-component/topology-component.ko.json
+++ b/examples/svg-infographic/typepacks/topology-component/topology-component.ko.json
@@ -71,7 +71,7 @@
   "tool": {
    "fonttools": "4.53.1",
    "brotli": "1.1.0",
-   "python": "3.14.6"
+   "python": "3.14.7"
   },
   "wrapperDigest": "sha256:f265dff7e9041e5c90e8fea0b92f43b2ba1e278e812ad6af2d28d6864a6c527f",
   "identity": [
@@ -285,14 +285,18 @@
    "version": 1,
    "canonicalization": 2
   },
-  "executionMode": "installed-runtime",
+  "executionMode": "source-development",
   "skillRoot": "skills/svg-infographic",
   "package": {
    "id": "svg-infographic",
    "surfaceRevision": 18
   },
   "runtimeSurfaceDigest": "sha256:996d911ae7e06519c0cec94155c775e297f47930f99e7ecca99a7fc4e53f8a0a",
-  "source": null,
+  "source": {
+   "headCommit": "3d4f2a5362cc9e40dc377705e073b2d135118830",
+   "repoDirty": false,
+   "runtimeSurfaceDirty": false
+  },
   "producer": {
    "kind": "generator",
    "generatorDigest": "sha256:6385ee4dbd7a5b332cee75f243a8e03b1f9125155f0b4c0c52aa1ab0c99852b2"

--- a/skills/docs-claim-check/CHANGELOG.md
+++ b/skills/docs-claim-check/CHANGELOG.md
@@ -11,7 +11,7 @@ automated checks read the topmost released heading to confirm it matches `metada
 `SKILL.md`. The full grammar is documented at
 [`docs/VERSIONING.md`](https://github.com/kyungseo/skillstead/blob/main/docs/VERSIONING.md).
 
-## [Unreleased]
+## [0.9.2] — 2026-09-07
 
 ### Documentation
 

--- a/skills/docs-claim-check/SKILL.md
+++ b/skills/docs-claim-check/SKILL.md
@@ -14,7 +14,7 @@ description: >
   only the out-of-scope part — by contract it does not execute commands or edit files.
 license: LICENSE.txt
 metadata:
-  version: 0.9.1
+  version: 0.9.2
 ---
 
 # docs-claim-check

--- a/skills/github-release-guide/CHANGELOG.md
+++ b/skills/github-release-guide/CHANGELOG.md
@@ -11,7 +11,7 @@ automated checks read the topmost released heading to confirm it matches `metada
 `SKILL.md`. The full grammar is documented at
 [`docs/VERSIONING.md`](https://github.com/kyungseo/skillstead/blob/main/docs/VERSIONING.md).
 
-## [Unreleased]
+## [0.9.1] — 2026-09-07
 
 ### Documentation
 

--- a/skills/github-release-guide/SKILL.md
+++ b/skills/github-release-guide/SKILL.md
@@ -3,7 +3,7 @@ name: github-release-guide
 description: Assess and guide safer github.com repository releases. Use when an existing private GitHub repository becomes public for the first time, or whenever an already-public GitHub repository publishes a new version, and the user needs readiness checks, release-surface decisions, explicit mutation approvals, release notes, settings checks, or post-release verification. Supports read-only Assess and approval-gated Guided modes. Do not use for repository bootstrap, package registries, signing, cloud deployment, security audits, GitHub Enterprise, other providers, force-push, or history rewrite.
 license: LICENSE.txt
 metadata:
-  version: 0.9.0
+  version: 0.9.1
 ---
 
 # github-release-guide

--- a/skills/street-portrait-artist/CHANGELOG.md
+++ b/skills/street-portrait-artist/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the `street-portrait-artist` skill package.
 
-## [Unreleased]
+## [0.1.2] — 2026-09-07
 
 ### Documentation
 

--- a/skills/street-portrait-artist/SKILL.md
+++ b/skills/street-portrait-artist/SKILL.md
@@ -3,7 +3,7 @@ name: street-portrait-artist
 description: Analyze supplied portrait references into a stable impression map, then create a kind Street Caricature or Romance Watercolor character portrait with coherent feature relationships and targeted revision. Use when a real person's recognizable visual identity should be interpreted rather than traced. Do not use for graffiti or murals, restoration, face swaps, photorealistic retouching, personality inference, or imitation of a named living artist.
 license: LICENSE.txt
 metadata:
-  version: 0.1.1
+  version: 0.1.2
 ---
 
 # Street Artist

--- a/skills/svg-infographic/CHANGELOG.md
+++ b/skills/svg-infographic/CHANGELOG.md
@@ -11,7 +11,7 @@ automated checks read the topmost released heading to confirm it matches `metada
 `SKILL.md`. The full grammar is documented at
 [`docs/VERSIONING.md`](https://github.com/kyungseo/skillstead/blob/main/docs/VERSIONING.md).
 
-## [Unreleased]
+## [0.11.1] — 2026-09-07
 
 ### Documentation
 

--- a/skills/svg-infographic/SKILL.md
+++ b/skills/svg-infographic/SKILL.md
@@ -3,7 +3,7 @@ name: svg-infographic
 description: Author technical/structured SVG infographics and diagrams, then render them to crisp PNG with a headless browser. Best for architecture diagrams, topology maps, flows, before/after comparisons, nested/onion layer models, roadmaps, decision matrices, and social-ready technical one-pagers. Prefers clean line icons in soft tinted circles. First-class Korean/CJK text. Includes an opt-in "tidy hand-drawn" sketch preset (paper background, Korean handwriting font, rough strokes, highlighter). Not for photo-heavy or illustration-heavy graphics, statistical charts, or mascot/character illustration.
 license: LICENSE.txt
 metadata:
-  version: 0.11.0
+  version: 0.11.1
 ---
 
 # svg-infographic

--- a/skills/writing-quality-editor/CHANGELOG.md
+++ b/skills/writing-quality-editor/CHANGELOG.md
@@ -11,7 +11,7 @@ automated checks read the topmost released heading to confirm it matches `metada
 `SKILL.md`. The full grammar is documented at
 [`docs/VERSIONING.md`](https://github.com/kyungseo/skillstead/blob/main/docs/VERSIONING.md).
 
-## [Unreleased]
+## [0.14.1] — 2026-09-07
 
 ### Documentation
 

--- a/skills/writing-quality-editor/SKILL.md
+++ b/skills/writing-quality-editor/SKILL.md
@@ -3,7 +3,7 @@ name: writing-quality-editor
 description: Writing Quality Editor (WQE) composes, assesses, revises, and adapts user-facing writing so it reads naturally while preserving meaning, claims, intent, voice, conditions, numbers, identifiers, exceptions, and risks. Use when a user asks to write, review, polish, fix, improve, supplement, clarify, translate, localize, or make a document sound natural; no skill or mode name is required. Covers README, onboarding, release notes, manuals, UI, errors, gallery copy, research-backed briefs, technical comparisons, and natural English↔Korean adaptation. If a host repository workflow owns document classification, path, indexing, lifecycle, or approval, keep it primary and use this skill only as an optional authoring layer. Locale-neutral design; EN↔KO (`ko-KR`) is the initial profile under validation. Do not game detectors, conceal provenance, invent claims, replace evidence review, or bypass host workflows.
 license: LICENSE.txt
 metadata:
-  version: 0.14.0
+  version: 0.14.1
 ---
 
 # Writing Quality Editor

--- a/tests/test_cutover.py
+++ b/tests/test_cutover.py
@@ -455,7 +455,7 @@ class RealRepoInstallSurface(unittest.TestCase):
         self.assertFalse(any(inv.ambiguous for inv in inventories))
         self.assertTrue(all(
             pin == install_pins.Pin(
-                "github-release-guide/v0.9.0", "github-release-guide")
+                "github-release-guide/v0.9.1", "github-release-guide")
             for pin in inventories[0].pins))
         self.assertEqual(
             install_pins.classify(inventories[0], lambda _t: True),

--- a/tests/test_svg_release_artifacts.py
+++ b/tests/test_svg_release_artifacts.py
@@ -7,10 +7,12 @@ import json
 import subprocess
 import tempfile
 import unittest
+from unittest.mock import patch
+from types import SimpleNamespace
 from pathlib import Path
 
 from tools.skillstead_validate.svg_release_artifacts import (
-    EXAMPLES, check_release_artifacts, expected_inventory,
+    EXAMPLES, check_release_artifacts, expected_inventory, _runtime_identity,
 )
 
 
@@ -52,7 +54,7 @@ class SvgReleaseArtifactGate(unittest.TestCase):
                         "provenance": {
                             "schema": {"canonicalization": 2},
                             "executionMode": "source-development",
-                            "package": {"surfaceRevision": 17},
+                            "package": {"surfaceRevision": 18},
                             "runtimeSurfaceDigest": DIGEST,
                             "source": {"headCommit": self.source, "repoDirty": False,
                                        "runtimeSurfaceDirty": False},
@@ -65,12 +67,40 @@ class SvgReleaseArtifactGate(unittest.TestCase):
     def check(self, **kwargs):
         return check_release_artifacts(
             self.repo, self.staging, self.source, typepack_ids=self.ids,
-            runtime_digest=DIGEST, verify_pairs=False, **kwargs,
+            runtime_digest=DIGEST, surface_revision=18, verify_pairs=False, **kwargs,
         )
 
     def test_exact_clean_staging_and_copy_pass(self) -> None:
         self.assertEqual(len(expected_inventory(self.ids)), 54)
         self.assertEqual(self.check(compare_repository=True), [])
+
+    def test_old_revision_is_rejected_against_live_package(self) -> None:
+        path = next((self.staging / EXAMPLES).glob("*/*.json"))
+        receipt = json.loads(path.read_text())
+        receipt["provenance"]["package"]["surfaceRevision"] = 17
+        path.write_text(json.dumps(receipt))
+        with patch("tools.skillstead_validate.svg_release_artifacts._runtime_identity",
+                   return_value=(DIGEST, 18)):
+            findings = check_release_artifacts(
+                self.repo, self.staging, self.source, typepack_ids=self.ids,
+                verify_pairs=False)
+        self.assertTrue(any("surface revision" in f.detail for f in findings), findings)
+
+    def test_runtime_identity_reads_the_observed_revision(self) -> None:
+        identity = {"digests": {"runtimeSurfaceDigest": DIGEST},
+                    "package": {"surfaceRevision": 19}}
+        result = SimpleNamespace(returncode=0, stdout=json.dumps(identity))
+        with patch("tools.skillstead_validate.svg_release_artifacts.subprocess.run",
+                   return_value=result):
+            self.assertEqual(_runtime_identity(self.repo), (DIGEST, 19))
+
+    def test_unobservable_runtime_identity_fails_closed(self) -> None:
+        with patch("tools.skillstead_validate.svg_release_artifacts._runtime_identity",
+                   side_effect=ValueError("invalid surface revision")):
+            findings = check_release_artifacts(
+                self.repo, self.staging, self.source, typepack_ids=self.ids,
+                verify_pairs=False)
+        self.assertTrue(any(f.check == "SVG-REL-OBSERVE" for f in findings), findings)
 
     def test_dirty_receipt_fails(self) -> None:
         path = next((self.staging / EXAMPLES).glob("*/*.json"))

--- a/tools/skillstead_validate/svg_release_artifacts.py
+++ b/tools/skillstead_validate/svg_release_artifacts.py
@@ -85,7 +85,7 @@ def _typepack_ids(repo: Path) -> set[str]:
     return {str(p["id"]) for p in json.loads(result.stdout).get("typepacks") or []}
 
 
-def _runtime_digest(repo: Path) -> str:
+def _runtime_identity(repo: Path) -> tuple[str, int]:
     env = dict(os.environ)
     env["SVGINFO_EXECUTION_MODE"] = "source-development"
     result = subprocess.run(
@@ -94,7 +94,14 @@ def _runtime_digest(repo: Path) -> str:
     )
     if result.returncode != 0:
         raise ValueError(f"package preflight failed: {(result.stderr or result.stdout).strip()}")
-    return str(json.loads(result.stdout)["digests"]["runtimeSurfaceDigest"])
+    identity = json.loads(result.stdout)
+    digest = identity["digests"]["runtimeSurfaceDigest"]
+    revision = identity["package"]["surfaceRevision"]
+    if not isinstance(digest, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+        raise ValueError("package preflight returned an invalid runtime digest")
+    if type(revision) is not int or revision < 1:
+        raise ValueError("package preflight returned an invalid surface revision")
+    return digest, revision
 
 
 def check_release_artifacts(
@@ -106,6 +113,7 @@ def check_release_artifacts(
     artifact_commit: str | None = None,
     typepack_ids: set[str] | None = None,
     runtime_digest: str | None = None,
+    surface_revision: int | None = None,
     verify_pairs: bool = True,
 ) -> list[Finding]:
     """Return findings without mutation. Test-only overrides avoid reimplementing repo fixtures."""
@@ -118,7 +126,10 @@ def check_release_artifacts(
 
     try:
         ids = typepack_ids if typepack_ids is not None else _typepack_ids(repo)
-        live_digest = runtime_digest if runtime_digest is not None else _runtime_digest(repo)
+        if runtime_digest is None or surface_revision is None:
+            observed_digest, observed_revision = _runtime_identity(repo)
+        live_digest = runtime_digest if runtime_digest is not None else observed_digest
+        live_revision = surface_revision if surface_revision is not None else observed_revision
     except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
         return findings + [Finding("SVG-REL-OBSERVE", "svg-infographic", str(error))]
     expected = expected_inventory(ids)
@@ -147,7 +158,7 @@ def check_release_artifacts(
             source = prov.get("source") or {}
             checks = {
                 "provenance canonicalization": (prov.get("schema") or {}).get("canonicalization") == 2,
-                "surface revision": (prov.get("package") or {}).get("surfaceRevision") == 17,
+                "surface revision": (prov.get("package") or {}).get("surfaceRevision") == live_revision,
                 "execution mode": prov.get("executionMode") == "source-development",
                 "runtime digest": prov.get("runtimeSurfaceDigest") == live_digest,
                 "source head": source.get("headCommit") == source_commit,


### PR DESCRIPTION
## 변경 내용

다섯 스킬의 README 개선을 설치 패키지로 받을 수 있도록 문서 패치를 준비합니다. 실행 지침과 성숙도는 기존 버전과 같습니다.

| 스킬 | 버전 |
| --- | --- |
| docs-claim-check | 0.9.2 |
| github-release-guide | 0.9.1 |
| street-portrait-artist | 0.1.2 |
| svg-infographic | 0.11.1 |
| writing-quality-editor | 0.14.1 |

버전·카탈로그·설치 pin·changelog를 맞추고 영어/한국어 릴리스 설명을 추가했습니다.

SVG 릴리스 검사에 남아 있던 고정 규격 17은 실제 패키지 규격 18을 거부했습니다. 현재 패키지의 preflight identity에서 규격을 읽도록 수정했으며, 틀린 규격과 관측 실패는 계속 거부합니다. 생성 기록만 갱신됐고 canonical SVG·PNG 36개는 기존 파일과 byte 동일합니다.

## 검증

- M1 repository 및 gallery: finding 0
- SVG release artifacts: 정확한 54개 파일, 생성 기록·2× PNG·저장소 복사·artifact commit 검사 통과
- 릴리스 검사 회귀 테스트: 8건 통과
- 이전 태그 대비 다섯 패키지 비교: 버전·README·CHANGELOG 외 변경 없음
- GFM 렌더링 및 다섯 bilingual Release request 검사 통과

저장소 정책에 따라 squash merge를 사용합니다. 생성 기록 전용 commit은 이 PR의 원래 commit history에 보존하며, 공개 clean source와 artifact-only commit의 관계 및 최종 배포 파일 일치를 별도로 검증했습니다. 태그는 병합 후 canonical M2로 함께 생성하고 Release는 M5로 순차 발행합니다.
